### PR TITLE
lifecycle: neutral consent audit result and bounded audit buffer

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -62,6 +62,14 @@ func WithNow(now func() time.Time) Option {
 	}
 }
 
+func WithAuditLogLimit(limit int) Option {
+	return func(s *Service) {
+		if limit > 0 {
+			s.auditLogLimit = limit
+		}
+	}
+}
+
 func WithIDGenerator(gen func(prefix string) string) Option {
 	return func(s *Service) {
 		if gen != nil {
@@ -85,6 +93,7 @@ type Service struct {
 	logs        map[string][]string
 	handoffs    map[string]DiagnosisHandoff
 	auditLogs   []AuditLog
+	auditLogLimit int
 	triager     baseagent.Triager
 	checker     runtimecheck.Checker
 	runner      commandexec.Runner
@@ -105,9 +114,10 @@ func NewService(triager baseagent.Triager, opts ...Option) *Service {
 		states:      make(map[string]AgentState),
 		manifests:   make(map[string]manifest.Manifest),
 		logs:        make(map[string][]string),
-		handoffs:    make(map[string]DiagnosisHandoff),
-		auditLogs:   make([]AuditLog, 0, 128),
-		triager:     triager,
+		handoffs:      make(map[string]DiagnosisHandoff),
+		auditLogs:     make([]AuditLog, 0, 128),
+		auditLogLimit: 1000,
+		triager:       triager,
 		checker:     runtimecheck.NewHostChecker(),
 		runner:      commandexec.NewShellRunner(),
 		diagnoseDir: filepath.Join(os.TempDir(), "agentd-diagnose"),
@@ -420,7 +430,7 @@ func (s *Service) CreateRemoteDiagnosisHandoff(agentID string, consent bool, act
 
 	result := AuditResultSuccess
 	if !consent {
-		result = AuditResultFailure
+		result = AuditResultNeutral
 	}
 	s.recordAudit(requestID, actor, "remote_diagnosis_consent", agentID, result, "", fmt.Sprintf("consent=%t handoff_id=%s", consent, handoff.ID))
 	return handoff, nil
@@ -579,6 +589,9 @@ func (s *Service) recordAudit(requestID, actor, action, target string, result Au
 		Message:   message,
 		Timestamp: s.now(),
 	})
+	if len(s.auditLogs) > s.auditLogLimit {
+		s.auditLogs = s.auditLogs[len(s.auditLogs)-s.auditLogLimit:]
+	}
 }
 
 func (s *Service) writeDiagnoseZip(path string, m manifest.Manifest, state AgentState, logs []string) error {

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -379,6 +379,60 @@ func TestCleanupExpiredDiagnosisHandoffs(t *testing.T) {
 	}
 }
 
+func TestCreateRemoteDiagnosisHandoffDeclinedUsesNeutralAuditResult(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	runner := &fakeRunner{}
+	checker := &fakeChecker{}
+	svc := newServiceForTest(t, runner, checker)
+
+	if err := svc.Install("openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := svc.HandleFailure(context.Background(), "openclaw", "cannot bind port"); err != nil {
+		t.Fatalf("handle failure: %v", err)
+	}
+	if _, err := svc.Diagnose("openclaw"); err != nil {
+		t.Fatalf("diagnose: %v", err)
+	}
+
+	handoff, err := svc.CreateRemoteDiagnosisHandoff("openclaw", false, "chat:123", "req-43")
+	if err != nil {
+		t.Fatalf("create handoff: %v", err)
+	}
+	if handoff.Status != HandoffStatusDeclined {
+		t.Fatalf("expected declined handoff, got %s", handoff.Status)
+	}
+
+	audits := svc.AuditLogs()
+	last := audits[len(audits)-1]
+	if last.Result != AuditResultNeutral {
+		t.Fatalf("expected neutral audit result, got %s", last.Result)
+	}
+}
+
+func TestAuditLogsBoundedByConfiguredLimit(t *testing.T) {
+	svc := NewService(nil,
+		WithAuditLogLimit(3),
+		WithNow(func() time.Time { return time.Date(2026, 2, 14, 4, 20, 0, 0, time.UTC) }),
+	)
+
+	svc.recordAudit("r1", "a", "x1", "t", AuditResultSuccess, "", "m1")
+	svc.recordAudit("r2", "a", "x2", "t", AuditResultSuccess, "", "m2")
+	svc.recordAudit("r3", "a", "x3", "t", AuditResultSuccess, "", "m3")
+	svc.recordAudit("r4", "a", "x4", "t", AuditResultSuccess, "", "m4")
+
+	audits := svc.AuditLogs()
+	if len(audits) != 3 {
+		t.Fatalf("expected 3 audit logs, got %d", len(audits))
+	}
+	if audits[0].RequestID != "r2" {
+		t.Fatalf("expected oldest retained request id r2, got %s", audits[0].RequestID)
+	}
+	if audits[2].RequestID != "r4" {
+		t.Fatalf("expected latest retained request id r4, got %s", audits[2].RequestID)
+	}
+}
+
 // Wrappers to keep tests explicit and avoid importing extra packages in each assertion block.
 var (
 	netListen     = net.Listen

--- a/daemon/internal/lifecycle/types.go
+++ b/daemon/internal/lifecycle/types.go
@@ -62,6 +62,7 @@ type AuditResult string
 const (
 	AuditResultSuccess AuditResult = "success"
 	AuditResultFailure AuditResult = "failure"
+	AuditResultNeutral AuditResult = "neutral"
 )
 
 type AuditLog struct {


### PR DESCRIPTION
## Summary
This PR implements two lightweight follow-ups from #16:

1. **Neutral audit result for user-declined remote diagnosis consent**
   - Adds `AuditResultNeutral`.
   - `CreateRemoteDiagnosisHandoff(..., consent=false, ...)` now records a neutral audit outcome (instead of failure), since this is a valid user choice.

2. **Bounded in-memory audit log growth**
   - Adds `WithAuditLogLimit(limit int)` option.
   - `recordAudit` now enforces a ring-buffer style cap to avoid unbounded memory growth in long-running daemon sessions.

## Tests
- Added test: declined consent emits `AuditResultNeutral`.
- Added test: audit log buffer respects configured cap and evicts oldest records.
- Existing daemon tests remain green (`go test ./...` in `daemon/`).

## Issue Link
- Follow-up for: #16
