### PR TITLE
lifecycle: add diagnosis handoff retention cleanup

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -70,6 +70,14 @@ func WithIDGenerator(gen func(prefix string) string) Option {
 	}
 }
 
+func WithHandoffRetention(ttl time.Duration) Option {
+	return func(s *Service) {
+		if ttl > 0 {
+			s.handoffTTL = ttl
+		}
+	}
+}
+
 type Service struct {
 	mu          sync.RWMutex
 	states      map[string]AgentState
@@ -82,6 +90,7 @@ type Service struct {
 	runner      commandexec.Runner
 	diagnoseDir string
 	logLimit    int
+	handoffTTL  time.Duration
 	now         func() time.Time
 	idCounter   uint64
 	idGenerator func(prefix string) string
@@ -103,6 +112,7 @@ func NewService(triager baseagent.Triager, opts ...Option) *Service {
 		runner:      commandexec.NewShellRunner(),
 		diagnoseDir: filepath.Join(os.TempDir(), "agentd-diagnose"),
 		logLimit:    1000,
+		handoffTTL:  24 * time.Hour,
 		now:         time.Now,
 	}
 	svc.idGenerator = func(prefix string) string {
@@ -327,6 +337,25 @@ func (s *Service) DiagnosisHandoffs() []DiagnosisHandoff {
 		return out[i].CreatedAt.Before(out[j].CreatedAt)
 	})
 	return out
+}
+
+func (s *Service) CleanupExpiredDiagnosisHandoffs() int {
+	cutoff := s.now().Add(-s.handoffTTL)
+
+	s.mu.Lock()
+	removed := 0
+	for id, h := range s.handoffs {
+		if h.CreatedAt.Before(cutoff) {
+			delete(s.handoffs, id)
+			removed++
+		}
+	}
+	s.mu.Unlock()
+
+	if removed > 0 {
+		s.recordAudit("", "system", "handoff_cleanup", "diagnosis_handoffs", AuditResultSuccess, "", fmt.Sprintf("removed=%d", removed))
+	}
+	return removed
 }
 
 func (s *Service) Diagnose(agentID string) (string, error) {

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -85,6 +85,20 @@ func newServiceForTest(t *testing.T, runner *fakeRunner, checker *fakeChecker) *
 	return svc
 }
 
+func newServiceForTestWithClock(t *testing.T, runner *fakeRunner, checker *fakeChecker, now func() time.Time) *Service {
+	t.Helper()
+	svc := NewService(nil,
+		WithRunner(runner),
+		WithRuntimeChecker(checker),
+		WithDiagnoseDir(t.TempDir()),
+		WithNow(now),
+	)
+	if err := svc.RegisterManifest(sampleManifest()); err != nil {
+		t.Fatalf("register manifest: %v", err)
+	}
+	return svc
+}
+
 func TestLifecycleInstallStartStop(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	runner := &fakeRunner{}
@@ -319,6 +333,49 @@ func TestCreateRemoteDiagnosisHandoffSuccessAndAudit(t *testing.T) {
 	}
 	if last.RequestID != "req-42" {
 		t.Fatalf("expected request id req-42, got %s", last.RequestID)
+	}
+}
+
+func TestCleanupExpiredDiagnosisHandoffs(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	runner := &fakeRunner{}
+	checker := &fakeChecker{}
+	now := time.Date(2026, 2, 14, 4, 20, 0, 0, time.UTC)
+	svc := newServiceForTestWithClock(t, runner, checker, func() time.Time { return now })
+
+	if err := svc.Install("openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := svc.HandleFailure(context.Background(), "openclaw", "cannot bind port"); err != nil {
+		t.Fatalf("handle failure: %v", err)
+	}
+	if _, err := svc.Diagnose("openclaw"); err != nil {
+		t.Fatalf("diagnose: %v", err)
+	}
+	if _, err := svc.CreateRemoteDiagnosisHandoff("openclaw", true, "chat:1", "req-old"); err != nil {
+		t.Fatalf("create old handoff: %v", err)
+	}
+
+	// Advance clock and create a fresh handoff.
+	now = now.Add(25 * time.Hour)
+	if _, err := svc.CreateRemoteDiagnosisHandoff("openclaw", true, "chat:2", "req-new"); err != nil {
+		t.Fatalf("create new handoff: %v", err)
+	}
+
+	removed := svc.CleanupExpiredDiagnosisHandoffs()
+	if removed != 1 {
+		t.Fatalf("expected 1 removed handoff, got %d", removed)
+	}
+
+	handoffs := svc.DiagnosisHandoffs()
+	if len(handoffs) != 1 {
+		t.Fatalf("expected 1 retained handoff, got %d", len(handoffs))
+	}
+
+	audits := svc.AuditLogs()
+	last := audits[len(audits)-1]
+	if last.Action != "handoff_cleanup" {
+		t.Fatalf("expected last audit action handoff_cleanup, got %s", last.Action)
 	}
 }
 


### PR DESCRIPTION
## Summary
Follow-up implementation for #16: diagnosis handoff retention cleanup.

### What’s added
- New service option: `WithHandoffRetention(ttl time.Duration)`
- New service method: `CleanupExpiredDiagnosisHandoffs() int`
  - removes handoff records older than configured retention TTL
  - emits an audit log entry (`handoff_cleanup`) when cleanup removes records

### Default behavior
- Default handoff retention is `24h`.
- Existing behavior remains unchanged unless cleanup is explicitly invoked.

### Tests
- Added test coverage for cleanup behavior:
  - expired handoffs are removed
  - recent handoffs are retained
  - cleanup emits audit trail entry
- `go test ./...` passes under `daemon/`.

## Issue
- Closes part of #16
