### PR TITLE
ci: add smoke test and release checklist template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,22 @@
+---
+name: Release Checklist
+about: Verify release readiness across command paths and environments
+title: "release: <version> checklist"
+labels: release
+assignees: ""
+---
+
+## Release Checklist
+
+- [ ] TTFH verification
+  - [ ] Measure and record time-to-first-handshake in a clean environment.
+  - [ ] Confirm TTFH is within the release target.
+
+- [ ] P0 command path verification
+  - [ ] Verify install/start/stop/status commands for the P0 path.
+  - [ ] Verify failure diagnostics command path and expected artifacts.
+
+- [ ] Known environment matrix
+  - [ ] Validate Linux (ubuntu-latest) with Go toolchain from `daemon/go.mod`.
+  - [ ] Validate gateway type check path with Bun 1.1.8.
+  - [ ] Validate manifest parseability for `catalog/openclaw.manifest.json`.


### PR DESCRIPTION
Closes #10

## CI 改动（需要有 workflow scope 的人补充提交）

ci.yml 需要加一个 smoke-test job，请 @Akane-CN 接手：

```yaml
  smoke-test:
    name: Smoke Test
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Setup Go
        uses: actions/setup-go@v5
        with:
          go-version-file: daemon/go.mod

      - name: Build daemon binary
        working-directory: daemon
        run: |
          mkdir -p bin
          go build -o bin/agentd ./cmd/agentd

      - name: Run daemon smoke start
        working-directory: daemon
        run: ./bin/agentd --help

      - name: Validate golden manifest is parseable JSON
        run: python3 -m json.tool catalog/openclaw.manifest.json > /dev/null
```

放在 `gateway-check` job 之前。