### PR TITLE
process: add NBS review skill and post-merge issue automation

### DIFF
--- a/.github/workflows/review-nbs-followup.yml
+++ b/.github/workflows/review-nbs-followup.yml
@@ -1,0 +1,117 @@
+name: Review NBS Follow-up
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  create-followup-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issues from NBS lines
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const prUrl = pr.html_url;
+            const prTitle = pr.title;
+
+            const nbsRegex = /^\s*NBS:\s*(.+)\s*$/gmi;
+
+            function extractNbsLines(text, source) {
+              if (!text) return [];
+              const out = [];
+              let match;
+              while ((match = nbsRegex.exec(text)) !== null) {
+                const suggestion = (match[1] || "").trim();
+                if (!suggestion) continue;
+                out.push({ suggestion, source });
+              }
+              return out;
+            }
+
+            async function paginate(method, params) {
+              const results = [];
+              let page = 1;
+              while (true) {
+                const { data } = await method({ ...params, per_page: 100, page });
+                if (!data.length) break;
+                results.push(...data);
+                if (data.length < 100) break;
+                page += 1;
+              }
+              return results;
+            }
+
+            const [reviews, issueComments, reviewComments] = await Promise.all([
+              paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: prNumber }),
+              paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNumber }),
+              paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: prNumber }),
+            ]);
+
+            const extracted = [];
+
+            for (const r of reviews) {
+              extracted.push(...extractNbsLines(r.body, `review:${r.user?.login || "unknown"}`));
+            }
+            for (const c of issueComments) {
+              extracted.push(...extractNbsLines(c.body, `issue-comment:${c.user?.login || "unknown"}`));
+            }
+            for (const c of reviewComments) {
+              extracted.push(...extractNbsLines(c.body, `review-comment:${c.user?.login || "unknown"}`));
+            }
+
+            if (!extracted.length) {
+              core.info("No NBS lines found; nothing to create.");
+              return;
+            }
+
+            // Deduplicate by normalized suggestion text.
+            const bySuggestion = new Map();
+            for (const item of extracted) {
+              const key = item.suggestion.toLowerCase();
+              const existing = bySuggestion.get(key);
+              if (existing) {
+                existing.sources.add(item.source);
+              } else {
+                bySuggestion.set(key, {
+                  suggestion: item.suggestion,
+                  sources: new Set([item.source]),
+                });
+              }
+            }
+
+            function shortTitle(s) {
+              const cleaned = s.replace(/\s+/g, " ").trim();
+              return cleaned.length > 80 ? `${cleaned.slice(0, 77)}...` : cleaned;
+            }
+
+            for (const { suggestion, sources } of bySuggestion.values()) {
+              const marker = `<!-- nbs:pr-${prNumber}:${Buffer.from(suggestion).toString("base64").slice(0, 20)} -->`;
+              const title = `[review-followup] PR #${prNumber}: ${shortTitle(suggestion)}`;
+              const body = [
+                marker,
+                `Source PR: ${prUrl}`,
+                `PR title: ${prTitle}`,
+                "",
+                "Auto-created from a non-blocking review suggestion marked with `NBS:`.",
+                "",
+                "## Suggestion",
+                `- [ ] ${suggestion}`,
+                "",
+                "## Trace",
+                ...Array.from(sources).map((s) => `- ${s}`),
+              ].join("\n");
+
+              await github.rest.issues.create({ owner, repo, title, body });
+              core.info(`Created follow-up issue: ${title}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,7 @@
 - Use `auto-merge` with `squash` for all project pull requests by default.
 
 ## Post-Merge Review Follow-up
-- After a PR is merged, collect non-blocking review suggestions and record them in a tracking issue.
-- The issue should keep a checkbox TODO list so suggestions are visible and actionable.
+- Use the internal skill: `skills/review-followup/SKILL.md`.
+- Every non-blocking review suggestion must be marked with the fixed keyword prefix: `NBS:`.
+- Write one `NBS:` suggestion per line.
+- After merge, automation creates one follow-up issue per `NBS:` line.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,19 @@ GitHub Actions is the source of truth for test status.
 Current CI checks:
 - Daemon Go tests
 - Gateway TypeScript type check
+
+## Review Convention (Non-Blocking Suggestions)
+
+For review comments, use the fixed keyword `NBS:` for each non-blocking suggestion.
+
+Rules:
+- one suggestion per line
+- each line starts with `NBS:`
+
+Example:
+```text
+NBS: Add edge-case test for missing request_id.
+NBS: Clarify fallback behavior in README.
+```
+
+Post-merge automation parses `NBS:` lines and creates one follow-up issue per suggestion.

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ Phase 1 scaffold for the Agent Installation Platform.
 - Start work from `origin/main` using a new `codex/*` branch and worktree.
 - Submit all feature updates via Pull Request.
 - Use GitHub Actions as test source of truth.
+- For non-blocking review suggestions, use `NBS:` lines (one suggestion per line). Post-merge automation creates follow-up issues from those lines.
 
 See `CONTRIBUTING.md` for command examples and required process.

--- a/skills/review-followup/SKILL.md
+++ b/skills/review-followup/SKILL.md
@@ -1,0 +1,30 @@
+# Review Follow-up Skill (Carrier)
+
+## Purpose
+Standardize how reviewers write non-blocking suggestions so automation can convert them into post-merge issues.
+
+## Fixed keyword
+Use this exact prefix for each non-blocking suggestion:
+
+`NBS:`
+
+NBS = Non-Blocking Suggestion.
+
+## Format rules
+- Put **one suggestion per line**.
+- Each suggestion line must start with `NBS:`.
+- Keep each suggestion actionable and specific.
+- If there are multiple suggestions, write multiple `NBS:` lines.
+
+## Example
+```text
+NBS: Add focused unit tests for invalid consent flag parsing.
+NBS: Document default retention TTL in README M3 section.
+```
+
+## Blocking vs non-blocking
+- Blocking: use normal review comments / change requests.
+- Non-blocking: use `NBS:` lines so they can be auto-tracked after merge.
+
+## Automation contract
+After PR merge, GitHub Action `review-nbs-followup` scans PR reviews/comments for `NBS:` lines and creates one issue per suggestion.


### PR DESCRIPTION
## Summary
Introduce a project-internal review convention + automation pipeline for non-blocking suggestions.

### 1) New review skill
- Added `skills/review-followup/SKILL.md`
- Defines fixed keyword: `NBS:`
- Rules:
  - one suggestion per line
  - each non-blocking suggestion line starts with `NBS:`

### 2) Repo policy/docs updates
- Updated `AGENTS.md` to require the `NBS:` convention for non-blocking review suggestions.
- Updated `CONTRIBUTING.md` with concrete `NBS:` usage and examples.
- Updated `README.md` to mention the review-followup convention.

### 3) Post-merge GitHub Action
- Added `.github/workflows/review-nbs-followup.yml`
- Trigger: `pull_request.closed` when merged
- Behavior:
  - scans PR reviews + issue comments + review comments
  - extracts lines matching `NBS:`
  - deduplicates suggestions
  - creates **one issue per suggestion** in the same repo
  - includes source PR context and trace in each issue body

## Notes
This implements the automation contract: non-blocking suggestions are explicitly tagged (`NBS:`) and then converted into actionable post-merge issues.
