### PR TITLE
W4: add gateway pairing/session and P0 command routing scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Phase 1 scaffold for the Agent Installation Platform.
 - Handoff records include consent flag, status, and diagnose artifact reference.
 
 ## M4 gateway routing scaffold status
-- Gateway command layer now supports `/diagnose-consent <agent_id> <yes|no>`.
-- `/diagnose-consent` routes to a daemon client placeholder that matches `CreateRemoteDiagnosisHandoff`.
-- Gateway forwards `provider`, `chat_id`, and `request_id` as actor/request context for handoff creation.
+- Gateway now supports `pair/agents/install/start/stop/status/logs/upgrade/diagnose/diagnose-consent` routing scaffold.
+- `/pair <code>` binds provider chat sessions and enforces session checks before non-pair commands.
+- Gateway forwards `provider`, `chat_id`, and `request_id` into daemon request context for command handling.
+- Logs/diagnose responses can issue short-lived read-only download tokens and URLs.
 
 ## Development flow
 - Start work from `origin/main` using a new `codex/*` branch and worktree.

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "bun run src/index.ts",
+    "dev": "bun run src/example.ts",
     "check": "bunx tsc --noEmit"
   },
   "devDependencies": {

--- a/gateway/src/contracts/commands.ts
+++ b/gateway/src/contracts/commands.ts
@@ -24,6 +24,8 @@ export type GatewayResponse = {
   requestId: string;
   result: "ok" | "error";
   message: string;
+  errorCode?: string;
+  sessionToken?: string;
   downloadUrl?: string;
   handoffId?: string;
   handoffStatus?: "pending" | "declined";

--- a/gateway/src/daemon/client.ts
+++ b/gateway/src/daemon/client.ts
@@ -1,5 +1,22 @@
 export type HandoffStatus = "pending" | "declined";
 
+export type RequestContext = {
+  actor: string;
+  requestId: string;
+};
+
+export type DaemonAgentState = {
+  id: string;
+  name: string;
+  version: string;
+  installed: boolean;
+  runtimeState: "running" | "stopped";
+  health: "healthy" | "unhealthy" | "unknown";
+  needsRemoteDiagnosis: boolean;
+  lastError?: string;
+  updatedAt: string;
+};
+
 export type RemoteDiagnosisHandoff = {
   id: string;
   agentId: string;
@@ -16,48 +33,308 @@ export type CreateRemoteDiagnosisHandoffInput = {
   requestId: string;
 };
 
+export type DiagnoseResult = {
+  artifactRef: string;
+};
+
+export type LogsResult = {
+  lines: string[];
+  truncated: boolean;
+};
+
+export type UpgradeResult = {
+  agentId: string;
+  fromVersion: string;
+  toVersion: string;
+};
+
 export interface DaemonClient {
+  listAgents(ctx: RequestContext): Promise<DaemonAgentState[]>;
+  installAgent(agentId: string, ctx: RequestContext): Promise<void>;
+  startAgent(agentId: string, ctx: RequestContext): Promise<void>;
+  stopAgent(agentId: string, ctx: RequestContext): Promise<void>;
+  getStatus(agentId: string | undefined, ctx: RequestContext): Promise<DaemonAgentState[]>;
+  getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult>;
+  upgradeAgent(agentId: string, ctx: RequestContext): Promise<UpgradeResult>;
+  diagnoseAgent(agentId: string, ctx: RequestContext): Promise<DiagnoseResult>;
   createRemoteDiagnosisHandoff(input: CreateRemoteDiagnosisHandoffInput): Promise<RemoteDiagnosisHandoff>;
 }
 
-export class RemoteDiagnosisNotNeededError extends Error {
-  readonly code = "E_REMOTE_DIAG_NOT_NEEDED";
-
-  constructor(message = "remote diagnosis is not required for this agent") {
+export class DaemonClientError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
     super(message);
+    this.name = "DaemonClientError";
+  }
+}
+
+export class RemoteDiagnosisNotNeededError extends DaemonClientError {
+  constructor(message = "remote diagnosis is not required for this agent") {
+    super("E_REMOTE_DIAG_NOT_NEEDED", message);
     this.name = "RemoteDiagnosisNotNeededError";
   }
 }
 
-type AgentRemoteDiagnosisState = {
+type InMemoryAgentState = {
+  id: string;
+  name: string;
+  version: string;
+  installed: boolean;
+  runtimeState: "running" | "stopped";
+  health: "healthy" | "unhealthy" | "unknown";
   needsRemoteDiagnosis: boolean;
+  lastError?: string;
   lastDiagnoseFile?: string;
+  updatedAt: string;
 };
 
-// Placeholder in-memory daemon adapter for M4 routing.
-// This is intentionally shaped to match daemon lifecycle CreateRemoteDiagnosisHandoff semantics.
-export class InMemoryDaemonClient implements DaemonClient {
-  private nextID = 0;
-  private readonly states = new Map<string, AgentRemoteDiagnosisState>();
+type DaemonAuditEvent = {
+  requestId: string;
+  actor: string;
+  action: string;
+  target: string;
+  message: string;
+  timestamp: string;
+};
 
-  setRemoteDiagnosisState(agentId: string, state: AgentRemoteDiagnosisState): void {
-    this.states.set(agentId, state);
+// In-memory daemon adapter for M4 command routing.
+// This keeps request context and command behavior close to the future daemon transport contract.
+export class InMemoryDaemonClient implements DaemonClient {
+  private nextHandoffID = 0;
+  private nextDiagnoseID = 0;
+  private readonly agents = new Map<string, InMemoryAgentState>();
+  private readonly logs = new Map<string, string[]>();
+  private readonly auditEvents: DaemonAuditEvent[] = [];
+
+  constructor(private readonly now: () => Date = () => new Date()) {
+    this.upsertAgent({
+      id: "openclaw",
+      name: "OpenClaw",
+      version: "0.1.0",
+      installed: false,
+      runtimeState: "stopped",
+      health: "unknown",
+      needsRemoteDiagnosis: false,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  setRemoteDiagnosisState(agentId: string, needsRemoteDiagnosis: boolean): void {
+    const state = this.requireAgent(agentId);
+    this.upsertAgent({
+      ...state,
+      needsRemoteDiagnosis,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  setDiagnoseArtifact(agentId: string, fileRef: string): void {
+    const state = this.requireAgent(agentId);
+    this.upsertAgent({
+      ...state,
+      lastDiagnoseFile: fileRef,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  getAuditEvents(): DaemonAuditEvent[] {
+    return this.auditEvents.slice();
+  }
+
+  async listAgents(ctx: RequestContext): Promise<DaemonAgentState[]> {
+    this.recordAudit(ctx, "list_agents", "*", "listed agents");
+    return [...this.agents.values()].map((state) => this.toPublicState(state));
+  }
+
+  async installAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    const state = this.requireAgent(agentId);
+    this.upsertAgent({
+      ...state,
+      installed: true,
+      runtimeState: "stopped",
+      health: "unknown",
+      lastError: undefined,
+      updatedAt: this.now().toISOString(),
+    });
+    this.appendLog(agentId, `[install] request=${ctx.requestId} actor=${ctx.actor} installed`);
+    this.recordAudit(ctx, "install", agentId, "installed");
+  }
+
+  async startAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    const state = this.requireAgent(agentId);
+    if (!state.installed) {
+      throw new DaemonClientError("E_NOT_INSTALLED", "agent is not installed");
+    }
+    if (state.runtimeState === "running") {
+      throw new DaemonClientError("E_ALREADY_RUNNING", "agent is already running");
+    }
+    this.upsertAgent({
+      ...state,
+      runtimeState: "running",
+      health: "healthy",
+      lastError: undefined,
+      updatedAt: this.now().toISOString(),
+    });
+    this.appendLog(agentId, `[start] request=${ctx.requestId} actor=${ctx.actor} started`);
+    this.recordAudit(ctx, "start", agentId, "started");
+  }
+
+  async stopAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    const state = this.requireAgent(agentId);
+    if (state.runtimeState === "stopped") {
+      throw new DaemonClientError("E_ALREADY_STOPPED", "agent is already stopped");
+    }
+    this.upsertAgent({
+      ...state,
+      runtimeState: "stopped",
+      health: "unknown",
+      updatedAt: this.now().toISOString(),
+    });
+    this.appendLog(agentId, `[stop] request=${ctx.requestId} actor=${ctx.actor} stopped`);
+    this.recordAudit(ctx, "stop", agentId, "stopped");
+  }
+
+  async getStatus(agentId: string | undefined, ctx: RequestContext): Promise<DaemonAgentState[]> {
+    if (!agentId) {
+      this.recordAudit(ctx, "status", "*", "status listed");
+      return [...this.agents.values()].map((state) => this.toPublicState(state));
+    }
+    const state = this.requireAgent(agentId);
+    this.recordAudit(ctx, "status", agentId, "status fetched");
+    return [this.toPublicState(state)];
+  }
+
+  async getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult> {
+    this.requireAgent(agentId);
+    const entries = this.logs.get(agentId) ?? [];
+    const safeTail = tail > 0 ? tail : 200;
+    const start = entries.length > safeTail ? entries.length - safeTail : 0;
+    this.recordAudit(ctx, "logs", agentId, `tail=${safeTail}`);
+    return {
+      lines: entries.slice(start),
+      truncated: start > 0,
+    };
+  }
+
+  async upgradeAgent(agentId: string, ctx: RequestContext): Promise<UpgradeResult> {
+    const state = this.requireAgent(agentId);
+    const fromVersion = state.version;
+    const toVersion = bumpPatchVersion(fromVersion);
+    this.upsertAgent({
+      ...state,
+      version: toVersion,
+      updatedAt: this.now().toISOString(),
+    });
+    this.appendLog(agentId, `[upgrade] request=${ctx.requestId} actor=${ctx.actor} ${fromVersion} -> ${toVersion}`);
+    this.recordAudit(ctx, "upgrade", agentId, `${fromVersion} -> ${toVersion}`);
+    return {
+      agentId,
+      fromVersion,
+      toVersion,
+    };
+  }
+
+  async diagnoseAgent(agentId: string, ctx: RequestContext): Promise<DiagnoseResult> {
+    const state = this.requireAgent(agentId);
+    this.nextDiagnoseID += 1;
+    const artifactRef = state.lastDiagnoseFile ?? `/tmp/${agentId}-diagnose-${this.nextDiagnoseID}.zip`;
+    this.upsertAgent({
+      ...state,
+      lastDiagnoseFile: artifactRef,
+      updatedAt: this.now().toISOString(),
+    });
+    this.appendLog(agentId, `[diagnose] request=${ctx.requestId} actor=${ctx.actor} ${artifactRef}`);
+    this.recordAudit(ctx, "diagnose", agentId, artifactRef);
+    return { artifactRef };
   }
 
   async createRemoteDiagnosisHandoff(input: CreateRemoteDiagnosisHandoffInput): Promise<RemoteDiagnosisHandoff> {
-    const state = this.states.get(input.agentId);
-    if (!state?.needsRemoteDiagnosis) {
+    const state = this.requireAgent(input.agentId);
+    if (!state.needsRemoteDiagnosis) {
       throw new RemoteDiagnosisNotNeededError();
     }
 
-    this.nextID += 1;
-    return {
-      id: `handoff-${this.nextID}`,
+    this.nextHandoffID += 1;
+    const handoff: RemoteDiagnosisHandoff = {
+      id: `handoff-${this.nextHandoffID}`,
       agentId: input.agentId,
       consent: input.consent,
       artifactRef: state.lastDiagnoseFile ?? "",
       status: input.consent ? "pending" : "declined",
-      createdAt: new Date().toISOString(),
+      createdAt: this.now().toISOString(),
+    };
+    this.recordAudit(
+      { actor: input.actor, requestId: input.requestId },
+      "remote_diagnosis_consent",
+      input.agentId,
+      `consent=${input.consent} handoff=${handoff.id}`,
+    );
+    return handoff;
+  }
+
+  private requireAgent(agentId: string): InMemoryAgentState {
+    const state = this.agents.get(agentId);
+    if (!state) {
+      throw new DaemonClientError("E_AGENT_NOT_FOUND", "agent not found");
+    }
+    return state;
+  }
+
+  private upsertAgent(state: InMemoryAgentState): void {
+    this.agents.set(state.id, state);
+    if (!this.logs.has(state.id)) {
+      this.logs.set(state.id, []);
+    }
+  }
+
+  private appendLog(agentId: string, message: string): void {
+    const logs = this.logs.get(agentId) ?? [];
+    logs.push(`${this.now().toISOString()} ${message}`);
+    if (logs.length > 2000) {
+      logs.splice(0, logs.length - 2000);
+    }
+    this.logs.set(agentId, logs);
+  }
+
+  private recordAudit(ctx: RequestContext, action: string, target: string, message: string): void {
+    this.auditEvents.push({
+      requestId: ctx.requestId,
+      actor: ctx.actor,
+      action,
+      target,
+      message,
+      timestamp: this.now().toISOString(),
+    });
+    if (this.auditEvents.length > 2000) {
+      this.auditEvents.splice(0, this.auditEvents.length - 2000);
+    }
+  }
+
+  private toPublicState(state: InMemoryAgentState): DaemonAgentState {
+    return {
+      id: state.id,
+      name: state.name,
+      version: state.version,
+      installed: state.installed,
+      runtimeState: state.runtimeState,
+      health: state.health,
+      needsRemoteDiagnosis: state.needsRemoteDiagnosis,
+      lastError: state.lastError,
+      updatedAt: state.updatedAt,
     };
   }
+}
+
+function bumpPatchVersion(version: string): string {
+  const parts = version.split(".");
+  if (parts.length !== 3) {
+    return version;
+  }
+  const patch = Number.parseInt(parts[2], 10);
+  if (!Number.isFinite(patch)) {
+    return version;
+  }
+  return `${parts[0]}.${parts[1]}.${patch + 1}`;
 }

--- a/gateway/src/downloads/token_store.ts
+++ b/gateway/src/downloads/token_store.ts
@@ -1,0 +1,55 @@
+import type { ReadOnlyDownloadToken } from "../contracts/session";
+
+type DownloadTokenRecord = ReadOnlyDownloadToken & {
+  consumedAt?: string;
+};
+
+export class DownloadTokenStore {
+  private nextToken = 0;
+  private readonly tokens = new Map<string, DownloadTokenRecord>();
+
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  issue(fileRef: string, ttlSeconds = 300, singleUse = true): ReadOnlyDownloadToken {
+    this.nextToken += 1;
+    const token = `dl-${this.nextToken}`;
+    const expiresAt = new Date(this.now().getTime() + ttlSeconds * 1000).toISOString();
+    const record: DownloadTokenRecord = {
+      token,
+      fileRef,
+      expiresAt,
+      singleUse,
+    };
+    this.tokens.set(token, record);
+    return record;
+  }
+
+  consume(token: string): ReadOnlyDownloadToken | null {
+    const record = this.tokens.get(token);
+    if (!record) {
+      return null;
+    }
+    if (Date.parse(record.expiresAt) <= this.now().getTime()) {
+      this.tokens.delete(token);
+      return null;
+    }
+    if (record.singleUse && record.consumedAt) {
+      return null;
+    }
+
+    if (record.singleUse) {
+      this.tokens.set(token, { ...record, consumedAt: this.now().toISOString() });
+    }
+    return {
+      token: record.token,
+      fileRef: record.fileRef,
+      expiresAt: record.expiresAt,
+      singleUse: record.singleUse,
+    };
+  }
+
+  toDownloadURL(token: ReadOnlyDownloadToken): string {
+    const fileName = token.fileRef.split("/").pop() || "artifact.zip";
+    return `/downloads/${token.token}/${fileName}`;
+  }
+}

--- a/gateway/src/example.ts
+++ b/gateway/src/example.ts
@@ -1,12 +1,26 @@
-import { handleCommand, parseInput } from "./index";
 import { InMemoryDaemonClient } from "./daemon/client";
+import { DownloadTokenStore } from "./downloads/token_store";
+import { safeHandleCommand } from "./index";
+import { SessionStore } from "./session/store";
 
 const daemon = new InMemoryDaemonClient();
-daemon.setRemoteDiagnosisState("openclaw", {
-  needsRemoteDiagnosis: true,
-  lastDiagnoseFile: "/tmp/openclaw-diagnose.zip",
-});
+const sessions = new SessionStore();
+const downloads = new DownloadTokenStore();
 
-const example = "telegram 123 req-1 /diagnose-consent openclaw yes";
-const response = await handleCommand(parseInput(example), daemon);
-console.log(JSON.stringify(response, null, 2));
+const pairCode = sessions.registerPairCode("pair-openclaw");
+const commands = [
+  `telegram 123 req-1 /pair ${pairCode.code}`,
+  "telegram 123 req-2 /agents",
+  "telegram 123 req-3 /install openclaw",
+  "telegram 123 req-4 /start openclaw",
+  "telegram 123 req-5 /diagnose openclaw",
+];
+
+for (const command of commands) {
+  const response = await safeHandleCommand(command, {
+    daemon,
+    sessions,
+    downloads,
+  });
+  console.log(JSON.stringify(response, null, 2));
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,12 +1,56 @@
-import type { GatewayCommand, GatewayResponse } from "./contracts/commands";
+import type {
+  CommandName,
+  GatewayCommand,
+  GatewayResponse,
+} from "./contracts/commands";
 import {
+  DaemonClientError,
   RemoteDiagnosisNotNeededError,
   type DaemonClient,
+  type RequestContext,
 } from "./daemon/client";
+import { DownloadTokenStore } from "./downloads/token_store";
+import { SessionStore } from "./session/store";
+
+const COMMAND_NAMES: ReadonlySet<CommandName> = new Set([
+  "/pair",
+  "/agents",
+  "/install",
+  "/start",
+  "/stop",
+  "/status",
+  "/logs",
+  "/upgrade",
+  "/diagnose",
+  "/diagnose-consent",
+]);
+
+export type GatewayDependencies = {
+  daemon: DaemonClient;
+  sessions: SessionStore;
+  downloads: DownloadTokenStore;
+};
+
+export class ParseError extends Error {
+  constructor(
+    readonly requestId: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ParseError";
+  }
+}
 
 export function parseInput(input: string): GatewayCommand {
   const parts = input.trim().split(/\s+/);
+  if (parts.length < 4) {
+    throw new ParseError("unknown", "usage: <provider> <chat_id> <request_id> <command> [...args]");
+  }
+
   const [provider, chatId, requestId, name, ...args] = parts;
+  if (!COMMAND_NAMES.has(name as CommandName)) {
+    throw new ParseError(requestId, `unknown command: ${name}`);
+  }
 
   return {
     provider: provider as GatewayCommand["provider"],
@@ -15,6 +59,220 @@ export function parseInput(input: string): GatewayCommand {
     name: name as GatewayCommand["name"],
     args,
   };
+}
+
+export async function handleCommand(
+  cmd: GatewayCommand,
+  deps: GatewayDependencies,
+): Promise<GatewayResponse> {
+  if (cmd.name === "/pair") {
+    const [code] = cmd.args;
+    if (!code) {
+      return usageError(cmd.requestId, "/pair <code>");
+    }
+    const session = deps.sessions.pair({
+      provider: cmd.provider,
+      chatId: cmd.chatId,
+      code,
+    });
+    if (!session) {
+      return errorResponse(cmd.requestId, "E_PAIR_CODE_INVALID", "pairing code is invalid or expired");
+    }
+    return {
+      requestId: cmd.requestId,
+      result: "ok",
+      message: `paired ${cmd.provider}:${cmd.chatId}`,
+      sessionToken: session.sessionToken,
+    };
+  }
+
+  const session = deps.sessions.getSession(cmd.provider, cmd.chatId);
+  if (!session) {
+    return errorResponse(
+      cmd.requestId,
+      "E_SESSION_REQUIRED",
+      "chat is not paired; run /pair <code> first",
+    );
+  }
+  deps.sessions.touch(cmd.provider, cmd.chatId);
+
+  const ctx = requestContext(cmd);
+  try {
+    switch (cmd.name) {
+      case "/agents": {
+        const agents = await deps.daemon.listAgents(ctx);
+        const installed = agents.filter((agent) => agent.installed).length;
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `listed ${agents.length} agents (${installed} installed)`,
+        };
+      }
+      case "/install": {
+        const [agentId] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/install <agent_id>");
+        }
+        await deps.daemon.installAgent(agentId, ctx);
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `install completed for ${agentId}`,
+        };
+      }
+      case "/start": {
+        const [agentId] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/start <agent_id>");
+        }
+        await deps.daemon.startAgent(agentId, ctx);
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `start completed for ${agentId}`,
+        };
+      }
+      case "/stop": {
+        const [agentId] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/stop <agent_id>");
+        }
+        await deps.daemon.stopAgent(agentId, ctx);
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `stop completed for ${agentId}`,
+        };
+      }
+      case "/status": {
+        const [agentId] = cmd.args;
+        const statuses = await deps.daemon.getStatus(agentId, ctx);
+        if (statuses.length === 0) {
+          return {
+            requestId: cmd.requestId,
+            result: "ok",
+            message: "no agent status available",
+          };
+        }
+        const summary = statuses
+          .map((status) => `${status.id}:${status.runtimeState}/${status.health}`)
+          .join(", ");
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `status ${summary}`,
+        };
+      }
+      case "/logs": {
+        const [agentId, tailRaw] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/logs <agent_id> [tail]");
+        }
+        const tail = parsePositiveInt(tailRaw, 200);
+        const logs = await deps.daemon.getLogs(agentId, tail, ctx);
+        const message = logs.lines.length === 0
+          ? `no logs for ${agentId}`
+          : `returned ${logs.lines.length} log lines for ${agentId}`;
+        const response: GatewayResponse = {
+          requestId: cmd.requestId,
+          result: "ok",
+          message,
+        };
+        if (logs.truncated || logs.lines.length > 50) {
+          const token = deps.downloads.issue(`/tmp/${agentId}-logs-${cmd.requestId}.txt`);
+          response.downloadUrl = deps.downloads.toDownloadURL(token);
+        }
+        return response;
+      }
+      case "/upgrade": {
+        const [agentId] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/upgrade <agent_id>");
+        }
+        const result = await deps.daemon.upgradeAgent(agentId, ctx);
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `upgrade completed for ${result.agentId}: ${result.fromVersion} -> ${result.toVersion}`,
+        };
+      }
+      case "/diagnose": {
+        const [agentId] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/diagnose <agent_id>");
+        }
+        const result = await deps.daemon.diagnoseAgent(agentId, ctx);
+        const token = deps.downloads.issue(result.artifactRef);
+        return {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `diagnose artifact prepared for ${agentId}`,
+          downloadUrl: deps.downloads.toDownloadURL(token),
+        };
+      }
+      case "/diagnose-consent": {
+        const [agentId, consentRaw] = cmd.args;
+        if (!agentId) {
+          return usageError(cmd.requestId, "/diagnose-consent <agent_id> <yes|no>");
+        }
+        const consent = parseConsentFlag(consentRaw);
+        if (consent === null) {
+          return errorResponse(cmd.requestId, "E_CONSENT_FLAG_INVALID", "expected yes or no");
+        }
+        const handoff = await deps.daemon.createRemoteDiagnosisHandoff({
+          agentId,
+          consent,
+          actor: ctx.actor,
+          requestId: ctx.requestId,
+        });
+        const response: GatewayResponse = {
+          requestId: cmd.requestId,
+          result: "ok",
+          message: `remote diagnosis consent recorded for ${agentId}`,
+          handoffId: handoff.id,
+          handoffStatus: handoff.status,
+        };
+        if (handoff.artifactRef) {
+          const token = deps.downloads.issue(handoff.artifactRef);
+          response.downloadUrl = deps.downloads.toDownloadURL(token);
+        }
+        return response;
+      }
+      default:
+        return errorResponse(cmd.requestId, "E_COMMAND_UNSUPPORTED", `unsupported command: ${cmd.name}`);
+    }
+  } catch (error) {
+    if (error instanceof RemoteDiagnosisNotNeededError) {
+      return errorResponse(cmd.requestId, error.code, error.message);
+    }
+    if (error instanceof DaemonClientError) {
+      return errorResponse(cmd.requestId, error.code, error.message);
+    }
+    return errorResponse(
+      cmd.requestId,
+      "E_COMMAND_FAILED",
+      error instanceof Error ? error.message : "unknown error",
+    );
+  }
+}
+
+export async function safeHandleCommand(
+  input: string,
+  deps: GatewayDependencies,
+): Promise<GatewayResponse> {
+  try {
+    const cmd = parseInput(input);
+    return await handleCommand(cmd, deps);
+  } catch (error) {
+    if (error instanceof ParseError) {
+      return errorResponse(error.requestId, "E_PARSE", error.message);
+    }
+    return errorResponse(
+      "unknown",
+      "E_PARSE",
+      error instanceof Error ? error.message : "invalid command input",
+    );
+  }
 }
 
 function parseConsentFlag(value: string | undefined): boolean | null {
@@ -31,64 +289,33 @@ function parseConsentFlag(value: string | undefined): boolean | null {
   return null;
 }
 
-export async function handleCommand(cmd: GatewayCommand, daemon: DaemonClient): Promise<GatewayResponse> {
-  if (cmd.name !== "/diagnose-consent") {
-    // Contract-only scaffold for other M4 command routing.
-    return {
-      requestId: cmd.requestId,
-      result: "ok",
-      message: `[${cmd.provider}] ${cmd.name} accepted for ${cmd.chatId}`,
-    };
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
   }
-
-  const [agentId, consentRaw] = cmd.args;
-  if (!agentId) {
-    return {
-      requestId: cmd.requestId,
-      result: "error",
-      message: "usage: /diagnose-consent <agent_id> <yes|no>",
-    };
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
   }
+  return parsed;
+}
 
-  const consent = parseConsentFlag(consentRaw);
-  if (consent === null) {
-    return {
-      requestId: cmd.requestId,
-      result: "error",
-      message: "invalid consent flag: expected yes or no",
-    };
-  }
+function requestContext(cmd: GatewayCommand): RequestContext {
+  return {
+    actor: `${cmd.provider}:${cmd.chatId}`,
+    requestId: cmd.requestId,
+  };
+}
 
-  try {
-    const handoff = await daemon.createRemoteDiagnosisHandoff({
-      agentId,
-      consent,
-      actor: `${cmd.provider}:${cmd.chatId}`,
-      requestId: cmd.requestId,
-    });
+function usageError(requestId: string, usage: string): GatewayResponse {
+  return errorResponse(requestId, "E_USAGE", `usage: ${usage}`);
+}
 
-    return {
-      requestId: cmd.requestId,
-      result: "ok",
-      message: `remote diagnosis consent recorded for ${agentId}`,
-      handoffId: handoff.id,
-      handoffStatus: handoff.status,
-      downloadUrl: handoff.artifactRef || undefined,
-    };
-  } catch (error) {
-    if (error instanceof RemoteDiagnosisNotNeededError) {
-      return {
-        requestId: cmd.requestId,
-        result: "error",
-        message: `${error.code}: ${error.message}`,
-      };
-    }
-    return {
-      requestId: cmd.requestId,
-      result: "error",
-      message: `failed to create remote diagnosis handoff: ${
-        error instanceof Error ? error.message : "unknown error"
-      }`,
-    };
-  }
+function errorResponse(requestId: string, errorCode: string, message: string): GatewayResponse {
+  return {
+    requestId,
+    result: "error",
+    errorCode,
+    message,
+  };
 }

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -1,0 +1,82 @@
+import type {
+  PairRequest,
+  SessionRecord,
+} from "../contracts/session";
+import type { Provider } from "../contracts/commands";
+
+type PairingCodeRecord = {
+  code: string;
+  expiresAt: string;
+};
+
+function sessionKey(provider: Provider, chatId: string): string {
+  return `${provider}:${chatId}`;
+}
+
+export class SessionStore {
+  private nextCode = 0;
+  private nextToken = 0;
+  private readonly pairCodes = new Map<string, PairingCodeRecord>();
+  private readonly sessions = new Map<string, SessionRecord>();
+
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  issuePairCode(ttlSeconds = 300): PairingCodeRecord {
+    this.nextCode += 1;
+    const code = `pair-${this.nextCode}`;
+    const expiresAt = new Date(this.now().getTime() + ttlSeconds * 1000).toISOString();
+    const record: PairingCodeRecord = { code, expiresAt };
+    this.pairCodes.set(code, record);
+    return record;
+  }
+
+  registerPairCode(code: string, ttlSeconds = 300): PairingCodeRecord {
+    const expiresAt = new Date(this.now().getTime() + ttlSeconds * 1000).toISOString();
+    const record: PairingCodeRecord = { code, expiresAt };
+    this.pairCodes.set(code, record);
+    return record;
+  }
+
+  pair(request: PairRequest): SessionRecord | null {
+    const codeRecord = this.pairCodes.get(request.code);
+    if (!codeRecord) {
+      return null;
+    }
+    if (Date.parse(codeRecord.expiresAt) <= this.now().getTime()) {
+      this.pairCodes.delete(request.code);
+      return null;
+    }
+
+    this.pairCodes.delete(request.code);
+    const existing = this.getSession(request.provider, request.chatId);
+    const createdAt = existing?.createdAt ?? this.now().toISOString();
+    const sessionToken = existing?.sessionToken ?? this.issueSessionToken();
+    const session: SessionRecord = {
+      provider: request.provider,
+      chatId: request.chatId,
+      sessionToken,
+      createdAt,
+      lastSeenAt: this.now().toISOString(),
+    };
+    this.sessions.set(sessionKey(request.provider, request.chatId), session);
+    return session;
+  }
+
+  getSession(provider: Provider, chatId: string): SessionRecord | null {
+    return this.sessions.get(sessionKey(provider, chatId)) ?? null;
+  }
+
+  touch(provider: Provider, chatId: string): void {
+    const key = sessionKey(provider, chatId);
+    const session = this.sessions.get(key);
+    if (!session) {
+      return;
+    }
+    this.sessions.set(key, { ...session, lastSeenAt: this.now().toISOString() });
+  }
+
+  private issueSessionToken(): string {
+    this.nextToken += 1;
+    return `session-${this.nextToken}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add gateway session store with pairing code issue/register/consume and chat-session binding
- add read-only download token store for logs and diagnose artifact URLs
- expand in-memory daemon client to cover P0 command contracts and request context propagation (actor, requestId)
- implement routing for /pair, /agents, /install, /start, /stop, /status, /logs, /upgrade, /diagnose, and /diagnose-consent
- enforce pairing for all non-pair commands and return structured gateway error codes
- update gateway example and README M4 status

## Validation
- bun run check (gateway)
- bun run dev (gateway example flow)

## Scope note
- This PR is command/session routing scaffold for W4 issue #42.
- Real provider adapters and endpoint wiring remain follow-up work.
