### PR TITLE
Fix Kanban automation permissions key

### DIFF
--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  project: write
+  projects: write
 
 jobs:
   sync:


### PR DESCRIPTION
修复 workflow permissions 中  的拼写为 ，该错误会导致 workflow 无法正常运行，issue/PR 无法被同步到 project。