### PR TITLE
skills: add pr-review and issue-triage agent skills

### DIFF
--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -25,7 +25,7 @@ Guide agents to periodically check open issues and pick up work that needs atten
 
 ## Handling Lightweight Issues
 1. Self-assign: `gh issue edit <number> --repo Keith-CY/carrier --add-assignee @me`
-2. Create worktree: `git worktree add /tmp/carrier-issue-<N> -b codex/issue-<N>-<description> origin/main`
+2. Create worktree: `git worktree add /tmp/carrier-issue-<N> -b codex/issue-<N>-<description> origin/main` (where `<description>` is a short kebab-case summary of the issue title, e.g., `codex/issue-42-fix-readme-typo`)
 3. Implement changes, run tests
 4. Push and create PR: `gh pr create --repo Keith-CY/carrier --base main`
 5. **Never push directly to main or develop**

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -6,7 +6,7 @@ Guide agents to review pull requests like a human collaborator — with inline c
 ## Review Process
 1. Fetch the PR diff via `gh pr diff <number> --repo Keith-CY/carrier`
 2. Read the full diff before commenting
-3. Submit a review using the GitHub Review API with inline `comments` array (path + position + body)
+3. Submit a review using the GitHub Review API with inline `comments` array (path, line, side, body)
 4. Approve if code is correct; request changes if blocking issues found
 
 ## What to Check
@@ -24,9 +24,10 @@ Guide agents to review pull requests like a human collaborator — with inline c
 - Reference related PRs/issues when relevant (e.g., "This conflicts with the pattern in PR #14")
 
 ## Build Verification
-Before approving, confirm the author validated:
+Before approving, confirm all CI checks have passed:
+- Check CI status: `gh pr checks <number> --repo Keith-CY/carrier`
 - **Daemon (Go)**: `cd daemon && go test ./...`
-- **Gateway (TypeScript)**: `cd gateway && bun run check && bun test`
+- **Gateway (TypeScript)**: `cd gateway && bun run check`
 
 ## Auto-Review Cadence
 A cron job runs every 15 minutes to check for unreviewed open PRs and submit reviews automatically.


### PR DESCRIPTION
## Summary
Add two agent skills to the project `skills/` directory:

### skills/pr-review
Guides agents on how to review PRs with inline code comments — what to check, comment style (NBS: convention), and build verification steps.

### skills/issue-triage
Guides agents on periodic issue triage — how to categorize lightweight vs heavy issues, and the workflow for self-assigning and creating PRs for lightweight ones.

Both skills document the automated cron cadence (every 15 min) for PR review and issue triage.