### PR TITLE
skills: update pr-review and issue-triage with refined workflows

### DIFF
--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -25,11 +25,12 @@ Guide agents to periodically check open issues and pick up work that needs atten
 
 ## Handling Lightweight Issues
 1. Self-assign: `gh issue edit <number> --repo Keith-CY/carrier --add-assignee @me`
-2. Create worktree: `git worktree add /tmp/carrier-issue-<N> -b codex/issue-<N>-<description> origin/main` (where `<description>` is a short kebab-case summary of the issue title, e.g., `codex/issue-42-fix-readme-typo`)
+2. Create worktree: `git worktree add /tmp/carrier-issue-<number> -b codex/issue-<number>-<description> origin/main` (where `<description>` is a short kebab-case summary of the issue title, e.g., `codex/issue-42-fix-readme-typo`)
 3. Implement changes, run tests
 4. Push and create PR: `gh pr create --repo Keith-CY/carrier --base main`
-5. **Never push directly to main or develop**
-6. **Never self-merge** — wait for maintainer review
+5. Set auto-merge: `gh pr merge --repo Keith-CY/carrier --squash --auto`
+6. **Never push directly to main or develop**
+7. **Never self-merge** — wait for maintainer review
 
 ## Auto-Triage Cadence
 A cron job runs every 15 minutes to scan issues and act on lightweight ones.


### PR DESCRIPTION
## Summary
Update both agent skill docs to reflect the optimized cron workflows.

### pr-review changes
- Skip re-review when no new commits since last review
- Own PRs: auto-fix conflicts (rebase), handle blocking reviews, note NBS
- Cadence: 5 minutes

### issue-triage changes
- Unassigned: self-assign lightweight, skip heavy
- Assigned to others: participate in discussion (new)
- Assigned to me: check for existing branch/PR
- Auto-merge (squash) after PR creation
- Cadence: 5 minutes