### PR TITLE
test(lifecycle): cover upgrade backup creation failure path

### DIFF
--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -600,6 +600,40 @@ func TestUpgradeFailureReturnsBackupGuidanceAndAuditFailure(t *testing.T) {
 	}
 }
 
+func TestUpgradeBackupCreationFailureReturnsFocusedError(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	runner := &fakeRunner{}
+	checker := &fakeChecker{}
+	svc := newServiceForTest(t, runner, checker)
+
+	if err := svc.Install("openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	blockedPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blockedPath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocked path: %v", err)
+	}
+	svc.diagnoseDir = blockedPath
+
+	err := svc.Upgrade("openclaw")
+	if err == nil {
+		t.Fatal("expected upgrade error")
+	}
+	if !strings.Contains(err.Error(), "create diagnose dir") {
+		t.Fatalf("expected diagnose-dir creation error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "manual rollback guidance") || strings.Contains(err.Error(), "-pre-upgrade-") {
+		t.Fatalf("backup guidance should not be shown when backup creation fails, got %v", err)
+	}
+
+	for _, log := range svc.AuditLogs() {
+		if log.Action == "upgrade" && strings.Contains(log.Message, "upgrade_start") {
+			t.Fatalf("unexpected upgrade_start audit when backup creation failed: %+v", log)
+		}
+	}
+}
+
 func TestCreateRemoteDiagnosisHandoffRequiresNeedFlag(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	runner := &fakeRunner{}


### PR DESCRIPTION
## Summary
- add a focused lifecycle test for the backup-creation failure path in `Upgrade`
- verify the returned user-facing error stays specific to backup creation (`create diagnose dir`) and does not include rollback guidance text intended for post-backup command failures
- assert no `upgrade_start` audit event is emitted when pre-upgrade backup creation fails

## Validation
- `cd daemon && go test ./...`

Closes #95
