### PR TITLE
test: close #69 and #70 with runtime naming + unknown command test

### DIFF
--- a/daemon/internal/runtimecheck/checker.go
+++ b/daemon/internal/runtimecheck/checker.go
@@ -25,10 +25,10 @@ type Checker interface {
 }
 
 const (
-	IssueCodeWSL2Missing      = "E_WSL2_MISSING"
-	IssueCodeNPMMissing       = "E_NPM_MISSING"
-	IssueCodeGoMissing        = "E_GO_MISSING"
-	IssueCodeRuntimeTypeUnknown = "E_RUNTIME_TYPE_UNKNOWN"
+	IssueCodeWSL2Missing    = "E_WSL2_MISSING"
+	IssueCodeNPMMissing     = "E_NPM_MISSING"
+	IssueCodeGoMissing      = "E_GO_MISSING"
+	IssueCodeUnknownRuntime = "E_RUNTIME_TYPE_UNKNOWN"
 )
 
 type Issue struct {
@@ -117,7 +117,7 @@ func (c HostChecker) collectIssues(runtimeType manifest.RuntimeType) []Issue {
 		// No extra host tool requirement.
 	default:
 		issues = append(issues, Issue{
-			Code:    IssueCodeRuntimeTypeUnknown,
+			Code:    IssueCodeUnknownRuntime,
 			Message: fmt.Sprintf("unsupported runtime type: %s", runtimeType),
 		})
 	}

--- a/gateway/src/index.test.ts
+++ b/gateway/src/index.test.ts
@@ -40,6 +40,10 @@ describe("gateway parseInput", () => {
     expect(cmd.name).toBe("/logs");
     expect(cmd.args).toEqual(["openclaw", "200"]);
   });
+
+  test("returns parse error for unknown command", () => {
+    expect(() => parseInput("telegram 100 req-1 /foobar")).toThrow("unknown command: /foobar");
+  });
 });
 
 describe("gateway diagnose-consent routing", () => {


### PR DESCRIPTION
## Summary
- rename `IssueCodeRuntimeTypeUnknown` to `IssueCodeUnknownRuntime` for cleaner, consistent naming
- add gateway parser test for unknown command (`/foobar`) to validate `ParseError` message behavior

## Validation
- `cd daemon && go test ./internal/runtimecheck`
- `cd gateway && bun test src/index.test.ts`

Closes #69
Closes #70
