### PR TITLE
docs(skills): keep cadence wording aligned with automation source-of-truth

### DIFF
--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -32,5 +32,5 @@ Guide agents to periodically check open issues and pick up work that needs atten
 6. **Never push directly to main or develop**
 7. **Never self-merge** — wait for maintainer review
 
-## Auto-Triage Cadence
-A cron job runs every 15 minutes to scan issues and act on lightweight ones.
+## Automation Trigger
+This skill is intended to be executed by repository automation (for example cron-driven sweeps). Keep cadence details in the automation configuration/prompt as the source of truth.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -29,5 +29,5 @@ Before approving, confirm all CI checks have passed:
 - **Daemon (Go)**: `cd daemon && go test ./...`
 - **Gateway (TypeScript)**: `cd gateway && bun run check`
 
-## Auto-Review Cadence
-A cron job runs every 15 minutes to check for unreviewed open PRs and submit reviews automatically.
+## Automation Trigger
+This skill is intended to be executed by repository automation (for example cron-driven sweeps). Keep cadence details in the automation configuration/prompt as the source of truth.


### PR DESCRIPTION
## Summary
- replace hard-coded cadence wording in `skills/pr-review/SKILL.md`
- replace hard-coded cadence wording in `skills/issue-triage/SKILL.md`
- document that automation prompt/config is the canonical source of cadence

## Why
Addresses review-followup issues requesting a single source of truth for cadence wording to avoid drift.

Closes #99
Closes #100
