### PR TITLE
ci: use generated changelog for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,6 @@ jobs:
           tag_name: main-${{ github.sha }}
           name: "main-${{ github.sha }}"
           generate_release_notes: true
-          body: |
-            自动发布：每次合并到 main 后自动打包。  
-            Commit: ${{ github.sha }}
           files: |
             dist/**/*.zip
             dist/**/*.sha256


### PR DESCRIPTION
## Summary
Implement issue #110 by removing the fixed `body:` block from release workflow notes.

### Change
- File: `.github/workflows/release.yml`
- In `softprops/action-gh-release` step:
  - keep `generate_release_notes: true`
  - remove static `body` text so release notes are generated from merged PR history

## Why
The fixed body produced repetitive, low-signal release notes. This change allows GitHub auto-generated changelog to be the primary release note content.

Closes #110