### PR TITLE
test(lifecycle): fix Upgrade() assignment to restore daemon CI

### DIFF
--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -758,7 +758,7 @@ func TestUpgradeBackupCreationFailureReturnsFocusedError(t *testing.T) {
 	}
 	svc.diagnoseDir = blockedPath
 
-	err := svc.Upgrade("openclaw")
+	_, err := svc.Upgrade("openclaw")
 	if err == nil {
 		t.Fatal("expected upgrade error")
 	}


### PR DESCRIPTION
## Summary
Fix CI-wide daemon test compile failure introduced by a mismatched assignment in lifecycle tests.

## Root cause
`Service.Upgrade()` now returns two values, but one test still assigned a single return value:
- `err := svc.Upgrade("openclaw")`

This caused package build failure during `go test ./...`:
- `assignment mismatch: 1 variable but svc.Upgrade returns 2 values`

## Fix
Update the test to correctly ignore the first return value:
- `_, err := svc.Upgrade("openclaw")`

## Validation
- `cd daemon && go test ./...` ✅