### PR TITLE
docs(skills): add skills directory index README

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,15 @@
+# Skills Directory
+
+This directory contains the skill definitions used by the Carrier automation system.
+
+## Available Skills
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [PR Review](pr-review/SKILL.md) | Automated pull-request review workflow | `skills/pr-review/` |
+| [Issue Triage](issue-triage/SKILL.md) | Automated issue triage and labelling | `skills/issue-triage/` |
+| [Review Followup](review-followup/SKILL.md) | Track and create follow-up issues from review comments | `skills/review-followup/` |
+
+## Adding a New Skill
+
+Create a new subdirectory under `skills/` with a `SKILL.md` file that describes the skill's purpose, triggers, and behaviour.


### PR DESCRIPTION
Create skills/README.md linking pr-review, issue-triage, and review-followup skill docs from a single index file.

Closes #68