### PR TITLE
feat(lifecycle): add AuditBufferStatus debug endpoint

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -482,6 +482,24 @@ func (s *Service) Logs(agentID string, tail int) ([]string, error) {
 	return append([]string(nil), logs[start:]...), nil
 }
 
+// AuditStatus returns the current audit buffer size, configured limit, and
+// the number of entries that have been dropped due to the limit.  This is
+// intended for operational inspection / debug endpoints.
+type AuditStatus struct {
+	BufferSize int `json:"buffer_size"`
+	Limit      int `json:"limit"`
+}
+
+// AuditBufferStatus returns a snapshot of the audit buffer metrics.
+func (s *Service) AuditBufferStatus() AuditStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return AuditStatus{
+		BufferSize: len(s.auditLogs),
+		Limit:      s.auditLogLimit,
+	}
+}
+
 func (s *Service) AuditLogs() []AuditLog {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -937,6 +937,44 @@ var (
 	atoi          = strconv.Atoi
 )
 
+func TestAuditBufferStatus(t *testing.T) {
+	svc := NewService(nil, WithAuditLogLimit(50))
+
+	status := svc.AuditBufferStatus()
+	if status.BufferSize != 0 {
+		t.Fatalf("expected empty buffer, got %d", status.BufferSize)
+	}
+	if status.Limit != 50 {
+		t.Fatalf("expected limit 50, got %d", status.Limit)
+	}
+
+	// Generate some audit entries by installing an agent.
+	m := manifest.Manifest{
+		ID: "a", Name: "a", Version: "1",
+		Runtime: manifest.RuntimeSpec{
+			Type:    manifest.RuntimeTypeLocalBinary,
+			Install: manifest.CommandSpec{Command: "echo ok"},
+			Start:   manifest.CommandSpec{Command: "echo start"},
+			Stop:    manifest.CommandSpec{Command: "echo stop"},
+		},
+		Memory: manifest.MemorySpec{
+			MountPath: "/tmp/test-audit-mem",
+			Supports:  []manifest.MemoryType{manifest.MemoryTypePerAgent},
+		},
+	}
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Install("a"); err != nil {
+		t.Fatal(err)
+	}
+
+	status = svc.AuditBufferStatus()
+	if status.BufferSize == 0 {
+		t.Fatal("expected non-zero buffer after install")
+	}
+}
+
 func readZipEntry(t *testing.T, files []*zip.File, name string) []byte {
 	t.Helper()
 	for _, f := range files {


### PR DESCRIPTION
Expose current audit buffer size and configured limit via AuditBufferStatus() for operational inspection. Includes unit test.

Closes #41