### PR TITLE
test(gateway): add unknown-token consume coverage

### DIFF
--- a/gateway/src/downloads/token_store.test.ts
+++ b/gateway/src/downloads/token_store.test.ts
@@ -37,6 +37,12 @@ describe("DownloadTokenStore", () => {
     expect(store.consume(tok.token)).toBeNull();
   });
 
+  test("consume() unknown token returns null", () => {
+    const store = new DownloadTokenStore(() => new Date("2026-01-01T00:00:00Z"));
+
+    expect(store.consume("not-a-real-token")).toBeNull();
+  });
+
   test("single-use token consumed twice → second returns null", () => {
     const store = new DownloadTokenStore(() => new Date("2026-01-01T00:00:00Z"));
     const tok = store.issue("file.txt", 300, true);


### PR DESCRIPTION
## Summary
- add a focused test for unknown download token consumption
- keep behavior explicit that unknown tokens return `null`
- reference follow-up issue context from PR #117

## Testing
- `cd gateway && bun test src/downloads/token_store.test.ts`

Closes #162
