### PR TITLE
ci: run e2e checks on PRs with safe CLI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run `End-to-End Tests` on `pull_request` as well as `push` to `main`
- keep the existing CLI availability guard in `scripts/run-e2e-tests.sh` so CI safely skips when `carrier` is unavailable

## Linked issue
- Closes #136

## Commit highlights
- update `e2e-tests` job `if:` expression in `.github/workflows/ci.yml` to include PR events
