### PR TITLE
docs(lifecycle): align AuditStatus comment with exposed fields

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -486,9 +486,8 @@ func (s *Service) Logs(agentID string, tail int) ([]string, error) {
 	return append([]string(nil), logs[start:]...), nil
 }
 
-// AuditStatus returns the current audit buffer size, configured limit, and
-// the number of entries that have been dropped due to the limit.  This is
-// intended for operational inspection / debug endpoints.
+// AuditStatus returns the current audit buffer size and configured limit.
+// This is intended for operational inspection / debug endpoints.
 type AuditStatus struct {
 	BufferSize int `json:"buffer_size"`
 	Limit      int `json:"limit"`


### PR DESCRIPTION
## Summary
- Align `AuditStatus` documentation with actual exported fields
- Remove dropped-count wording that is not currently exposed by the struct

## Validation
- `cd daemon && go test ./internal/lifecycle -run TestAuditBufferStatus`

Closes #160
