### PR TITLE
ci(workflows): clarify octokit client variable naming

### DIFF
--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -34,7 +34,7 @@ jobs:
             const eventName = context.eventName;
             const payload = context.payload;
             const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
-            const gh = token ? github.getOctokit(token) : github;
+            const octokit = token ? github.getOctokit(token) : github;
 
             const getStatusCandidates = (item, labels) => {
               const hasLabel = (target) => labels.includes(target.toLowerCase());
@@ -174,7 +174,7 @@ jobs:
               }
             }`;
 
-            const preflight = await gh.graphql(preflightQuery, { projectId });
+            const preflight = await octokit.graphql(preflightQuery, { projectId });
             if (!preflight?.node) {
               core.setFailed(`Unable to read project ${projectId}. Verify the token and projectId are valid.`);
               return;
@@ -341,7 +341,7 @@ jobs:
                 }
               }`;
 
-              const data = await gh.graphql(query, { projectId, after: cursor });
+              const data = await octokit.graphql(query, { projectId, after: cursor });
               const project = data.node;
 
               const found = project.items.nodes.find((entry) => {
@@ -373,7 +373,7 @@ jobs:
                 }
               }`;
 
-              const addResp = await gh.graphql(addMutation, { projectId, contentId });
+              const addResp = await octokit.graphql(addMutation, { projectId, contentId });
               return addResp.addProjectV2ItemById.item.id;
             };
 
@@ -417,7 +417,7 @@ jobs:
             for (const update of updates) {
               try {
                 if (update.kind === 'single_select') {
-                  await gh.graphql(updateMutations.single_select, {
+                  await octokit.graphql(updateMutations.single_select, {
                     projectId,
                     itemId: finalItemId,
                     fieldId: update.fieldId,
@@ -427,7 +427,7 @@ jobs:
                 }
 
                 if (update.kind === 'number') {
-                  await gh.graphql(updateMutations.number, {
+                  await octokit.graphql(updateMutations.number, {
                     projectId,
                     itemId: finalItemId,
                     fieldId: update.fieldId,
@@ -437,7 +437,7 @@ jobs:
                 }
 
                 if (update.kind === 'text') {
-                  await gh.graphql(updateMutations.text, {
+                  await octokit.graphql(updateMutations.text, {
                     projectId,
                     itemId: finalItemId,
                     fieldId: update.fieldId,
@@ -447,7 +447,7 @@ jobs:
                 }
 
                 if (update.kind === 'date') {
-                  await gh.graphql(updateMutations.date, {
+                  await octokit.graphql(updateMutations.date, {
                     projectId,
                     itemId: finalItemId,
                     fieldId: update.fieldId,

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -37,9 +37,9 @@ jobs:
             const repo = context.repo.repo;
             const dryRunInput = String((context.payload.inputs?.dry_run || process.env.DRY_RUN || 'false')).toLowerCase() === 'true';
             const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
-            const gh = token ? github.getOctokit(token) : github;
+            const octokit = token ? github.getOctokit(token) : github;
 
-            const repoMeta = await gh.graphql(`
+            const repoMeta = await octokit.graphql(`
               query($owner: String!, $repo: String!) {
                 repository(owner: $owner, name: $repo) {
                   id
@@ -67,7 +67,7 @@ jobs:
               return;
             }
 
-            const preflight = await gh.graphql(`
+            const preflight = await octokit.graphql(`
               query($projectId: ID!) {
                 node(id: $projectId) {
                   ... on ProjectV2 {
@@ -361,7 +361,7 @@ jobs:
 
             const title = `Carrier Kanban：字段/视图配置与工作量报告 (${isoDate})`;
 
-            const resp = await gh.graphql(createDiscussionMutation, {
+            const resp = await octokit.graphql(createDiscussionMutation, {
               repositoryId: repoMeta.repository.id,
               categoryId: category.id,
               title,


### PR DESCRIPTION
## Summary
- rename the workflow script client variable from `gh` to `octokit` in kanban automation workflows
- keep token-based initialization behavior unchanged
- improve readability and avoid confusion with the GitHub CLI `gh` command

## Testing
- not run (workflow script variable rename only)

Closes #168
