### PR TITLE
feat: W1.1 Implement Manifest and Catalog contracts

### DIFF
--- a/catalog/openclaw.manifest.json
+++ b/catalog/openclaw.manifest.json
@@ -2,6 +2,8 @@
   "id": "openclaw",
   "name": "OpenClaw",
   "version": "1.0.0",
+  "description": "Full-featured AI assistant with memory support",
+  "capabilities": ["chat", "code", "memory"],
   "runtime": {
     "type": "local_binary",
     "install": { "command": "./install.sh" },
@@ -14,8 +16,8 @@
     "healthcheck": { "type": "http", "url": "http://localhost:8080/health" }
   },
   "env": {
-    "required": [{ "name": "OPENAI_API_KEY", "secret": true }],
-    "optional": [{ "name": "LOG_LEVEL", "default": "info" }]
+    "required": [{ "name": "OPENAI_API_KEY", "secret": true, "description": "OpenAI API key for LLM access" }],
+    "optional": [{ "name": "LOG_LEVEL", "default": "info", "description": "Logging verbosity level" }]
   },
   "memory": {
     "supports": ["per_agent", "shared", "public"],
@@ -24,6 +26,13 @@
   "upgrade": {
     "channel": "stable",
     "strategy": "in_place_or_reinstall"
+  },
+  "health": {
+    "interval_seconds": 30,
+    "timeout_seconds": 5,
+    "retries": 3,
+    "restart_loop_window": 300,
+    "restart_loop_max": 5
   },
   "diagnostics": {
     "include": ["runtime_logs", "process_state", "env_sanitized"]

--- a/daemon/internal/catalog/catalog.go
+++ b/daemon/internal/catalog/catalog.go
@@ -2,6 +2,7 @@ package catalog
 
 import "sort"
 
+// CandidateStatus represents the lifecycle stage of a catalog entry.
 type CandidateStatus string
 
 const (
@@ -9,18 +10,67 @@ const (
 	StatusCandidate CandidateStatus = "candidate"
 )
 
+// Entry represents an agent in the catalog with version and capability metadata.
 type Entry struct {
-	ID     string
-	Name   string
-	Status CandidateStatus
+	ID           string
+	Name         string
+	Version      string
+	Status       CandidateStatus
+	Capabilities []string
+	Description  string
 }
 
+// List returns all catalog entries sorted by ID.
+func List() []Entry {
+	return DefaultEntries()
+}
+
+// ListByStatus returns entries filtered by candidate status.
+func ListByStatus(status CandidateStatus) []Entry {
+	var result []Entry
+	for _, e := range DefaultEntries() {
+		if e.Status == status {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// DefaultEntries returns the built-in catalog sorted by ID.
 func DefaultEntries() []Entry {
 	entries := []Entry{
-		{ID: "openclaw", Name: "OpenClaw", Status: StatusActive},
-		{ID: "pi-mono", Name: "Pi Mono", Status: StatusCandidate},
-		{ID: "nanoclaw", Name: "NanoClaw", Status: StatusCandidate},
-		{ID: "picoclaw", Name: "Pico Claw", Status: StatusCandidate},
+		{
+			ID:           "openclaw",
+			Name:         "OpenClaw",
+			Version:      "1.0.0",
+			Status:       StatusActive,
+			Capabilities: []string{"chat", "code", "memory"},
+			Description:  "Full-featured AI assistant with memory support",
+		},
+		{
+			ID:           "pi-mono",
+			Name:         "Pi Mono",
+			Version:      "0.1.0",
+			Status:       StatusCandidate,
+			Capabilities: []string{"chat"},
+			Description:  "Lightweight conversational agent",
+		},
+		{
+			ID:           "nanoclaw",
+			Name:         "NanoClaw",
+			Version:      "0.1.0",
+			Status:       StatusCandidate,
+			Capabilities: []string{"chat", "code"},
+			Description:  "Compact coding assistant",
+		},
+		{
+			ID:           "picoclaw",
+			Name:         "Pico Claw",
+			Version:      "0.1.0",
+			Status:       StatusCandidate,
+			Capabilities: []string{"chat"},
+			Description:  "Minimal chat agent",
+		},
 	}
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].ID < entries[j].ID
@@ -28,6 +78,7 @@ func DefaultEntries() []Entry {
 	return entries
 }
 
+// FindByID looks up a catalog entry by its ID.
 func FindByID(id string) (Entry, bool) {
 	for _, e := range DefaultEntries() {
 		if e.ID == id {
@@ -35,4 +86,19 @@ func FindByID(id string) (Entry, bool) {
 		}
 	}
 	return Entry{}, false
+}
+
+// IsRunnable returns true if the entry has active status and can be installed/started.
+func (e Entry) IsRunnable() bool {
+	return e.Status == StatusActive
+}
+
+// HasCapability checks if the entry advertises the given capability.
+func (e Entry) HasCapability(cap string) bool {
+	for _, c := range e.Capabilities {
+		if c == cap {
+			return true
+		}
+	}
+	return false
 }

--- a/daemon/internal/catalog/catalog_test.go
+++ b/daemon/internal/catalog/catalog_test.go
@@ -29,3 +29,81 @@ func TestCandidateAgentsPresent(t *testing.T) {
 		}
 	}
 }
+
+func TestListReturnsAllEntries(t *testing.T) {
+	all := List()
+	if len(all) != 4 {
+		t.Fatalf("expected 4 entries from List(), got %d", len(all))
+	}
+}
+
+func TestListByStatusActive(t *testing.T) {
+	active := ListByStatus(StatusActive)
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active entry, got %d", len(active))
+	}
+	if active[0].ID != "openclaw" {
+		t.Fatalf("expected openclaw, got %s", active[0].ID)
+	}
+}
+
+func TestListByStatusCandidate(t *testing.T) {
+	candidates := ListByStatus(StatusCandidate)
+	if len(candidates) != 3 {
+		t.Fatalf("expected 3 candidate entries, got %d", len(candidates))
+	}
+}
+
+func TestEntryVersions(t *testing.T) {
+	openclaw, _ := FindByID("openclaw")
+	if openclaw.Version != "1.0.0" {
+		t.Fatalf("expected openclaw version 1.0.0, got %s", openclaw.Version)
+	}
+	pi, _ := FindByID("pi-mono")
+	if pi.Version != "0.1.0" {
+		t.Fatalf("expected pi-mono version 0.1.0, got %s", pi.Version)
+	}
+}
+
+func TestEntryCapabilities(t *testing.T) {
+	openclaw, _ := FindByID("openclaw")
+	if !openclaw.HasCapability("chat") {
+		t.Fatal("expected openclaw to have chat capability")
+	}
+	if !openclaw.HasCapability("code") {
+		t.Fatal("expected openclaw to have code capability")
+	}
+	if !openclaw.HasCapability("memory") {
+		t.Fatal("expected openclaw to have memory capability")
+	}
+	if openclaw.HasCapability("nonexistent") {
+		t.Fatal("expected openclaw not to have nonexistent capability")
+	}
+}
+
+func TestEntryIsRunnable(t *testing.T) {
+	openclaw, _ := FindByID("openclaw")
+	if !openclaw.IsRunnable() {
+		t.Fatal("expected openclaw to be runnable")
+	}
+	pi, _ := FindByID("pi-mono")
+	if pi.IsRunnable() {
+		t.Fatal("expected pi-mono not to be runnable")
+	}
+}
+
+func TestEntryDescriptions(t *testing.T) {
+	openclaw, _ := FindByID("openclaw")
+	if openclaw.Description == "" {
+		t.Fatal("expected openclaw to have a description")
+	}
+}
+
+func TestEntriesSortedByID(t *testing.T) {
+	entries := DefaultEntries()
+	for i := 1; i < len(entries); i++ {
+		if entries[i].ID < entries[i-1].ID {
+			t.Fatalf("entries not sorted: %s before %s", entries[i-1].ID, entries[i].ID)
+		}
+	}
+}

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -4,9 +4,11 @@ import "carrier/daemon/internal/manifest"
 
 func OpenClawManifest() manifest.Manifest {
 	return manifest.Manifest{
-		ID:      "openclaw",
-		Name:    "OpenClaw",
-		Version: "1.0.0",
+		ID:           "openclaw",
+		Name:         "OpenClaw",
+		Version:      "1.0.0",
+		Description:  "Full-featured AI assistant with memory support",
+		Capabilities: []string{"chat", "code", "memory"},
 		Runtime: manifest.RuntimeSpec{
 			Type:    manifest.RuntimeTypeLocalBinary,
 			Install: manifest.CommandSpec{Command: "./install.sh"},
@@ -22,14 +24,21 @@ func OpenClawManifest() manifest.Manifest {
 			},
 		},
 		Env: manifest.EnvSpec{
-			Required: []manifest.EnvVar{{Name: "OPENAI_API_KEY", Secret: true}},
-			Optional: []manifest.EnvVar{{Name: "LOG_LEVEL", Default: "info"}},
+			Required: []manifest.EnvVar{{Name: "OPENAI_API_KEY", Secret: true, Description: "OpenAI API key for LLM access"}},
+			Optional: []manifest.EnvVar{{Name: "LOG_LEVEL", Default: "info", Description: "Logging verbosity level"}},
 		},
 		Memory: manifest.MemorySpec{
 			Supports:  []manifest.MemoryType{manifest.MemoryTypePerAgent, manifest.MemoryTypeShared, manifest.MemoryTypePublic},
 			MountPath: "./memory",
 		},
 		Upgrade: manifest.UpgradeSpec{Channel: "stable", Strategy: "in_place_or_reinstall"},
+		Health: manifest.HealthSpec{
+			IntervalSeconds:   30,
+			TimeoutSeconds:    5,
+			Retries:           3,
+			RestartLoopWindow: 300,
+			RestartLoopMax:    5,
+		},
 		Diagnostics: manifest.Diagnostics{Include: []string{"runtime_logs", "process_state", "env_sanitized"}},
 	}
 }

--- a/daemon/internal/manifest/types.go
+++ b/daemon/internal/manifest/types.go
@@ -26,16 +26,21 @@ const (
 	UpgradeStrategyInPlaceOrReinstall = "in_place_or_reinstall"
 )
 
+// Manifest is the full agent manifest schema covering runtime, env, network,
+// health, upgrade, memory, and diagnostics as required by the PRD.
 type Manifest struct {
-	ID          string        `json:"id"`
-	Name        string        `json:"name"`
-	Version     string        `json:"version"`
-	Runtime     RuntimeSpec   `json:"runtime"`
-	Network     NetworkSpec   `json:"network"`
-	Env         EnvSpec       `json:"env"`
-	Memory      MemorySpec    `json:"memory"`
-	Upgrade     UpgradeSpec   `json:"upgrade"`
-	Diagnostics Diagnostics   `json:"diagnostics"`
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	Version      string        `json:"version"`
+	Description  string        `json:"description,omitempty"`
+	Capabilities []string      `json:"capabilities,omitempty"`
+	Runtime      RuntimeSpec   `json:"runtime"`
+	Network      NetworkSpec   `json:"network"`
+	Env          EnvSpec       `json:"env"`
+	Memory       MemorySpec    `json:"memory"`
+	Upgrade      UpgradeSpec   `json:"upgrade"`
+	Health       HealthSpec    `json:"health"`
+	Diagnostics  Diagnostics   `json:"diagnostics"`
 }
 
 type RuntimeSpec struct {
@@ -56,13 +61,24 @@ type NetworkSpec struct {
 }
 
 type PortSpec struct {
-	Name string `json:"name"`
-	Port int    `json:"port"`
+	Name     string `json:"name"`
+	Port     int    `json:"port"`
+	Protocol string `json:"protocol,omitempty"`
 }
 
 type HealthcheckSpec struct {
 	Type string `json:"type"`
 	URL  string `json:"url"`
+}
+
+// HealthSpec defines the top-level health configuration for the agent,
+// covering probe intervals, timeouts, and restart-loop detection.
+type HealthSpec struct {
+	IntervalSeconds    int `json:"interval_seconds,omitempty"`
+	TimeoutSeconds     int `json:"timeout_seconds,omitempty"`
+	Retries            int `json:"retries,omitempty"`
+	RestartLoopWindow  int `json:"restart_loop_window,omitempty"`
+	RestartLoopMax     int `json:"restart_loop_max,omitempty"`
 }
 
 type EnvSpec struct {
@@ -71,9 +87,10 @@ type EnvSpec struct {
 }
 
 type EnvVar struct {
-	Name    string `json:"name"`
-	Secret  bool   `json:"secret,omitempty"`
-	Default string `json:"default,omitempty"`
+	Name        string `json:"name"`
+	Secret      bool   `json:"secret,omitempty"`
+	Default     string `json:"default,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type MemorySpec struct {
@@ -110,6 +127,15 @@ func (m Manifest) Validate() error {
 		return err
 	}
 	if err := validateUpgrade(m.Upgrade); err != nil {
+		return err
+	}
+	if err := validateNetwork(m.Network); err != nil {
+		return err
+	}
+	if err := validateHealth(m.Health); err != nil {
+		return err
+	}
+	if err := validateCapabilities(m.Capabilities); err != nil {
 		return err
 	}
 
@@ -211,5 +237,52 @@ func validateEnv(e EnvSpec) error {
 		seen[key.Name] = struct{}{}
 	}
 
+	return nil
+}
+
+func validateNetwork(n NetworkSpec) error {
+	seen := map[int]struct{}{}
+	for _, p := range n.Ports {
+		if p.Port < 0 || p.Port > 65535 {
+			return fmt.Errorf("network.ports: port %d out of range (0-65535)", p.Port)
+		}
+		if p.Name == "" {
+			return errors.New("network.ports: port name is required")
+		}
+		if _, ok := seen[p.Port]; ok {
+			return fmt.Errorf("network.ports: duplicate port %d", p.Port)
+		}
+		seen[p.Port] = struct{}{}
+	}
+	return nil
+}
+
+func validateHealth(h HealthSpec) error {
+	if h.IntervalSeconds < 0 {
+		return errors.New("health.interval_seconds must not be negative")
+	}
+	if h.TimeoutSeconds < 0 {
+		return errors.New("health.timeout_seconds must not be negative")
+	}
+	if h.Retries < 0 {
+		return errors.New("health.retries must not be negative")
+	}
+	if h.TimeoutSeconds > 0 && h.IntervalSeconds > 0 && h.TimeoutSeconds >= h.IntervalSeconds {
+		return errors.New("health.timeout_seconds must be less than health.interval_seconds")
+	}
+	return nil
+}
+
+func validateCapabilities(caps []string) error {
+	seen := map[string]struct{}{}
+	for _, c := range caps {
+		if strings.TrimSpace(c) == "" {
+			return errors.New("capability must not be empty")
+		}
+		if _, ok := seen[c]; ok {
+			return fmt.Errorf("duplicate capability: %q", c)
+		}
+		seen[c] = struct{}{}
+	}
 	return nil
 }

--- a/daemon/internal/manifest/types_test.go
+++ b/daemon/internal/manifest/types_test.go
@@ -6,27 +6,7 @@ import (
 )
 
 func TestValidateSuccess(t *testing.T) {
-	m := Manifest{
-		ID:      "openclaw",
-		Name:    "OpenClaw",
-		Version: "1.0.0",
-		Runtime: RuntimeSpec{
-			Type:    RuntimeTypeLocalBinary,
-			Install: CommandSpec{Command: "./install.sh"},
-			Upgrade: CommandSpec{Command: "./install.sh --upgrade"},
-			Start:   CommandSpec{Command: "./openclaw start"},
-			Stop:    CommandSpec{Command: "./openclaw stop"},
-		},
-		Memory: MemorySpec{
-			Supports:  []MemoryType{MemoryTypePerAgent, MemoryTypeShared, MemoryTypePublic},
-			MountPath: "./memory",
-		},
-		Env: EnvSpec{
-			Required: []EnvVar{{Name: "OPENAI_API_KEY", Secret: true}},
-			Optional: []EnvVar{{Name: "LOG_LEVEL", Default: "info"}},
-		},
-	}
-
+	m := validManifestForTest()
 	if err := m.Validate(); err != nil {
 		t.Fatalf("expected valid manifest, got error: %v", err)
 	}
@@ -39,45 +19,33 @@ func TestValidateRejectsMissingRequiredFields(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "missing id",
-			mutate: func(m *Manifest) {
-				m.ID = " "
-			},
+			name:    "missing id",
+			mutate:  func(m *Manifest) { m.ID = " " },
 			wantErr: "manifest.id is required",
 		},
 		{
-			name: "missing name",
-			mutate: func(m *Manifest) {
-				m.Name = ""
-			},
+			name:    "missing name",
+			mutate:  func(m *Manifest) { m.Name = "" },
 			wantErr: "manifest.name is required",
 		},
 		{
-			name: "missing version",
-			mutate: func(m *Manifest) {
-				m.Version = ""
-			},
+			name:    "missing version",
+			mutate:  func(m *Manifest) { m.Version = "" },
 			wantErr: "manifest.version is required",
 		},
 		{
-			name: "missing runtime type",
-			mutate: func(m *Manifest) {
-				m.Runtime.Type = ""
-			},
+			name:    "missing runtime type",
+			mutate:  func(m *Manifest) { m.Runtime.Type = "" },
 			wantErr: "runtime.type is required",
 		},
 		{
-			name: "missing runtime install command",
-			mutate: func(m *Manifest) {
-				m.Runtime.Install.Command = " "
-			},
+			name:    "missing runtime install command",
+			mutate:  func(m *Manifest) { m.Runtime.Install.Command = " " },
 			wantErr: "runtime.install.command is required",
 		},
 		{
-			name: "missing runtime start command",
-			mutate: func(m *Manifest) {
-				m.Runtime.Start.Command = ""
-			},
+			name:    "missing runtime start command",
+			mutate:  func(m *Manifest) { m.Runtime.Start.Command = "" },
 			wantErr: "runtime.start.command is required",
 		},
 	}
@@ -86,7 +54,6 @@ func TestValidateRejectsMissingRequiredFields(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := validManifestForTest()
 			tc.mutate(&m)
-
 			err := m.Validate()
 			if err == nil {
 				t.Fatalf("expected error %q, got nil", tc.wantErr)
@@ -101,7 +68,6 @@ func TestValidateRejectsMissingRequiredFields(t *testing.T) {
 func TestValidateRejectsInvalidRuntimeType(t *testing.T) {
 	m := validManifestForTest()
 	m.Runtime.Type = RuntimeType("docker")
-
 	err := m.Validate()
 	if err == nil {
 		t.Fatal("expected error for invalid runtime type")
@@ -113,11 +79,7 @@ func TestValidateRejectsInvalidRuntimeType(t *testing.T) {
 
 func TestValidateAcceptsValidUpgradeSpec(t *testing.T) {
 	m := validManifestForTest()
-	m.Upgrade = UpgradeSpec{
-		Channel:  "stable",
-		Strategy: UpgradeStrategyInPlaceOrReinstall,
-	}
-
+	m.Upgrade = UpgradeSpec{Channel: "stable", Strategy: UpgradeStrategyInPlaceOrReinstall}
 	if err := m.Validate(); err != nil {
 		t.Fatalf("expected valid upgrade manifest, got error: %v", err)
 	}
@@ -125,11 +87,7 @@ func TestValidateAcceptsValidUpgradeSpec(t *testing.T) {
 
 func TestValidateRejectsUnsupportedUpgradeStrategy(t *testing.T) {
 	m := validManifestForTest()
-	m.Upgrade = UpgradeSpec{
-		Channel:  "stable",
-		Strategy: "unsupported-strategy",
-	}
-
+	m.Upgrade = UpgradeSpec{Channel: "stable", Strategy: "unsupported-strategy"}
 	err := m.Validate()
 	if err == nil {
 		t.Fatal("expected error for unsupported upgrade strategy")
@@ -140,25 +98,121 @@ func TestValidateRejectsUnsupportedUpgradeStrategy(t *testing.T) {
 }
 
 func TestValidateRejectsDuplicateMemoryType(t *testing.T) {
-	m := Manifest{
-		ID:      "openclaw",
-		Name:    "OpenClaw",
-		Version: "1.0.0",
-		Runtime: RuntimeSpec{
-			Type:    RuntimeTypeGoCLI,
-			Install: CommandSpec{Command: "x"},
-			Upgrade: CommandSpec{Command: "x"},
-			Start:   CommandSpec{Command: "x"},
-			Stop:    CommandSpec{Command: "x"},
-		},
-		Memory: MemorySpec{
-			Supports:  []MemoryType{MemoryTypeShared, MemoryTypeShared},
-			MountPath: "./memory",
-		},
-	}
-
+	m := validManifestForTest()
+	m.Memory.Supports = []MemoryType{MemoryTypeShared, MemoryTypeShared}
 	if err := m.Validate(); err == nil {
 		t.Fatal("expected error for duplicate memory types")
+	}
+}
+
+func TestValidateNetworkPortRange(t *testing.T) {
+	m := validManifestForTest()
+	m.Network.Ports = []PortSpec{{Name: "bad", Port: -1}}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for port -1")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("expected 'out of range' in error, got %q", err.Error())
+	}
+}
+
+func TestValidateNetworkPortZeroIsValid(t *testing.T) {
+	m := validManifestForTest()
+	m.Network.Ports = []PortSpec{{Name: "dynamic", Port: 0}}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected port 0 (dynamic) to be valid, got: %v", err)
+	}
+}
+
+func TestValidateNetworkPortTooHigh(t *testing.T) {
+	m := validManifestForTest()
+	m.Network.Ports = []PortSpec{{Name: "bad", Port: 70000}}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for port 70000")
+	}
+}
+
+func TestValidateNetworkDuplicatePort(t *testing.T) {
+	m := validManifestForTest()
+	m.Network.Ports = []PortSpec{{Name: "a", Port: 8080}, {Name: "b", Port: 8080}}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for duplicate port")
+	}
+	if !strings.Contains(err.Error(), "duplicate port") {
+		t.Fatalf("expected 'duplicate port' in error, got %q", err.Error())
+	}
+}
+
+func TestValidateNetworkMissingPortName(t *testing.T) {
+	m := validManifestForTest()
+	m.Network.Ports = []PortSpec{{Name: "", Port: 8080}}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing port name")
+	}
+}
+
+func TestValidateHealthNegativeInterval(t *testing.T) {
+	m := validManifestForTest()
+	m.Health.IntervalSeconds = -1
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for negative interval")
+	}
+}
+
+func TestValidateHealthTimeoutExceedsInterval(t *testing.T) {
+	m := validManifestForTest()
+	m.Health.IntervalSeconds = 10
+	m.Health.TimeoutSeconds = 15
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error when timeout >= interval")
+	}
+}
+
+func TestValidateHealthValidConfig(t *testing.T) {
+	m := validManifestForTest()
+	m.Health = HealthSpec{IntervalSeconds: 30, TimeoutSeconds: 5, Retries: 3}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid health config, got: %v", err)
+	}
+}
+
+func TestValidateCapabilitiesDuplicate(t *testing.T) {
+	m := validManifestForTest()
+	m.Capabilities = []string{"chat", "chat"}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for duplicate capability")
+	}
+}
+
+func TestValidateCapabilitiesEmpty(t *testing.T) {
+	m := validManifestForTest()
+	m.Capabilities = []string{"chat", ""}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty capability")
+	}
+}
+
+func TestValidateCapabilitiesValid(t *testing.T) {
+	m := validManifestForTest()
+	m.Capabilities = []string{"chat", "code", "memory"}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid capabilities, got: %v", err)
+	}
+}
+
+func TestValidateDescriptionOptional(t *testing.T) {
+	m := validManifestForTest()
+	m.Description = "A test agent"
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid with description, got: %v", err)
 	}
 }
 
@@ -173,6 +227,10 @@ func validManifestForTest() Manifest {
 			Upgrade: CommandSpec{Command: "./install.sh --upgrade"},
 			Start:   CommandSpec{Command: "./openclaw start"},
 			Stop:    CommandSpec{Command: "./openclaw stop"},
+		},
+		Network: NetworkSpec{
+			Ports:       []PortSpec{{Name: "http", Port: 8080}},
+			Healthcheck: HealthcheckSpec{Type: "http", URL: "http://localhost:8080/health"},
 		},
 		Memory: MemorySpec{
 			Supports:  []MemoryType{MemoryTypePerAgent, MemoryTypeShared, MemoryTypePublic},


### PR DESCRIPTION
## Summary

Enhance manifest schema and catalog implementation to fully cover PRD requirements.

### Manifest changes
- Add `Description`, `Capabilities`, and `Health` fields
- Add `EnvVar.Description` and `PortSpec.Protocol` optional fields
- Network port validation: range (0-65535), no duplicates, name required
- Health probe validation: interval/timeout/retries, restart-loop window/max
- Capability validation: no duplicates, no empty strings

### Catalog changes
- Entries now include `Version`, `Capabilities`, `Description`
- New `List()` and `ListByStatus(status)` query functions
- New `Entry.IsRunnable()` and `Entry.HasCapability(cap)` methods
- OpenClaw is active with capabilities: chat, code, memory
- Candidates (Pi Mono, NanoClaw, Pico Claw) have version and capability metadata

### Other
- Updated `catalog/openclaw.manifest.json` with all new fields
- Comprehensive test coverage for all new validation and catalog logic

Closes #29