### PR TITLE
feat(runtimecheck): structured pre-flight checks (env vars, port conflicts, command validation)

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -292,20 +292,32 @@ func (s *Service) Start(agentID string) error {
 		return err
 	}
 
-	if err := s.checkRuntimePrerequisites(m); err != nil {
-		s.updateStateOnStartError(agentID, err)
-		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
-		return err
-	}
-	if err := s.validateRequiredEnv(m); err != nil {
-		s.updateStateOnStartError(agentID, err)
-		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_ENV_MISSING", err.Error())
-		return err
-	}
-	if err := s.ensurePortsAvailable(m.Network.Ports); err != nil {
-		s.updateStateOnStartError(agentID, err)
-		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_PORT_CONFLICT", err.Error())
-		return err
+	if pf, ok := s.checker.(runtimecheck.PreFlighter); ok {
+		pfResult := pf.PreFlight(m)
+		if !pfResult.Passed {
+			failMsg := formatPreFlightFailures(pfResult)
+			errCode := firstFailedCode(pfResult)
+			pfErr := fmt.Errorf("pre-flight checks failed: %s", failMsg)
+			s.updateStateOnStartError(agentID, pfErr)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, errCode, failMsg)
+			return pfErr
+		}
+	} else {
+		if err := s.checkRuntimePrerequisites(m); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
+			return err
+		}
+		if err := s.validateRequiredEnv(m); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_ENV_MISSING", err.Error())
+			return err
+		}
+		if err := s.ensurePortsAvailable(m.Network.Ports); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_PORT_CONFLICT", err.Error())
+			return err
+		}
 	}
 
 	result, runErr := s.runner.Run(context.Background(), m.Runtime.Start.Command)
@@ -705,6 +717,29 @@ func (s *Service) checkRuntimePrerequisites(m manifest.Manifest) error {
 		return fmt.Errorf("%w: %v", ErrRuntimePrerequisites, err)
 	}
 	return nil
+}
+
+func formatPreFlightFailures(result runtimecheck.PreFlightResult) string {
+	var parts []string
+	for _, c := range result.Checks {
+		if !c.Passed {
+			msg := c.Message
+			if c.Repair != "" {
+				msg += " (fix: " + c.Repair + ")"
+			}
+			parts = append(parts, msg)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func firstFailedCode(result runtimecheck.PreFlightResult) string {
+	for _, c := range result.Checks {
+		if !c.Passed && c.Code != "" {
+			return c.Code
+		}
+	}
+	return "E_PREFLIGHT_FAILED"
 }
 
 func (s *Service) formatUpgradeFailure(runErr error, backupPath string) error {

--- a/daemon/internal/runtimecheck/checker.go
+++ b/daemon/internal/runtimecheck/checker.go
@@ -24,6 +24,11 @@ type Checker interface {
 	Check(m manifest.Manifest) error
 }
 
+// PreFlighter runs structured pre-flight checks and returns a PreFlightResult.
+type PreFlighter interface {
+	PreFlight(m manifest.Manifest) PreFlightResult
+}
+
 const (
 	IssueCodeWSL2Missing    = "E_WSL2_MISSING"
 	IssueCodeNPMMissing     = "E_NPM_MISSING"
@@ -131,6 +136,11 @@ func (c HostChecker) hasTool(name string) bool {
 	}
 	_, err := c.Lookup.LookPath(name)
 	return err == nil
+}
+
+// PreFlight runs all pre-flight checks and returns a structured result.
+func (c HostChecker) PreFlight(m manifest.Manifest) PreFlightResult {
+	return RunPreFlight(m, c)
 }
 
 func (c HostChecker) detectWSL() bool {

--- a/daemon/internal/runtimecheck/preflight.go
+++ b/daemon/internal/runtimecheck/preflight.go
@@ -1,0 +1,208 @@
+package runtimecheck
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	"carrier/daemon/internal/manifest"
+)
+
+const (
+	CheckNameEnvVars          = "required_env_vars"
+	CheckNamePortConflict     = "port_conflict"
+	CheckNameCommandExists    = "command_exists"
+	CheckNameRuntimePrereqs   = "runtime_prerequisites"
+
+	IssueCodeEnvMissing       = "E_ENV_MISSING"
+	IssueCodePortConflict     = "E_PORT_CONFLICT"
+	IssueCodeCommandNotFound  = "E_COMMAND_NOT_FOUND"
+)
+
+// CheckResult represents a single pre-flight check outcome.
+type CheckResult struct {
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+	Repair  string `json:"repair,omitempty"`
+}
+
+// PreFlightResult aggregates all pre-flight check results.
+type PreFlightResult struct {
+	Passed bool          `json:"passed"`
+	Checks []CheckResult `json:"checks"`
+}
+
+// PreFlightOption configures the pre-flight runner.
+type PreFlightOption func(*preFlightRunner)
+
+type preFlightRunner struct {
+	checker    HostChecker
+	getenv     func(string) string
+	listenTCP  func(network, address string) (net.Listener, error)
+	lookPath   func(string) (string, error)
+}
+
+// WithGetenv overrides os.Getenv for testing.
+func WithGetenv(fn func(string) string) PreFlightOption {
+	return func(r *preFlightRunner) { r.getenv = fn }
+}
+
+// WithListenTCP overrides net.Listen for testing.
+func WithListenTCP(fn func(string, string) (net.Listener, error)) PreFlightOption {
+	return func(r *preFlightRunner) { r.listenTCP = fn }
+}
+
+// WithCommandLookPath overrides exec.LookPath for testing.
+func WithCommandLookPath(fn func(string) (string, error)) PreFlightOption {
+	return func(r *preFlightRunner) { r.lookPath = fn }
+}
+
+// RunPreFlight executes all pre-flight checks against the given manifest and
+// returns a structured PreFlightResult.
+func RunPreFlight(m manifest.Manifest, checker HostChecker, opts ...PreFlightOption) PreFlightResult {
+	r := &preFlightRunner{
+		checker:   checker,
+		getenv:    os.Getenv,
+		listenTCP: net.Listen,
+		lookPath:  exec.LookPath,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	var checks []CheckResult
+
+	// 1. Runtime prerequisites (existing checker logic)
+	checks = append(checks, r.checkRuntimePrereqs(m))
+
+	// 2. Required env vars
+	checks = append(checks, r.checkEnvVars(m)...)
+
+	// 3. Port conflicts
+	checks = append(checks, r.checkPorts(m)...)
+
+	// 4. Start command executable
+	checks = append(checks, r.checkCommandExists(m))
+
+	passed := true
+	for _, c := range checks {
+		if !c.Passed {
+			passed = false
+			break
+		}
+	}
+
+	return PreFlightResult{Passed: passed, Checks: checks}
+}
+
+func (r *preFlightRunner) checkRuntimePrereqs(m manifest.Manifest) CheckResult {
+	err := r.checker.Check(m)
+	if err != nil {
+		return CheckResult{
+			Name:    CheckNameRuntimePrereqs,
+			Passed:  false,
+			Message: err.Error(),
+			Code:    "E_RUNTIME_PREREQUISITES",
+		}
+	}
+	return CheckResult{Name: CheckNameRuntimePrereqs, Passed: true, Message: "all runtime prerequisites met"}
+}
+
+func (r *preFlightRunner) checkEnvVars(m manifest.Manifest) []CheckResult {
+	if len(m.Env.Required) == 0 {
+		return []CheckResult{{Name: CheckNameEnvVars, Passed: true, Message: "no required env vars"}}
+	}
+
+	var missing []string
+	for _, ev := range m.Env.Required {
+		if strings.TrimSpace(r.getenv(ev.Name)) == "" {
+			missing = append(missing, ev.Name)
+		}
+	}
+
+	if len(missing) == 0 {
+		return []CheckResult{{Name: CheckNameEnvVars, Passed: true, Message: "all required env vars set"}}
+	}
+
+	results := make([]CheckResult, 0, len(missing))
+	for _, name := range missing {
+		results = append(results, CheckResult{
+			Name:    CheckNameEnvVars,
+			Passed:  false,
+			Code:    IssueCodeEnvMissing,
+			Message: fmt.Sprintf("required environment variable %s is not set", name),
+			Repair:  fmt.Sprintf("export %s=<value>", name),
+		})
+	}
+	return results
+}
+
+func (r *preFlightRunner) checkPorts(m manifest.Manifest) []CheckResult {
+	if len(m.Network.Ports) == 0 {
+		return []CheckResult{{Name: CheckNamePortConflict, Passed: true, Message: "no ports declared"}}
+	}
+
+	var results []CheckResult
+	for _, ps := range m.Network.Ports {
+		if ps.Port <= 0 {
+			continue
+		}
+		addr := fmt.Sprintf("127.0.0.1:%d", ps.Port)
+		ln, err := r.listenTCP("tcp", addr)
+		if err != nil {
+			results = append(results, CheckResult{
+				Name:    CheckNamePortConflict,
+				Passed:  false,
+				Code:    IssueCodePortConflict,
+				Message: fmt.Sprintf("port %d (%s) is already in use", ps.Port, ps.Name),
+				Repair:  fmt.Sprintf("free port %d: lsof -ti:%d | xargs kill -9", ps.Port, ps.Port),
+			})
+		} else {
+			_ = ln.Close()
+			results = append(results, CheckResult{
+				Name:    CheckNamePortConflict,
+				Passed:  true,
+				Message: fmt.Sprintf("port %d (%s) is available", ps.Port, ps.Name),
+			})
+		}
+	}
+	if len(results) == 0 {
+		return []CheckResult{{Name: CheckNamePortConflict, Passed: true, Message: "no ports declared"}}
+	}
+	return results
+}
+
+func (r *preFlightRunner) checkCommandExists(m manifest.Manifest) CheckResult {
+	cmd := strings.TrimSpace(m.Runtime.Start.Command)
+	if cmd == "" {
+		return CheckResult{
+			Name:    CheckNameCommandExists,
+			Passed:  false,
+			Code:    IssueCodeCommandNotFound,
+			Message: "runtime.start.command is empty",
+		}
+	}
+
+	// Extract the first token (executable name)
+	executable := strings.Fields(cmd)[0]
+
+	_, err := r.lookPath(executable)
+	if err != nil {
+		return CheckResult{
+			Name:    CheckNameCommandExists,
+			Passed:  false,
+			Code:    IssueCodeCommandNotFound,
+			Message: fmt.Sprintf("executable %q not found in PATH", executable),
+			Repair:  fmt.Sprintf("install %q or add its directory to PATH", executable),
+		}
+	}
+	return CheckResult{
+		Name:    CheckNameCommandExists,
+		Passed:  true,
+		Message: fmt.Sprintf("executable %q found", executable),
+	}
+}

--- a/daemon/internal/runtimecheck/preflight_test.go
+++ b/daemon/internal/runtimecheck/preflight_test.go
@@ -1,0 +1,195 @@
+package runtimecheck
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"carrier/daemon/internal/manifest"
+)
+
+func newPassingChecker() HostChecker {
+	return HostChecker{
+		GOOS: "linux",
+		Lookup: LookupFunc(func(string) (string, error) {
+			return "/usr/bin/x", nil
+		}),
+		ReadFile: func(string) ([]byte, error) {
+			return []byte("Linux version x.y.z-generic"), nil
+		},
+	}
+}
+
+func baseManifest() manifest.Manifest {
+	return manifest.Manifest{
+		Runtime: manifest.RuntimeSpec{
+			Type:  manifest.RuntimeTypeLocalBinary,
+			Start: manifest.CommandSpec{Command: "myagent serve"},
+		},
+		Env: manifest.EnvSpec{
+			Required: []manifest.EnvVar{{Name: "API_KEY"}},
+		},
+		Network: manifest.NetworkSpec{
+			Ports: []manifest.PortSpec{{Name: "http", Port: 18080}},
+		},
+	}
+}
+
+func TestRunPreFlight_AllPass(t *testing.T) {
+	m := baseManifest()
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(name string) string {
+			if name == "API_KEY" {
+				return "secret"
+			}
+			return ""
+		}),
+		WithListenTCP(func(_, _ string) (net.Listener, error) {
+			return &fakeListener{}, nil
+		}),
+		WithCommandLookPath(func(name string) (string, error) {
+			return "/usr/bin/" + name, nil
+		}),
+	)
+
+	if !result.Passed {
+		t.Fatalf("expected all checks to pass, got failures: %+v", result.Checks)
+	}
+}
+
+func TestRunPreFlight_MissingEnvVar(t *testing.T) {
+	m := baseManifest()
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(string) string { return "" }),
+		WithListenTCP(func(_, _ string) (net.Listener, error) { return &fakeListener{}, nil }),
+		WithCommandLookPath(func(string) (string, error) { return "/usr/bin/x", nil }),
+	)
+
+	if result.Passed {
+		t.Fatal("expected failure due to missing env var")
+	}
+	found := false
+	for _, c := range result.Checks {
+		if c.Code == IssueCodeEnvMissing {
+			found = true
+			if c.Repair == "" {
+				t.Error("expected repair hint for missing env var")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected E_ENV_MISSING check result")
+	}
+}
+
+func TestRunPreFlight_PortConflict(t *testing.T) {
+	m := baseManifest()
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(string) string { return "val" }),
+		WithListenTCP(func(_, _ string) (net.Listener, error) {
+			return nil, errors.New("address already in use")
+		}),
+		WithCommandLookPath(func(string) (string, error) { return "/usr/bin/x", nil }),
+	)
+
+	if result.Passed {
+		t.Fatal("expected failure due to port conflict")
+	}
+	found := false
+	for _, c := range result.Checks {
+		if c.Code == IssueCodePortConflict {
+			found = true
+			if c.Repair == "" {
+				t.Error("expected repair hint for port conflict")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected E_PORT_CONFLICT check result")
+	}
+}
+
+func TestRunPreFlight_CommandNotFound(t *testing.T) {
+	m := baseManifest()
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(string) string { return "val" }),
+		WithListenTCP(func(_, _ string) (net.Listener, error) { return &fakeListener{}, nil }),
+		WithCommandLookPath(func(string) (string, error) {
+			return "", errors.New("not found")
+		}),
+	)
+
+	if result.Passed {
+		t.Fatal("expected failure due to missing command")
+	}
+	found := false
+	for _, c := range result.Checks {
+		if c.Code == IssueCodeCommandNotFound {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected E_COMMAND_NOT_FOUND check result")
+	}
+}
+
+func TestRunPreFlight_NoRequiredEnvVars(t *testing.T) {
+	m := baseManifest()
+	m.Env.Required = nil
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(string) string { return "" }),
+		WithListenTCP(func(_, _ string) (net.Listener, error) { return &fakeListener{}, nil }),
+		WithCommandLookPath(func(string) (string, error) { return "/usr/bin/x", nil }),
+	)
+
+	if !result.Passed {
+		t.Fatalf("expected pass with no required env vars, got: %+v", result.Checks)
+	}
+}
+
+func TestRunPreFlight_NoPorts(t *testing.T) {
+	m := baseManifest()
+	m.Network.Ports = nil
+	checker := newPassingChecker()
+
+	result := RunPreFlight(m, checker,
+		WithGetenv(func(string) string { return "val" }),
+		WithListenTCP(func(_, _ string) (net.Listener, error) { return &fakeListener{}, nil }),
+		WithCommandLookPath(func(string) (string, error) { return "/usr/bin/x", nil }),
+	)
+
+	if !result.Passed {
+		t.Fatalf("expected pass with no ports, got: %+v", result.Checks)
+	}
+}
+
+func TestHostChecker_PreFlight(t *testing.T) {
+	checker := newPassingChecker()
+	m := manifest.Manifest{
+		Runtime: manifest.RuntimeSpec{
+			Type:  manifest.RuntimeTypeLocalBinary,
+			Start: manifest.CommandSpec{Command: "ls"},
+		},
+	}
+	result := checker.PreFlight(m)
+	if !result.Passed {
+		t.Fatalf("expected pass, got: %+v", result.Checks)
+	}
+}
+
+// fakeListener implements net.Listener for testing.
+type fakeListener struct{}
+
+func (f *fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }
+func (f *fakeListener) Close() error               { return nil }
+func (f *fakeListener) Addr() net.Addr              { return &net.TCPAddr{} }


### PR DESCRIPTION
## Summary

Implements structured runtime pre-flight checks per issue #31 (W2.2).

### Changes

- **`runtimecheck/preflight.go`**: New `RunPreFlight()` function that runs all checks and returns a structured `PreFlightResult`:
  - `CheckNameRuntimePrereqs`: existing runtime type checks (npm/go/WSL2)
  - `CheckNameEnvVars`: validates all `manifest.env.required` vars are set
  - `CheckNamePortConflict`: verifies declared ports are available via `net.Listen`
  - `CheckNameCommandExists`: verifies `runtime.start.command` executable is in PATH
  - Each failed check includes a `Repair` hint (e.g., `export VAR=<value>`, `lsof -ti:PORT | xargs kill -9`)

- **`runtimecheck/checker.go`**: Added `PreFlighter` interface and `HostChecker.PreFlight()` method

- **`lifecycle/service.go`**: `Start()` now uses `PreFlight()` when the checker implements `PreFlighter`, with fallback to legacy per-check validation for backward compatibility

- **Tests**: 7 new test cases covering all pre-flight scenarios

### Addresses
- FR-D-010: Pre-flight checks for macOS/Linux/WSL2
- FR-D-011: Port conflict detection with repair recommendations  
- FR-D-012: Manifest required env var validation before start

Closes #31