### PR TITLE
docs(e2e): add CONTRIBUTING hint when carrier CLI is missing

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -14,10 +14,12 @@ if ! command -v carrier >/dev/null 2>&1; then
   if [[ "${CI:-}" == "true" ]]; then
     echo "CI mode: failing fast to avoid silently skipping end-to-end validation."
     echo "Install/configure carrier CLI in CI before running this workflow."
+    echo "Hint: see CONTRIBUTING.md for carrier CLI setup guidance."
     exit 1
   fi
 
   echo "Install/configure the carrier CLI before running e2e checks locally."
+  echo "Hint: see CONTRIBUTING.md for carrier CLI setup guidance."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING.md setup hint when `carrier` CLI is missing in CI mode
- add the same hint for local runs

## Why
Issue #173 requested a newcomer-friendly pointer after fail-fast `exit 1` messages.

## Commit highlights
- scripts/run-e2e-tests.sh: add `Hint: see CONTRIBUTING.md for carrier CLI setup guidance.` before both exit paths.

Closes #173
