### PR TITLE
docs(ci): document octokit fallback token behavior

### DIFF
--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -34,6 +34,7 @@ jobs:
             const eventName = context.eventName;
             const payload = context.payload;
             const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
+            // Fallback `github` comes from @actions/github and uses the default GITHUB_TOKEN context.
             const octokit = token ? github.getOctokit(token) : github;
 
             const getStatusCandidates = (item, labels) => {

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -37,6 +37,7 @@ jobs:
             const repo = context.repo.repo;
             const dryRunInput = String((context.payload.inputs?.dry_run || process.env.DRY_RUN || 'false')).toLowerCase() === 'true';
             const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
+            // Fallback `github` comes from @actions/github and uses the default GITHUB_TOKEN context.
             const octokit = token ? github.getOctokit(token) : github;
 
             const repoMeta = await octokit.graphql(`

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -487,7 +487,7 @@ func (s *Service) Logs(agentID string, tail int) ([]string, error) {
 }
 
 // AuditStatus returns the current audit buffer size and configured limit.
-// This is intended for operational inspection / debug endpoints.
+// This is primarily queried by operational inspection/debug endpoints.
 type AuditStatus struct {
 	BufferSize int `json:"buffer_size"`
 	Limit      int `json:"limit"`


### PR DESCRIPTION
## Summary
- add explicit note in both kanban workflows that the `github` fallback comes from `@actions/github` and uses default `GITHUB_TOKEN` context
- clarify `AuditStatus` usage note to state it is primarily queried by operational/debug endpoints

## Testing
- `cd daemon && go test ./...`

Closes #187
Closes #188
