### PR TITLE
test: combine redundant expect calls for unknown command error

### DIFF
--- a/gateway/src/index.test.ts
+++ b/gateway/src/index.test.ts
@@ -42,8 +42,9 @@ describe("gateway parseInput", () => {
   });
 
   test("returns parse error for unknown command", () => {
-    expect(() => parseInput("telegram 100 req-1 /foobar")).toThrow("unknown command: /foobar");
-    expect(() => parseInput("telegram 100 req-1 /foobar")).toThrow("requestId=req-1");
+    expect(() => parseInput("telegram 100 req-1 /foobar")).toThrow(
+      /unknown command:.*requestId=req-1/,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #145

Merge two separate `toThrow` assertions into a single regex pattern that checks both the error message and requestId in one call, avoiding a redundant function invocation.