### PR TITLE
ci: remove redundant explicit test already covered by go test ./...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
         working-directory: daemon
         run: go test ./...
 
-      - name: Validate catalog manifest parseability
-        working-directory: daemon
-        run: go test ./internal/manifest -run TestLoadFileAcceptsCatalogManifest -count=1
-
   gateway-check:
     name: Gateway Type Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #132
Closes #135

The `TestLoadFileAcceptsCatalogManifest` test is already included in `go test ./...` which runs all daemon tests. The separate `-run` invocation adds ~1s but no extra coverage.