### PR TITLE
chore(e2e): collapse duplicated missing-carrier exit path

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -14,11 +14,10 @@ if ! command -v carrier >/dev/null 2>&1; then
   if [[ "${CI:-}" == "true" ]]; then
     echo "CI mode: failing fast to avoid silently skipping end-to-end validation."
     echo "Install/configure carrier CLI in CI before running this workflow."
-    echo "Hint: see CONTRIBUTING.md for carrier CLI setup guidance."
-    exit 1
+  else
+    echo "Install/configure the carrier CLI before running e2e checks locally."
   fi
 
-  echo "Install/configure the carrier CLI before running e2e checks locally."
   echo "Hint: see CONTRIBUTING.md for carrier CLI setup guidance."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- collapse duplicated `exit 1` handling when `carrier` CLI is missing
- keep CI vs local guidance text, but use one common exit path
- preserves current behavior while simplifying script flow

Closes #192