### PR TITLE
feat(daemon): configuration file support (JSON)

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"carrier/daemon/internal/baseagent"
 	"carrier/daemon/internal/catalog"
+	"carrier/daemon/internal/config"
 	"carrier/daemon/internal/lifecycle"
 	"carrier/daemon/internal/logging"
 )
@@ -21,14 +22,32 @@ func main() {
 	logger := logging.Init()
 	logger.Info("initializing agentd")
 
-	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	cfg, err := config.Load("config.json")
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	var opts []lifecycle.Option
+
+	window, err := cfg.CrashWindowDuration()
+	if err != nil {
+		log.Fatalf("invalid crash window %q: %v", cfg.Lifecycle.CrashWindow, err)
+	}
+	cooldown, err := cfg.CrashCooldownDuration()
+	if err != nil {
+		log.Fatalf("invalid crash cooldown %q: %v", cfg.Lifecycle.CrashCooldown, err)
+	}
+	opts = append(opts, lifecycle.WithCrashLoopConfig(cfg.Lifecycle.CrashThreshold, window, cooldown))
+
+	svc := lifecycle.NewService(baseagent.NoopTriager{}, opts...)
 
 	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
 		log.Fatalf("register openclaw manifest: %v", err)
 	}
 
 	logger.Info("agentd scaffold booted")
-	fmt.Println("agentd scaffold booted")
+	fmt.Printf("agentd scaffold booted (listen=%s:%d log=%s/%s)\n",
+		cfg.Server.Host, cfg.Server.Port, cfg.Log.Level, cfg.Log.Format)
 	fmt.Println("catalog:")
 	for _, entry := range catalog.DefaultEntries() {
 		fmt.Printf("- %s (%s): %s\n", entry.Name, entry.ID, entry.Status)

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -1,0 +1,127 @@
+// Package config provides configuration file support for the carrier daemon.
+//
+// Configuration is loaded from a JSON file (config.json) and can be overridden
+// by environment variables with the CARRIER_ prefix.
+//
+// Supported environment variables:
+//   - CARRIER_SERVER_HOST       — server listen host (default "127.0.0.1")
+//   - CARRIER_SERVER_PORT       — server listen port (default 9090)
+//   - CARRIER_LOG_LEVEL         — logging level: debug, info, warn, error (default "info")
+//   - CARRIER_LOG_FORMAT        — logging format: text, json (default "text")
+//   - CARRIER_CRASH_THRESHOLD   — crash-loop restart threshold (default 3)
+//   - CARRIER_CRASH_WINDOW      — crash-loop window e.g. "5m" (default "5m")
+//   - CARRIER_CRASH_COOLDOWN    — crash-loop cooldown e.g. "5m" (default "5m")
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config holds the daemon configuration.
+type Config struct {
+	Server    ServerConfig    `json:"server"`
+	Log       LogConfig       `json:"log"`
+	Lifecycle LifecycleConfig `json:"lifecycle"`
+}
+
+// ServerConfig holds the network server settings.
+type ServerConfig struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// LogConfig holds the logging settings.
+type LogConfig struct {
+	Level  string `json:"level"`
+	Format string `json:"format"`
+}
+
+// LifecycleConfig holds crash-loop detection settings.
+type LifecycleConfig struct {
+	CrashThreshold int    `json:"crash_threshold"`
+	CrashWindow    string `json:"crash_window"`
+	CrashCooldown  string `json:"crash_cooldown"`
+}
+
+// Default returns a Config with sensible defaults.
+func Default() Config {
+	return Config{
+		Server: ServerConfig{
+			Host: "127.0.0.1",
+			Port: 9090,
+		},
+		Log: LogConfig{
+			Level:  "info",
+			Format: "text",
+		},
+		Lifecycle: LifecycleConfig{
+			CrashThreshold: 3,
+			CrashWindow:    "5m",
+			CrashCooldown:  "5m",
+		},
+	}
+}
+
+// Load reads configuration from the given JSON file path. If the file does
+// not exist, defaults are returned. Environment variables with the CARRIER_
+// prefix override file values.
+func Load(path string) (Config, error) {
+	cfg := Default()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return cfg, fmt.Errorf("config: read %s: %w", path, err)
+		}
+		// File not found — use defaults, still apply env overrides.
+	} else {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return cfg, fmt.Errorf("config: parse %s: %w", path, err)
+		}
+	}
+
+	applyEnvOverrides(&cfg)
+	return cfg, nil
+}
+
+// CrashWindowDuration parses the CrashWindow string as a time.Duration.
+func (c *Config) CrashWindowDuration() (time.Duration, error) {
+	return time.ParseDuration(c.Lifecycle.CrashWindow)
+}
+
+// CrashCooldownDuration parses the CrashCooldown string as a time.Duration.
+func (c *Config) CrashCooldownDuration() (time.Duration, error) {
+	return time.ParseDuration(c.Lifecycle.CrashCooldown)
+}
+
+func applyEnvOverrides(cfg *Config) {
+	if v := os.Getenv("CARRIER_SERVER_HOST"); v != "" {
+		cfg.Server.Host = v
+	}
+	if v := os.Getenv("CARRIER_SERVER_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 {
+			cfg.Server.Port = p
+		}
+	}
+	if v := os.Getenv("CARRIER_LOG_LEVEL"); v != "" {
+		cfg.Log.Level = v
+	}
+	if v := os.Getenv("CARRIER_LOG_FORMAT"); v != "" {
+		cfg.Log.Format = v
+	}
+	if v := os.Getenv("CARRIER_CRASH_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Lifecycle.CrashThreshold = n
+		}
+	}
+	if v := os.Getenv("CARRIER_CRASH_WINDOW"); v != "" {
+		cfg.Lifecycle.CrashWindow = v
+	}
+	if v := os.Getenv("CARRIER_CRASH_COOLDOWN"); v != "" {
+		cfg.Lifecycle.CrashCooldown = v
+	}
+}

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultValues(t *testing.T) {
+	cfg := Default()
+	if cfg.Server.Host != "127.0.0.1" {
+		t.Errorf("expected host 127.0.0.1, got %s", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", cfg.Server.Port)
+	}
+	if cfg.Log.Level != "info" {
+		t.Errorf("expected log level info, got %s", cfg.Log.Level)
+	}
+	if cfg.Lifecycle.CrashThreshold != 3 {
+		t.Errorf("expected crash threshold 3, got %d", cfg.Lifecycle.CrashThreshold)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	cfg, err := Load("/tmp/nonexistent-carrier-config.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Port != 9090 {
+		t.Errorf("expected default port, got %d", cfg.Server.Port)
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data := `{"server":{"host":"0.0.0.0","port":8080},"log":{"level":"debug"}}`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("expected host 0.0.0.0, got %s", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", cfg.Server.Port)
+	}
+	if cfg.Log.Level != "debug" {
+		t.Errorf("expected log level debug, got %s", cfg.Log.Level)
+	}
+}
+
+func TestLoadInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{bad`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestEnvOverrides(t *testing.T) {
+	t.Setenv("CARRIER_SERVER_HOST", "10.0.0.1")
+	t.Setenv("CARRIER_SERVER_PORT", "3000")
+	t.Setenv("CARRIER_LOG_LEVEL", "error")
+	t.Setenv("CARRIER_LOG_FORMAT", "json")
+	t.Setenv("CARRIER_CRASH_THRESHOLD", "5")
+	t.Setenv("CARRIER_CRASH_WINDOW", "10m")
+	t.Setenv("CARRIER_CRASH_COOLDOWN", "15m")
+
+	cfg, err := Load("/tmp/nonexistent-carrier-config.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Host != "10.0.0.1" {
+		t.Errorf("expected host 10.0.0.1, got %s", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 3000 {
+		t.Errorf("expected port 3000, got %d", cfg.Server.Port)
+	}
+	if cfg.Log.Level != "error" {
+		t.Errorf("expected log level error, got %s", cfg.Log.Level)
+	}
+	if cfg.Log.Format != "json" {
+		t.Errorf("expected log format json, got %s", cfg.Log.Format)
+	}
+	if cfg.Lifecycle.CrashThreshold != 5 {
+		t.Errorf("expected crash threshold 5, got %d", cfg.Lifecycle.CrashThreshold)
+	}
+	if cfg.Lifecycle.CrashWindow != "10m" {
+		t.Errorf("expected crash window 10m, got %s", cfg.Lifecycle.CrashWindow)
+	}
+}
+
+func TestCrashDurations(t *testing.T) {
+	cfg := Default()
+	w, err := cfg.CrashWindowDuration()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Minutes() != 5 {
+		t.Errorf("expected 5m, got %v", w)
+	}
+	c, err := cfg.CrashCooldownDuration()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Minutes() != 5 {
+		t.Errorf("expected 5m, got %v", c)
+	}
+}


### PR DESCRIPTION
Closes #203

- Add `daemon/internal/config` package with `Load()` from `config.json`
- Support `CARRIER_*` environment variable overrides (host, port, log level/format, crash-loop thresholds)
- Load config at startup in `cmd/agentd/main.go`
- Add tests