### PR TITLE
feat(gateway): rate limiting and request throttling

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -10,6 +10,7 @@ import {
   type RequestContext,
 } from "./daemon/client";
 import { DownloadTokenStore } from "./downloads/token_store";
+import { RateLimiter } from "./ratelimit";
 import { SessionStore } from "./session/store";
 
 const COMMAND_NAMES: ReadonlySet<CommandName> = new Set([
@@ -29,6 +30,7 @@ export type GatewayDependencies = {
   daemon: DaemonClient;
   sessions: SessionStore;
   downloads: DownloadTokenStore;
+  rateLimiter?: RateLimiter;
 };
 
 export class ParseError extends Error {
@@ -95,6 +97,14 @@ export async function handleCommand(
     );
   }
   deps.sessions.touch(cmd.provider, cmd.chatId);
+
+  if (deps.rateLimiter) {
+    const sessionKey = `${cmd.provider}:${cmd.chatId}`;
+    const rl = deps.rateLimiter.check(sessionKey);
+    if (!rl.allowed) {
+      return errorResponse(cmd.requestId, rl.errorCode ?? "E_RATE_LIMITED", rl.message ?? "rate limit exceeded");
+    }
+  }
 
   const ctx = requestContext(cmd);
   try {

--- a/gateway/src/ratelimit/index.test.ts
+++ b/gateway/src/ratelimit/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { RateLimiter } from "./index";
+
+describe("RateLimiter", () => {
+  it("allows requests under the limit", () => {
+    const limiter = new RateLimiter({ perSession: 3, global: 10, windowMs: 1000 });
+    const r1 = limiter.check("s1", 1000);
+    const r2 = limiter.check("s1", 1001);
+    const r3 = limiter.check("s1", 1002);
+    expect(r1.allowed).toBe(true);
+    expect(r2.allowed).toBe(true);
+    expect(r3.allowed).toBe(true);
+  });
+
+  it("blocks when per-session limit is exceeded", () => {
+    const limiter = new RateLimiter({ perSession: 2, global: 100, windowMs: 1000 });
+    limiter.check("s1", 1000);
+    limiter.check("s1", 1001);
+    const r = limiter.check("s1", 1002);
+    expect(r.allowed).toBe(false);
+    expect(r.errorCode).toBe("E_RATE_LIMITED");
+    expect(r.message).toContain("per-session");
+  });
+
+  it("blocks when global limit is exceeded", () => {
+    const limiter = new RateLimiter({ perSession: 100, global: 3, windowMs: 1000 });
+    limiter.check("s1", 1000);
+    limiter.check("s2", 1001);
+    limiter.check("s3", 1002);
+    const r = limiter.check("s4", 1003);
+    expect(r.allowed).toBe(false);
+    expect(r.errorCode).toBe("E_RATE_LIMITED");
+    expect(r.message).toContain("global");
+  });
+
+  it("allows requests after window expires", () => {
+    const limiter = new RateLimiter({ perSession: 2, global: 100, windowMs: 1000 });
+    limiter.check("s1", 1000);
+    limiter.check("s1", 1001);
+    // Blocked within window
+    expect(limiter.check("s1", 1002).allowed).toBe(false);
+    // Allowed after window passes
+    expect(limiter.check("s1", 2001).allowed).toBe(true);
+  });
+
+  it("isolates sessions from each other", () => {
+    const limiter = new RateLimiter({ perSession: 1, global: 100, windowMs: 1000 });
+    limiter.check("s1", 1000);
+    expect(limiter.check("s1", 1001).allowed).toBe(false);
+    expect(limiter.check("s2", 1001).allowed).toBe(true);
+  });
+
+  it("clearSession removes session tracking", () => {
+    const limiter = new RateLimiter({ perSession: 1, global: 100, windowMs: 60000 });
+    limiter.check("s1", 1000);
+    expect(limiter.check("s1", 1001).allowed).toBe(false);
+    limiter.clearSession("s1");
+    expect(limiter.check("s1", 1002).allowed).toBe(true);
+  });
+
+  it("reset clears all state", () => {
+    const limiter = new RateLimiter({ perSession: 1, global: 1, windowMs: 60000 });
+    limiter.check("s1", 1000);
+    expect(limiter.check("s2", 1001).allowed).toBe(false);
+    limiter.reset();
+    expect(limiter.check("s2", 1002).allowed).toBe(true);
+  });
+
+  it("returns config via getConfig", () => {
+    const limiter = new RateLimiter({ perSession: 5, global: 50, windowMs: 2000 });
+    const cfg = limiter.getConfig();
+    expect(cfg.perSession).toBe(5);
+    expect(cfg.global).toBe(50);
+    expect(cfg.windowMs).toBe(2000);
+  });
+});

--- a/gateway/src/ratelimit/index.ts
+++ b/gateway/src/ratelimit/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Rate limiting module using a sliding window algorithm.
+ *
+ * Supports per-session and global rate limiting.
+ * Configure via environment variables:
+ *   - CARRIER_RATE_LIMIT_PER_SESSION (default: 30 requests per window)
+ *   - CARRIER_RATE_LIMIT_GLOBAL      (default: 200 requests per window)
+ *   - CARRIER_RATE_LIMIT_WINDOW_MS   (default: 60000 = 1 minute)
+ */
+
+export interface RateLimitConfig {
+  /** Max requests per session within the window */
+  perSession: number;
+  /** Max global requests within the window */
+  global: number;
+  /** Sliding window duration in ms */
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  errorCode?: string;
+  message?: string;
+}
+
+export class RateLimiter {
+  private readonly config: RateLimitConfig;
+  private readonly sessionWindows: Map<string, number[]> = new Map();
+  private globalWindow: number[] = [];
+
+  constructor(config?: Partial<RateLimitConfig>) {
+    this.config = {
+      perSession: config?.perSession ?? envInt("CARRIER_RATE_LIMIT_PER_SESSION", 30),
+      global: config?.global ?? envInt("CARRIER_RATE_LIMIT_GLOBAL", 200),
+      windowMs: config?.windowMs ?? envInt("CARRIER_RATE_LIMIT_WINDOW_MS", 60_000),
+    };
+  }
+
+  /**
+   * Check whether a request from the given session is allowed.
+   * If allowed, the request is recorded. If not, returns an error.
+   */
+  check(sessionKey: string, now: number = Date.now()): RateLimitResult {
+    const cutoff = now - this.config.windowMs;
+
+    // Prune and check global
+    this.globalWindow = this.globalWindow.filter((t) => t > cutoff);
+    if (this.globalWindow.length >= this.config.global) {
+      return {
+        allowed: false,
+        errorCode: "E_RATE_LIMITED",
+        message: `global rate limit exceeded (${this.config.global} req/${this.config.windowMs}ms)`,
+      };
+    }
+
+    // Prune and check per-session
+    let timestamps = this.sessionWindows.get(sessionKey) ?? [];
+    timestamps = timestamps.filter((t) => t > cutoff);
+    if (timestamps.length >= this.config.perSession) {
+      this.sessionWindows.set(sessionKey, timestamps);
+      return {
+        allowed: false,
+        errorCode: "E_RATE_LIMITED",
+        message: `per-session rate limit exceeded (${this.config.perSession} req/${this.config.windowMs}ms)`,
+      };
+    }
+
+    // Record
+    timestamps.push(now);
+    this.sessionWindows.set(sessionKey, timestamps);
+    this.globalWindow.push(now);
+
+    return { allowed: true };
+  }
+
+  /** Remove all tracked state for a session. */
+  clearSession(sessionKey: string): void {
+    this.sessionWindows.delete(sessionKey);
+  }
+
+  /** Reset all state. */
+  reset(): void {
+    this.sessionWindows.clear();
+    this.globalWindow = [];
+  }
+
+  /** Return current config (for inspection/testing). */
+  getConfig(): Readonly<RateLimitConfig> {
+    return { ...this.config };
+  }
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = typeof process !== "undefined" ? process.env?.[name] : undefined;
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}


### PR DESCRIPTION
Closes #204

- Add `gateway/src/ratelimit/` with sliding window algorithm
- Per-session and global rate limits, configurable via `CARRIER_RATE_LIMIT_PER_SESSION`, `CARRIER_RATE_LIMIT_GLOBAL`
- Returns `E_RATE_LIMITED` error code when exceeded
- Integrated into `handleCommand` pipeline
- 8 tests