### PR TITLE
feat(daemon): health check endpoint for monitoring

### DIFF
--- a/daemon/internal/health/health.go
+++ b/daemon/internal/health/health.go
@@ -1,0 +1,82 @@
+// Package health provides HTTP health check endpoints for the carrier daemon.
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Version can be set at build time via -ldflags.
+var Version = "dev"
+
+// AgentCounter returns the number of currently running agents.
+type AgentCounter interface {
+	RunningAgentsCount() int
+}
+
+// Server exposes /healthz and /readyz endpoints.
+type Server struct {
+	startTime time.Time
+	ready     atomic.Bool
+	agents    AgentCounter
+}
+
+// NewServer creates a new health check server.
+func NewServer(agents AgentCounter) *Server {
+	return &Server{
+		startTime: time.Now(),
+		agents:    agents,
+	}
+}
+
+// SetReady marks the daemon as fully initialized.
+func (s *Server) SetReady(v bool) {
+	s.ready.Store(v)
+}
+
+// Handler returns an http.ServeMux with /healthz and /readyz registered.
+func (s *Server) Handler() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/readyz", s.handleReadyz)
+	return mux
+}
+
+type healthzResponse struct {
+	Status        string `json:"status"`
+	Uptime        string `json:"uptime"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	RunningAgents int    `json:"running_agents"`
+	Version       string `json:"version"`
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	uptime := time.Since(s.startTime)
+	count := 0
+	if s.agents != nil {
+		count = s.agents.RunningAgentsCount()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(healthzResponse{
+		Status:        "ok",
+		Uptime:        uptime.Round(time.Second).String(),
+		UptimeSeconds: int64(uptime.Seconds()),
+		RunningAgents: count,
+		Version:       Version,
+	})
+}
+
+func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if !s.ready.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "not_ready"})
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+}

--- a/daemon/internal/health/health_test.go
+++ b/daemon/internal/health/health_test.go
@@ -1,0 +1,84 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type mockCounter struct{ count int }
+
+func (m mockCounter) RunningAgentsCount() int { return m.count }
+
+func TestHealthzReturns200(t *testing.T) {
+	s := NewServer(mockCounter{count: 3})
+	s.SetReady(true)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body healthzResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("expected status ok, got %s", body.Status)
+	}
+	if body.RunningAgents != 3 {
+		t.Errorf("expected 3 running agents, got %d", body.RunningAgents)
+	}
+	if body.Version != "dev" {
+		t.Errorf("expected version dev, got %s", body.Version)
+	}
+}
+
+func TestReadyzNotReady(t *testing.T) {
+	s := NewServer(mockCounter{})
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestReadyzReady(t *testing.T) {
+	s := NewServer(mockCounter{})
+	s.SetReady(true)
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHealthzNilCounter(t *testing.T) {
+	s := NewServer(nil)
+	s.SetReady(true)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var body healthzResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.RunningAgents != 0 {
+		t.Errorf("expected 0 agents, got %d", body.RunningAgents)
+	}
+}


### PR DESCRIPTION
Closes #205

- Add `daemon/internal/health` package
- `/healthz` returns 200 + JSON (uptime, running agents count, version)
- `/readyz` returns 200 when ready, 503 otherwise
- 4 tests