### PR TITLE
chore: add Makefile for common development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: test test-daemon test-gateway lint build clean hooks help
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
+
+test: test-daemon test-gateway ## Run all tests
+
+test-daemon: ## Run daemon Go tests
+	cd daemon && go test ./...
+
+test-gateway: ## Run gateway TypeScript type check and tests
+	cd gateway && npx tsc --noEmit
+	cd gateway && npx bun test
+
+lint: ## Run linters (go vet + tsc)
+	cd daemon && go vet ./...
+	cd gateway && npx tsc --noEmit
+
+build: ## Build daemon binary
+	cd daemon && go build -o ../bin/agentd ./cmd/agentd
+
+clean: ## Remove build artifacts
+	rm -rf bin/
+
+hooks: ## Configure git hooks
+	git config core.hooksPath .githooks
+	@echo "Git hooks configured to use .githooks/"


### PR DESCRIPTION
## Summary

Adds a root Makefile with targets for common development workflows across both the Go daemon and TypeScript gateway codebases.

### Targets

| Target | Description |
|--------|-------------|
| `make test` | Run all tests (daemon + gateway) |
| `make test-daemon` | Run daemon Go tests |
| `make test-gateway` | Run gateway type check and tests |
| `make lint` | Run go vet + tsc --noEmit |
| `make build` | Build daemon binary |
| `make clean` | Remove build artifacts |
| `make hooks` | Configure git hooks path |

Closes #219

**Milestone:** Phase 1