### PR TITLE
docs(daemon): add package-level godoc comments to all internal packages

### DIFF
--- a/daemon/internal/baseagent/doc.go
+++ b/daemon/internal/baseagent/doc.go
@@ -1,0 +1,4 @@
+// Package baseagent provides the failure triage interface and default policies
+// used by the lifecycle service to analyze agent errors and decide whether
+// remote diagnosis is required.
+package baseagent

--- a/daemon/internal/catalog/doc.go
+++ b/daemon/internal/catalog/doc.go
@@ -1,0 +1,4 @@
+// Package catalog manages the agent catalog — a registry of available agent
+// definitions loaded from JSON manifest files. It provides lookup and
+// listing operations used during install and upgrade flows.
+package catalog

--- a/daemon/internal/commandexec/doc.go
+++ b/daemon/internal/commandexec/doc.go
@@ -1,0 +1,4 @@
+// Package commandexec defines the Runner interface for executing shell commands
+// and provides a default ShellRunner implementation that delegates to the
+// host's shell (/bin/sh on Unix, wsl.exe on Windows).
+package commandexec

--- a/daemon/internal/lifecycle/doc.go
+++ b/daemon/internal/lifecycle/doc.go
@@ -1,0 +1,5 @@
+// Package lifecycle implements the core agent lifecycle state machine, managing
+// install, start, stop, upgrade, and diagnose operations. It coordinates
+// runtime checks, command execution, crash-loop detection, memory management,
+// and audit logging.
+package lifecycle

--- a/daemon/internal/manifest/doc.go
+++ b/daemon/internal/manifest/doc.go
@@ -1,0 +1,4 @@
+// Package manifest defines the agent manifest schema and provides loading and
+// validation logic. A manifest describes an agent's identity, runtime commands,
+// environment requirements, network ports, and upgrade strategy.
+package manifest

--- a/daemon/internal/memory/doc.go
+++ b/daemon/internal/memory/doc.go
@@ -1,0 +1,5 @@
+// Package memory implements an in-memory store for memory packages — named,
+// versioned data units that can be mounted to and unmounted from agents.
+// It enforces state transitions (created → mounted → detached → archived)
+// and access-mode policies per memory type.
+package memory

--- a/daemon/internal/redact/doc.go
+++ b/daemon/internal/redact/doc.go
@@ -1,0 +1,4 @@
+// Package redact provides utilities for scrubbing sensitive information
+// (API keys, tokens, passwords, URL credentials) from text, environment
+// variables, and diagnostic artifacts before they leave the host.
+package redact

--- a/daemon/internal/runtimecheck/doc.go
+++ b/daemon/internal/runtimecheck/doc.go
@@ -1,0 +1,4 @@
+// Package runtimecheck defines the Checker and PreFlighter interfaces for
+// verifying that host prerequisites (runtimes, ports, environment) are
+// satisfied before an agent is installed or started.
+package runtimecheck


### PR DESCRIPTION
## Summary

Adds `doc.go` files with package-level documentation to all 8 daemon internal packages. This makes `go doc` output immediately useful for new contributors.

### Packages documented

- `baseagent` — failure triage interface and policies
- `catalog` — agent catalog registry
- `commandexec` — shell command execution
- `lifecycle` — agent lifecycle state machine
- `manifest` — manifest schema, loading, validation
- `memory` — memory package store and state transitions
- `redact` — sensitive data scrubbing
- `runtimecheck` — host prerequisite verification

Closes #220

**Milestone:** Phase 1