### PR TITLE
fix(gateway): add cleanup method and size accessors to SessionStore

### DIFF
--- a/gateway/src/session/store.test.ts
+++ b/gateway/src/session/store.test.ts
@@ -158,4 +158,43 @@ describe("SessionStore", () => {
       store.touch("telegram", "unknown");
     });
   });
+
+  describe("cleanup", () => {
+    test("removes expired pairing codes", () => {
+      let time = new Date("2026-01-01T00:00:00Z");
+      const store = new SessionStore(() => time);
+      store.registerPairCode("code-a", 60);
+      store.registerPairCode("code-b", 300);
+
+      expect(store.pairCodeCount).toBe(2);
+
+      // Advance past first code's expiry but before second
+      time = new Date("2026-01-01T00:02:00Z");
+      const removed = store.cleanup();
+
+      expect(removed).toBe(1);
+      expect(store.pairCodeCount).toBe(1);
+
+      // The non-expired code should still work
+      const session = store.pair({ provider: "telegram", chatId: "c1", code: "code-b" });
+      expect(session).not.toBeNull();
+    });
+
+    test("returns 0 when nothing to clean", () => {
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"));
+      expect(store.cleanup()).toBe(0);
+    });
+  });
+
+  describe("sessionCount", () => {
+    test("tracks active sessions", () => {
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"));
+      expect(store.sessionCount).toBe(0);
+
+      store.registerPairCode("code-1", 300);
+      store.pair({ provider: "telegram", chatId: "c1", code: "code-1" });
+
+      expect(store.sessionCount).toBe(1);
+    });
+  });
 });

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -75,6 +75,29 @@ export class SessionStore {
     this.sessions.set(key, { ...session, lastSeenAt: this.now().toISOString() });
   }
 
+  /** Remove expired pairing codes from the internal map. */
+  cleanup(): number {
+    let removed = 0;
+    const nowMs = this.now().getTime();
+    for (const [key, record] of this.pairCodes) {
+      if (Date.parse(record.expiresAt) <= nowMs) {
+        this.pairCodes.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Return the number of active pairing codes. */
+  get pairCodeCount(): number {
+    return this.pairCodes.size;
+  }
+
+  /** Return the number of active sessions. */
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
   private issueSessionToken(): string {
     this.nextToken += 1;
     return `session-${this.nextToken}`;


### PR DESCRIPTION
## Summary

Adds a `cleanup()` method to `SessionStore` that removes expired pairing codes, preventing unbounded memory growth when codes are issued but never consumed.

Also adds `pairCodeCount` and `sessionCount` getters for operational visibility.

### Changes

- `gateway/src/session/store.ts` — new `cleanup()`, `pairCodeCount`, `sessionCount`
- `gateway/src/session/store.test.ts` — tests for cleanup and accessors

Closes #222

**Milestone:** Phase 1