### PR TITLE
security(gateway): replace sequential token generation with crypto-secure

### DIFF
--- a/gateway/src/downloads/token_store.ts
+++ b/gateway/src/downloads/token_store.ts
@@ -5,14 +5,12 @@ type DownloadTokenRecord = ReadOnlyDownloadToken & {
 };
 
 export class DownloadTokenStore {
-  private nextToken = 0;
   private readonly tokens = new Map<string, DownloadTokenRecord>();
 
   constructor(private readonly now: () => Date = () => new Date()) {}
 
   issue(fileRef: string, ttlSeconds = 300, singleUse = true): ReadOnlyDownloadToken {
-    this.nextToken += 1;
-    const token = `dl-${this.nextToken}`;
+    const token = `dl-${crypto.randomUUID()}`;
     const expiresAt = new Date(this.now().getTime() + ttlSeconds * 1000).toISOString();
     const record: DownloadTokenRecord = {
       token,

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -14,16 +14,13 @@ function sessionKey(provider: Provider, chatId: string): string {
 }
 
 export class SessionStore {
-  private nextCode = 0;
-  private nextToken = 0;
   private readonly pairCodes = new Map<string, PairingCodeRecord>();
   private readonly sessions = new Map<string, SessionRecord>();
 
   constructor(private readonly now: () => Date = () => new Date()) {}
 
   issuePairCode(ttlSeconds = 300): PairingCodeRecord {
-    this.nextCode += 1;
-    const code = `pair-${this.nextCode}`;
+    const code = `pair-${crypto.randomUUID()}`;
     const expiresAt = new Date(this.now().getTime() + ttlSeconds * 1000).toISOString();
     const record: PairingCodeRecord = { code, expiresAt };
     this.pairCodes.set(code, record);
@@ -76,7 +73,6 @@ export class SessionStore {
   }
 
   private issueSessionToken(): string {
-    this.nextToken += 1;
-    return `session-${this.nextToken}`;
+    return `session-${crypto.randomUUID()}`;
   }
 }


### PR DESCRIPTION
Closes #218

- Replace sequential `pair-N`, `session-N`, `dl-N` tokens with `crypto.randomUUID()`
- Remove `nextCode`/`nextToken` counters from `SessionStore` and `DownloadTokenStore`
- All 92 gateway tests pass