### PR TITLE
refactor(daemon): split lifecycle/service.go into focused files

### DIFF
--- a/daemon/internal/lifecycle/audit.go
+++ b/daemon/internal/lifecycle/audit.go
@@ -1,0 +1,46 @@
+package lifecycle
+
+// AuditStatus returns the current audit buffer size and configured limit.
+// This is primarily queried by operational inspection/debug endpoints.
+type AuditStatus struct {
+	BufferSize int `json:"buffer_size"`
+	Limit      int `json:"limit"`
+}
+
+// AuditBufferStatus returns a snapshot of the audit buffer metrics.
+func (s *Service) AuditBufferStatus() AuditStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return AuditStatus{
+		BufferSize: len(s.auditLogs),
+		Limit:      s.auditLogLimit,
+	}
+}
+
+func (s *Service) AuditLogs() []AuditLog {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]AuditLog(nil), s.auditLogs...)
+}
+
+func (s *Service) recordAudit(requestID, actor, action, target string, result AuditResult, errorCode, message string) {
+	if actor == "" {
+		actor = "system"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.auditLogs = append(s.auditLogs, AuditLog{
+		RequestID: requestID,
+		Actor:     actor,
+		Action:    action,
+		Target:    target,
+		Result:    result,
+		ErrorCode: errorCode,
+		Message:   message,
+		Timestamp: s.now(),
+	})
+	if len(s.auditLogs) > s.auditLogLimit {
+		s.auditLogs = s.auditLogs[len(s.auditLogs)-s.auditLogLimit:]
+	}
+}

--- a/daemon/internal/lifecycle/helpers.go
+++ b/daemon/internal/lifecycle/helpers.go
@@ -1,0 +1,396 @@
+package lifecycle
+
+import (
+	"archive/zip"
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"carrier/daemon/internal/commandexec"
+	"carrier/daemon/internal/manifest"
+	"carrier/daemon/internal/redact"
+	"carrier/daemon/internal/runtimecheck"
+)
+
+func (s *Service) getManifestAndState(agentID string) (manifest.Manifest, AgentState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	m, ok := s.manifests[agentID]
+	if !ok {
+		return manifest.Manifest{}, AgentState{}, ErrAgentNotFound
+	}
+	state := s.states[agentID]
+	return m, state, nil
+}
+
+func (s *Service) appendCommandLog(agentID, action, command string, result commandexec.Result, runErr error) {
+	line := fmt.Sprintf("[%s] command=%q exit=%d", action, command, result.ExitCode)
+	s.appendLog(agentID, line)
+	if result.CombinedOutput != "" {
+		s.appendLog(agentID, fmt.Sprintf("[%s] output=%s", action, result.CombinedOutput))
+	}
+	if runErr != nil {
+		s.appendLog(agentID, fmt.Sprintf("[%s] error=%v", action, runErr))
+	}
+}
+
+func (s *Service) appendLog(agentID, line string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, ok := s.logs[agentID]
+	if !ok {
+		return
+	}
+	entry := fmt.Sprintf("%s %s", s.now().UTC().Format(time.RFC3339), line)
+	entries = append(entries, entry)
+	if len(entries) > s.logLimit {
+		entries = entries[len(entries)-s.logLimit:]
+	}
+	s.logs[agentID] = entries
+}
+
+func (s *Service) updateStateOnInstallError(agentID string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[agentID]
+	if !ok {
+		return
+	}
+	state.Install = InstallStateBroken
+	state.Runtime = RuntimeStateStopped
+	state.Health = HealthStateUnhealthy
+	state.LastError = err.Error()
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+}
+
+func (s *Service) updateStateOnStartError(agentID string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[agentID]
+	if !ok {
+		return
+	}
+	now := s.now()
+	restarts := append(s.restarts[agentID], now)
+	restarts = trimRestartHistory(restarts, now.Add(-s.crashLoopWindow))
+	s.restarts[agentID] = restarts
+	state.Runtime = RuntimeStateCrashing
+	state.Health = HealthStateUnhealthy
+	state.LastError = err.Error()
+	if len(restarts) >= s.crashLoopThreshold {
+		cooldownUntil := now.Add(s.crashLoopCooldown)
+		s.cooldowns[agentID] = cooldownUntil
+		state.LastError = fmt.Sprintf(
+			"crash-loop detected: %d restarts within %s; cooldown until %s; last error: %v",
+			len(restarts),
+			s.crashLoopWindow.String(),
+			cooldownUntil.UTC().Format(time.RFC3339),
+			err,
+		)
+	}
+	state.UpdatedAt = now
+	s.states[agentID] = state
+}
+
+func (s *Service) updateStateOnUpgradeError(agentID string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[agentID]
+	if !ok {
+		return
+	}
+	state.Health = HealthStateUnhealthy
+	state.LastError = err.Error()
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+}
+
+func (s *Service) checkRuntimePrerequisites(m manifest.Manifest) error {
+	if err := s.checker.Check(m); err != nil {
+		return fmt.Errorf("%w: %v", ErrRuntimePrerequisites, err)
+	}
+	return nil
+}
+
+func formatPreFlightFailures(result runtimecheck.PreFlightResult) string {
+	var parts []string
+	for _, c := range result.Checks {
+		if !c.Passed {
+			msg := c.Message
+			if c.Repair != "" {
+				msg += " (fix: " + c.Repair + ")"
+			}
+			parts = append(parts, msg)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func firstFailedCode(result runtimecheck.PreFlightResult) string {
+	for _, c := range result.Checks {
+		if !c.Passed && c.Code != "" {
+			return c.Code
+		}
+	}
+	return "E_PREFLIGHT_FAILED"
+}
+
+func (s *Service) validateRequiredEnv(m manifest.Manifest) error {
+	missing := make([]string, 0)
+	for _, envVar := range m.Env.Required {
+		if strings.TrimSpace(os.Getenv(envVar.Name)) == "" {
+			missing = append(missing, envVar.Name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", ErrMissingRequiredEnv, strings.Join(missing, ","))
+}
+
+func (s *Service) ensurePortsAvailable(ports []manifest.PortSpec) error {
+	for _, port := range ports {
+		if port.Port <= 0 {
+			continue
+		}
+		addr := fmt.Sprintf("127.0.0.1:%d", port.Port)
+		ln, err := listenTCP("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("%w: %s (%d) is in use by %s", ErrPortConflict, port.Name, port.Port, portOccupantFor(port.Port))
+		}
+		_ = ln.Close()
+	}
+	return nil
+}
+
+func (s *Service) blockIfCrashLoopCoolingDown(agentID string, state AgentState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cooldownUntil, ok := s.cooldowns[agentID]
+	if !ok || cooldownUntil.IsZero() {
+		return nil
+	}
+
+	now := s.now()
+	if !now.Before(cooldownUntil) {
+		delete(s.cooldowns, agentID)
+		delete(s.restarts, agentID)
+		return nil
+	}
+
+	restartCount := len(trimRestartHistory(s.restarts[agentID], now.Add(-s.crashLoopWindow)))
+	state.Runtime = RuntimeStateCrashing
+	state.Health = HealthStateUnhealthy
+	state.LastError = fmt.Sprintf(
+		"crash-loop detected: %d restarts within %s; cooldown until %s",
+		restartCount,
+		s.crashLoopWindow.String(),
+		cooldownUntil.UTC().Format(time.RFC3339),
+	)
+	state.UpdatedAt = now
+	s.states[agentID] = state
+
+	return fmt.Errorf("%w: %s", ErrCrashLoop, state.LastError)
+}
+
+func trimRestartHistory(history []time.Time, windowStart time.Time) []time.Time {
+	if len(history) == 0 {
+		return history
+	}
+	firstKept := 0
+	for firstKept < len(history) && history[firstKept].Before(windowStart) {
+		firstKept++
+	}
+	if firstKept == 0 {
+		return history
+	}
+	if firstKept >= len(history) {
+		return nil
+	}
+	return append([]time.Time(nil), history[firstKept:]...)
+}
+
+func describePortOccupant(port int) string {
+	if runtime.GOOS != "linux" {
+		return "an unknown process"
+	}
+
+	inode, err := findListeningSocketInode(port)
+	if err != nil || inode == "" {
+		return "an unknown process"
+	}
+
+	pid, processName, err := findProcessBySocketInode(inode)
+	if err != nil || pid <= 0 {
+		return fmt.Sprintf("socket inode %s (pid unknown)", inode)
+	}
+	if processName == "" {
+		return fmt.Sprintf("pid %d", pid)
+	}
+	return fmt.Sprintf("pid %d (%s)", pid, processName)
+}
+
+func findListeningSocketInode(port int) (string, error) {
+	for _, procFile := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		inode, err := findListeningSocketInodeInFile(procFile, port)
+		if err == nil && inode != "" {
+			return inode, nil
+		}
+	}
+	return "", errors.New("listening socket not found")
+}
+
+func findListeningSocketInodeInFile(path string, port int) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "sl") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 10 {
+			continue
+		}
+		localAddress := fields[1]
+		state := fields[3]
+		if state != "0A" {
+			continue
+		}
+		parts := strings.Split(localAddress, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		p, err := strconv.ParseInt(parts[1], 16, 32)
+		if err != nil || int(p) != port {
+			continue
+		}
+		return fields[9], nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("socket not found")
+}
+
+func findProcessBySocketInode(inode string) (int, string, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, "", err
+	}
+	target := "socket:[" + inode + "]"
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			linkPath := filepath.Join(fdDir, fd.Name())
+			link, err := os.Readlink(linkPath)
+			if err != nil {
+				continue
+			}
+			if link != target {
+				continue
+			}
+			nameBytes, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "comm"))
+			if err != nil {
+				return pid, "", nil
+			}
+			return pid, strings.TrimSpace(string(nameBytes)), nil
+		}
+	}
+	return 0, "", errors.New("process not found")
+}
+
+func (s *Service) writeDiagnoseZip(path string, m manifest.Manifest, state AgentState, logs []string, createdAt time.Time) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create diagnose zip: %w", err)
+	}
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+
+	stateJSON, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	manifestJSON, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	redactedEnvJSON, err := json.MarshalIndent(redact.RedactEnviron(os.Environ()), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal env: %w", err)
+	}
+
+	artifacts := map[string][]byte{
+		"state.json":    []byte(redact.RedactText(string(stateJSON))),
+		"manifest.json": []byte(redact.RedactText(string(manifestJSON))),
+		"logs.txt":      []byte(redact.RedactText(strings.Join(logs, "\n"))),
+		"env.json":      redactedEnvJSON,
+	}
+
+	metadataJSON, err := redact.MetadataJSON(createdAt, 24*time.Hour, artifacts)
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+	artifacts["metadata.json"] = metadataJSON
+
+	names := make([]string, 0, len(artifacts))
+	for name := range artifacts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if err := addZipFile(zipWriter, name, artifacts[name]); err != nil {
+			return err
+		}
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		return fmt.Errorf("close zip writer: %w", err)
+	}
+
+	return nil
+}
+
+func addZipFile(zw *zip.Writer, name string, content []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("create zip entry %s: %w", name, err)
+	}
+	if _, err := w.Write(content); err != nil {
+		return fmt.Errorf("write zip entry %s: %w", name, err)
+	}
+	return nil
+}

--- a/daemon/internal/lifecycle/install.go
+++ b/daemon/internal/lifecycle/install.go
@@ -1,0 +1,41 @@
+package lifecycle
+
+import (
+	"context"
+)
+
+func (s *Service) Install(ctx context.Context, agentID string) error {
+	m, state, err := s.getManifestAndState(agentID)
+	if err != nil {
+		return err
+	}
+
+	if err := s.checkRuntimePrerequisites(m); err != nil {
+		s.updateStateOnInstallError(agentID, err)
+		s.recordAudit("", "system", "install", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
+		return err
+	}
+
+	result, runErr := s.runner.Run(ctx, m.Runtime.Install.Command)
+	s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
+	if runErr != nil {
+		s.updateStateOnInstallError(agentID, runErr)
+		s.recordAudit("", "system", "install", agentID, AuditResultFailure, "E_INSTALL_FAILED", runErr.Error())
+		return runErr
+	}
+
+	s.mu.Lock()
+	state = s.states[agentID]
+	state.Install = InstallStateInstalled
+	state.Runtime = RuntimeStateStopped
+	state.Health = HealthStateUnknown
+	state.LastError = ""
+	state.LastTriageSummary = ""
+	state.NeedsRemoteDiagnosis = false
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+	s.mu.Unlock()
+	s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed")
+
+	return nil
+}

--- a/daemon/internal/lifecycle/memory.go
+++ b/daemon/internal/lifecycle/memory.go
@@ -1,0 +1,59 @@
+package lifecycle
+
+import (
+	"fmt"
+
+	"carrier/daemon/internal/memory"
+)
+
+// autoMountMemories mounts all memory links for an agent on start.
+func (s *Service) autoMountMemories(agentID string) {
+	if s.memoryStore == nil {
+		return
+	}
+	s.mu.RLock()
+	links := append([]string(nil), s.memoryLinks[agentID]...)
+	s.mu.RUnlock()
+
+	for _, memID := range links {
+		if _, err := s.memoryStore.Mount(memID, agentID, memory.AccessReadOnly); err != nil {
+			s.appendLog(agentID, fmt.Sprintf("memory auto-mount %s failed: %v", memID, err))
+		} else {
+			s.appendLog(agentID, fmt.Sprintf("memory auto-mounted %s", memID))
+		}
+	}
+}
+
+// autoUnmountMemories unmounts all memories for an agent on stop.
+func (s *Service) autoUnmountMemories(agentID string) {
+	if s.memoryStore == nil {
+		return
+	}
+	n := s.memoryStore.UnmountAll(agentID)
+	if n > 0 {
+		s.appendLog(agentID, fmt.Sprintf("memory auto-unmounted %d memories", n))
+	}
+}
+
+// SetMemoryAttachments sets the memory links for an agent (alias for setMemoryAttachments).
+func (s *Service) SetMemoryAttachments(agentID string, attachments []string) {
+	s.setMemoryAttachments(agentID, attachments)
+}
+
+// GetMemoryAttachments returns the memory links for an agent (alias for getMemoryAttachments).
+func (s *Service) GetMemoryAttachments(agentID string) []string {
+	return s.getMemoryAttachments(agentID)
+}
+
+func (s *Service) getMemoryAttachments(agentID string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	attachments := s.memoryLinks[agentID]
+	return append([]string(nil), attachments...)
+}
+
+func (s *Service) setMemoryAttachments(agentID string, attachments []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.memoryLinks[agentID] = append([]string(nil), attachments...)
+}

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -1,19 +1,13 @@
 package lifecycle
 
 import (
-	"archive/zip"
-	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,7 +16,6 @@ import (
 	"carrier/daemon/internal/commandexec"
 	"carrier/daemon/internal/manifest"
 	"carrier/daemon/internal/memory"
-	"carrier/daemon/internal/redact"
 	"carrier/daemon/internal/runtimecheck"
 )
 
@@ -223,16 +216,6 @@ func (s *Service) RegisterManifest(m manifest.Manifest) error {
 	return nil
 }
 
-type upgradeBackup struct {
-	AgentID           string            `json:"agent_id"`
-	CreatedAt         time.Time         `json:"created_at"`
-	CurrentVersion    string            `json:"current_version"`
-	EnvVarKeys        []string          `json:"env_var_keys"`
-	MemoryAttachments []string          `json:"memory_attachments"`
-	RuntimeState      AgentState        `json:"runtime_state"`
-	Config            manifest.Manifest `json:"config"`
-}
-
 func (s *Service) ListAgents() []AgentState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -249,241 +232,6 @@ func (s *Service) ListAgents() []AgentState {
 	}
 
 	return out
-}
-
-func (s *Service) Install(ctx context.Context, agentID string) error {
-	m, state, err := s.getManifestAndState(agentID)
-	if err != nil {
-		return err
-	}
-
-	if err := s.checkRuntimePrerequisites(m); err != nil {
-		s.updateStateOnInstallError(agentID, err)
-		s.recordAudit("", "system", "install", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
-		return err
-	}
-
-	result, runErr := s.runner.Run(ctx, m.Runtime.Install.Command)
-	s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
-	if runErr != nil {
-		s.updateStateOnInstallError(agentID, runErr)
-		s.recordAudit("", "system", "install", agentID, AuditResultFailure, "E_INSTALL_FAILED", runErr.Error())
-		return runErr
-	}
-
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.Install = InstallStateInstalled
-	state.Runtime = RuntimeStateStopped
-	state.Health = HealthStateUnknown
-	state.LastError = ""
-	state.LastTriageSummary = ""
-	state.NeedsRemoteDiagnosis = false
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	s.mu.Unlock()
-	s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed")
-
-	return nil
-}
-
-func (s *Service) Start(ctx context.Context, agentID string) error {
-	m, state, err := s.getManifestAndState(agentID)
-	if err != nil {
-		return err
-	}
-	if state.Install != InstallStateInstalled {
-		return ErrNotInstalled
-	}
-	if state.Runtime == RuntimeStateRunning {
-		return ErrAlreadyRunning
-	}
-	if err := s.blockIfCrashLoopCoolingDown(agentID, state); err != nil {
-		return err
-	}
-
-	if pf, ok := s.checker.(runtimecheck.PreFlighter); ok {
-		pfResult := pf.PreFlight(m)
-		if !pfResult.Passed {
-			failMsg := formatPreFlightFailures(pfResult)
-			errCode := firstFailedCode(pfResult)
-			pfErr := fmt.Errorf("pre-flight checks failed: %s", failMsg)
-			s.updateStateOnStartError(agentID, pfErr)
-			s.recordAudit("", "system", "start", agentID, AuditResultFailure, errCode, failMsg)
-			return pfErr
-		}
-	} else {
-		if err := s.checkRuntimePrerequisites(m); err != nil {
-			s.updateStateOnStartError(agentID, err)
-			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
-			return err
-		}
-		if err := s.validateRequiredEnv(m); err != nil {
-			s.updateStateOnStartError(agentID, err)
-			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_ENV_MISSING", err.Error())
-			return err
-		}
-		if err := s.ensurePortsAvailable(m.Network.Ports); err != nil {
-			s.updateStateOnStartError(agentID, err)
-			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_PORT_CONFLICT", err.Error())
-			return err
-		}
-	}
-
-	result, runErr := s.runner.Run(ctx, m.Runtime.Start.Command)
-	s.appendCommandLog(agentID, "start", m.Runtime.Start.Command, result, runErr)
-	if runErr != nil {
-		triage, triageErr := s.HandleFailure(ctx, agentID, runErr.Error())
-		if triageErr == nil {
-			s.appendLog(agentID, fmt.Sprintf("triage summary: %s", triage.Summary))
-		}
-		s.updateStateOnStartError(agentID, runErr)
-		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_START_FAILED", runErr.Error())
-		return runErr
-	}
-
-	// Auto-mount memories linked to this agent.
-	s.autoMountMemories(agentID)
-
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.Runtime = RuntimeStateRunning
-	state.Health = HealthStateHealthy
-	state.LastError = ""
-	state.LastTriageSummary = ""
-	state.NeedsRemoteDiagnosis = false
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	delete(s.restarts, agentID)
-	delete(s.cooldowns, agentID)
-	s.mu.Unlock()
-	s.recordAudit("", "system", "start", agentID, AuditResultSuccess, "", "start completed")
-
-	return nil
-}
-
-func (s *Service) Upgrade(ctx context.Context, agentID string) (UpgradeResult, error) {
-	m, state, err := s.getManifestAndState(agentID)
-	if err != nil {
-		return UpgradeResult{}, err
-	}
-	fromVersion := state.Version
-	if state.Install != InstallStateInstalled {
-		return UpgradeResult{}, ErrNotInstalled
-	}
-	if state.Runtime == RuntimeStateRunning {
-		return UpgradeResult{}, ErrAgentRunning
-	}
-	if strings.TrimSpace(m.Runtime.Upgrade.Command) == "" {
-		return UpgradeResult{}, ErrUpgradeNotSupported
-	}
-
-	strategy := strings.TrimSpace(m.Upgrade.Strategy)
-	if strategy == "" {
-		strategy = manifest.UpgradeStrategyInPlaceOrReinstall
-	}
-	if strategy != manifest.UpgradeStrategyInPlaceOrReinstall {
-		return UpgradeResult{}, fmt.Errorf("%w: unsupported strategy %q; supported: %q", ErrUpgradeStrategyUnsupported, strategy, manifest.UpgradeStrategyInPlaceOrReinstall)
-	}
-
-	toVersion, err := nextPatchVersion(fromVersion)
-	if err != nil {
-		s.updateStateOnUpgradeError(agentID, fmt.Errorf("upgrade target version calculation failed: %w", err))
-		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_VERSION", err.Error())
-		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, err
-	}
-
-	if err := s.checkRuntimePrerequisites(m); err != nil {
-		updateErr := fmt.Errorf("%w: %v", ErrUpgradeFailed, err)
-		s.updateStateOnUpgradeError(agentID, updateErr)
-		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_PREREQUISITES", err.Error())
-		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, updateErr
-	}
-
-	attachments := s.getMemoryAttachments(agentID)
-	backupPath, backupErr := s.createUpgradeBackup(agentID, m, state, attachments)
-	if backupErr != nil {
-		updateErr := fmt.Errorf("%w: backup failed: %v", ErrUpgradeFailed, backupErr)
-		s.updateStateOnUpgradeError(agentID, updateErr)
-		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_BACKUP", backupErr.Error())
-		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, updateErr
-	}
-	s.recordAudit("", "system", "upgrade", agentID, AuditResultSuccess, "", fmt.Sprintf("upgrade_start backup=%q command=%q", backupPath, m.Runtime.Upgrade.Command))
-
-	result, runErr := s.runner.Run(ctx, m.Runtime.Upgrade.Command)
-	s.appendCommandLog(agentID, "upgrade", m.Runtime.Upgrade.Command, result, runErr)
-	if runErr != nil {
-		updateErr := s.formatUpgradeFailure(runErr, backupPath)
-		s.updateStateOnUpgradeError(agentID, updateErr)
-		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_FAILED", fmt.Sprintf("upgrade_failure backup=%q error=%q", backupPath, runErr.Error()))
-		return UpgradeResult{
-			AgentID:     agentID,
-			FromVersion: fromVersion,
-			ToVersion:   fromVersion,
-			BackupPath:  backupPath,
-		}, updateErr
-	}
-
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.Version = toVersion
-	state.LastError = ""
-	state.Runtime = RuntimeStateStopped
-	state.Health = HealthStateUnknown
-	state.LastTriageSummary = ""
-	state.NeedsRemoteDiagnosis = false
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	s.restarts[agentID] = nil
-	delete(s.cooldowns, agentID)
-	s.memoryLinks[agentID] = append([]string(nil), attachments...)
-	s.mu.Unlock()
-
-	s.recordAudit("", "system", "upgrade", agentID, AuditResultSuccess, "", fmt.Sprintf("upgrade_success from=%s to=%s backup=%q", fromVersion, toVersion, backupPath))
-	return UpgradeResult{
-		AgentID:     agentID,
-		FromVersion: fromVersion,
-		ToVersion:   toVersion,
-		BackupPath:  backupPath,
-	}, nil
-}
-
-func (s *Service) Stop(ctx context.Context, agentID string) error {
-	m, state, err := s.getManifestAndState(agentID)
-	if err != nil {
-		return err
-	}
-	if state.Runtime == RuntimeStateStopped {
-		return ErrAlreadyStopped
-	}
-
-	result, runErr := s.runner.Run(ctx, m.Runtime.Stop.Command)
-	s.appendCommandLog(agentID, "stop", m.Runtime.Stop.Command, result, runErr)
-	if runErr != nil {
-		s.mu.Lock()
-		state = s.states[agentID]
-		state.LastError = runErr.Error()
-		state.UpdatedAt = s.now()
-		s.states[agentID] = state
-		s.mu.Unlock()
-		s.recordAudit("", "system", "stop", agentID, AuditResultFailure, "E_STOP_FAILED", runErr.Error())
-		return runErr
-	}
-
-	// Auto-unmount all memories for this agent.
-	s.autoUnmountMemories(agentID)
-
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.Runtime = RuntimeStateStopped
-	state.Health = HealthStateUnknown
-	state.LastError = ""
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	s.mu.Unlock()
-	s.recordAudit("", "system", "stop", agentID, AuditResultSuccess, "", "stop completed")
-
-	return nil
 }
 
 func (s *Service) Status(agentID string) (AgentState, error) {
@@ -514,61 +262,40 @@ func (s *Service) Logs(agentID string, tail int) ([]string, error) {
 	return append([]string(nil), logs[start:]...), nil
 }
 
-// AuditStatus returns the current audit buffer size and configured limit.
-// This is primarily queried by operational inspection/debug endpoints.
-type AuditStatus struct {
-	BufferSize int `json:"buffer_size"`
-	Limit      int `json:"limit"`
-}
-
-// AuditBufferStatus returns a snapshot of the audit buffer metrics.
-func (s *Service) AuditBufferStatus() AuditStatus {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return AuditStatus{
-		BufferSize: len(s.auditLogs),
-		Limit:      s.auditLogLimit,
-	}
-}
-
-func (s *Service) AuditLogs() []AuditLog {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return append([]AuditLog(nil), s.auditLogs...)
-}
-
-func (s *Service) DiagnosisHandoffs() []DiagnosisHandoff {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	out := make([]DiagnosisHandoff, 0, len(s.handoffs))
-	for _, h := range s.handoffs {
-		out = append(out, h)
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].CreatedAt.Before(out[j].CreatedAt)
-	})
-	return out
-}
-
-func (s *Service) CleanupExpiredDiagnosisHandoffs() int {
-	cutoff := s.now().Add(-s.handoffTTL)
-
+func (s *Service) HandleFailure(ctx context.Context, agentID, lastError string) (baseagent.TriageResult, error) {
 	s.mu.Lock()
-	removed := 0
-	for id, h := range s.handoffs {
-		if h.CreatedAt.Before(cutoff) {
-			delete(s.handoffs, id)
-			removed++
-		}
+	state, ok := s.states[agentID]
+	if !ok {
+		s.mu.Unlock()
+		return baseagent.TriageResult{}, ErrAgentNotFound
 	}
+
+	state.Runtime = RuntimeStateCrashing
+	state.Health = HealthStateUnhealthy
+	state.LastError = lastError
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
 	s.mu.Unlock()
 
-	if removed > 0 {
-		s.recordAudit("", "system", "handoff_cleanup", "diagnosis_handoffs", AuditResultSuccess, "", fmt.Sprintf("removed=%d", removed))
+	triage, err := s.triager.Analyze(ctx, baseagent.Evidence{AgentID: agentID, LastError: lastError})
+	if err != nil {
+		return baseagent.TriageResult{}, err
 	}
-	return removed
+
+	s.mu.Lock()
+	state = s.states[agentID]
+	state.LastTriageSummary = triage.Summary
+	state.NeedsRemoteDiagnosis = triage.RequiresRemoteDiagnosis
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+	s.mu.Unlock()
+	s.recordAudit("", "base-agent", "triage", agentID, AuditResultSuccess, "", triage.Summary)
+
+	return triage, nil
 }
+
+// MemoryStore returns the memory store, or nil if none was configured.
+func (s *Service) MemoryStore() *memory.Store { return s.memoryStore }
 
 func (s *Service) Diagnose(agentID string) (string, error) {
 	m, state, err := s.getManifestAndState(agentID)
@@ -638,563 +365,35 @@ func (s *Service) CreateRemoteDiagnosisHandoff(agentID string, consent bool, act
 	return handoff, nil
 }
 
-func (s *Service) HandleFailure(ctx context.Context, agentID, lastError string) (baseagent.TriageResult, error) {
-	s.mu.Lock()
-	state, ok := s.states[agentID]
-	if !ok {
-		s.mu.Unlock()
-		return baseagent.TriageResult{}, ErrAgentNotFound
-	}
-
-	state.Runtime = RuntimeStateCrashing
-	state.Health = HealthStateUnhealthy
-	state.LastError = lastError
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	s.mu.Unlock()
-
-	triage, err := s.triager.Analyze(ctx, baseagent.Evidence{AgentID: agentID, LastError: lastError})
-	if err != nil {
-		return baseagent.TriageResult{}, err
-	}
-
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.LastTriageSummary = triage.Summary
-	state.NeedsRemoteDiagnosis = triage.RequiresRemoteDiagnosis
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-	s.mu.Unlock()
-	s.recordAudit("", "base-agent", "triage", agentID, AuditResultSuccess, "", triage.Summary)
-
-	return triage, nil
-}
-
-func (s *Service) updateStateOnInstallError(agentID string, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	state, ok := s.states[agentID]
-	if !ok {
-		return
-	}
-	state.Install = InstallStateBroken
-	state.Runtime = RuntimeStateStopped
-	state.Health = HealthStateUnhealthy
-	state.LastError = err.Error()
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-}
-
-func (s *Service) updateStateOnStartError(agentID string, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	state, ok := s.states[agentID]
-	if !ok {
-		return
-	}
-	now := s.now()
-	restarts := append(s.restarts[agentID], now)
-	restarts = trimRestartHistory(restarts, now.Add(-s.crashLoopWindow))
-	s.restarts[agentID] = restarts
-	state.Runtime = RuntimeStateCrashing
-	state.Health = HealthStateUnhealthy
-	state.LastError = err.Error()
-	if len(restarts) >= s.crashLoopThreshold {
-		cooldownUntil := now.Add(s.crashLoopCooldown)
-		s.cooldowns[agentID] = cooldownUntil
-		state.LastError = fmt.Sprintf(
-			"crash-loop detected: %d restarts within %s; cooldown until %s; last error: %v",
-			len(restarts),
-			s.crashLoopWindow.String(),
-			cooldownUntil.UTC().Format(time.RFC3339),
-			err,
-		)
-	}
-	state.UpdatedAt = now
-	s.states[agentID] = state
-}
-
-func (s *Service) updateStateOnUpgradeError(agentID string, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	state, ok := s.states[agentID]
-	if !ok {
-		return
-	}
-	state.Health = HealthStateUnhealthy
-	state.LastError = err.Error()
-	state.UpdatedAt = s.now()
-	s.states[agentID] = state
-}
-
-func (s *Service) checkRuntimePrerequisites(m manifest.Manifest) error {
-	if err := s.checker.Check(m); err != nil {
-		return fmt.Errorf("%w: %v", ErrRuntimePrerequisites, err)
-	}
-	return nil
-}
-
-func formatPreFlightFailures(result runtimecheck.PreFlightResult) string {
-	var parts []string
-	for _, c := range result.Checks {
-		if !c.Passed {
-			msg := c.Message
-			if c.Repair != "" {
-				msg += " (fix: " + c.Repair + ")"
-			}
-			parts = append(parts, msg)
-		}
-	}
-	return strings.Join(parts, "; ")
-}
-
-func firstFailedCode(result runtimecheck.PreFlightResult) string {
-	for _, c := range result.Checks {
-		if !c.Passed && c.Code != "" {
-			return c.Code
-		}
-	}
-	return "E_PREFLIGHT_FAILED"
-}
-
-func (s *Service) formatUpgradeFailure(runErr error, backupPath string) error {
-	detail := fmt.Sprintf("upgrade failed: %v", runErr)
-	if backupPath != "" {
-		return fmt.Errorf("%s. backup captured at %s; manual rollback guidance: restore from this backup path before retrying", detail, backupPath)
-	}
-	return fmt.Errorf("%s. no backup was captured; manual rollback guidance unavailable", detail)
-}
-
-func nextPatchVersion(version string) (string, error) {
-	parts := strings.Split(version, ".")
-	if len(parts) != 3 {
-		return "", fmt.Errorf("invalid version format %q, expected MAJOR.MINOR.PATCH", version)
-	}
-
-	patch, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return "", fmt.Errorf("invalid patch version %q: %w", parts[2], err)
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return "", fmt.Errorf("invalid major version %q: %w", parts[0], err)
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("invalid minor version %q: %w", parts[1], err)
-	}
-
-	return fmt.Sprintf("%d.%d.%d", major, minor, patch+1), nil
-}
-
-func (s *Service) validateRequiredEnv(m manifest.Manifest) error {
-	missing := make([]string, 0)
-	for _, envVar := range m.Env.Required {
-		if strings.TrimSpace(os.Getenv(envVar.Name)) == "" {
-			missing = append(missing, envVar.Name)
-		}
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-
-	return fmt.Errorf("%w: %s", ErrMissingRequiredEnv, strings.Join(missing, ","))
-}
-
-func (s *Service) ensurePortsAvailable(ports []manifest.PortSpec) error {
-	for _, port := range ports {
-		if port.Port <= 0 {
-			continue
-		}
-		addr := fmt.Sprintf("127.0.0.1:%d", port.Port)
-		ln, err := listenTCP("tcp", addr)
-		if err != nil {
-			return fmt.Errorf("%w: %s (%d) is in use by %s", ErrPortConflict, port.Name, port.Port, portOccupantFor(port.Port))
-		}
-		_ = ln.Close()
-	}
-	return nil
-}
-
-func (s *Service) blockIfCrashLoopCoolingDown(agentID string, state AgentState) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cooldownUntil, ok := s.cooldowns[agentID]
-	if !ok || cooldownUntil.IsZero() {
-		return nil
-	}
-
-	now := s.now()
-	if !now.Before(cooldownUntil) {
-		delete(s.cooldowns, agentID)
-		delete(s.restarts, agentID)
-		return nil
-	}
-
-	restartCount := len(trimRestartHistory(s.restarts[agentID], now.Add(-s.crashLoopWindow)))
-	state.Runtime = RuntimeStateCrashing
-	state.Health = HealthStateUnhealthy
-	state.LastError = fmt.Sprintf(
-		"crash-loop detected: %d restarts within %s; cooldown until %s",
-		restartCount,
-		s.crashLoopWindow.String(),
-		cooldownUntil.UTC().Format(time.RFC3339),
-	)
-	state.UpdatedAt = now
-	s.states[agentID] = state
-
-	return fmt.Errorf("%w: %s", ErrCrashLoop, state.LastError)
-}
-
-func trimRestartHistory(history []time.Time, windowStart time.Time) []time.Time {
-	if len(history) == 0 {
-		return history
-	}
-	firstKept := 0
-	for firstKept < len(history) && history[firstKept].Before(windowStart) {
-		firstKept++
-	}
-	if firstKept == 0 {
-		return history
-	}
-	if firstKept >= len(history) {
-		return nil
-	}
-	return append([]time.Time(nil), history[firstKept:]...)
-}
-
-func describePortOccupant(port int) string {
-	if runtime.GOOS != "linux" {
-		return "an unknown process"
-	}
-
-	inode, err := findListeningSocketInode(port)
-	if err != nil || inode == "" {
-		return "an unknown process"
-	}
-
-	pid, processName, err := findProcessBySocketInode(inode)
-	if err != nil || pid <= 0 {
-		return fmt.Sprintf("socket inode %s (pid unknown)", inode)
-	}
-	if processName == "" {
-		return fmt.Sprintf("pid %d", pid)
-	}
-	return fmt.Sprintf("pid %d (%s)", pid, processName)
-}
-
-func findListeningSocketInode(port int) (string, error) {
-	for _, procFile := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
-		inode, err := findListeningSocketInodeInFile(procFile, port)
-		if err == nil && inode != "" {
-			return inode, nil
-		}
-	}
-	return "", errors.New("listening socket not found")
-}
-
-func findListeningSocketInodeInFile(path string, port int) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "sl") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 10 {
-			continue
-		}
-		localAddress := fields[1]
-		state := fields[3]
-		if state != "0A" {
-			continue
-		}
-		parts := strings.Split(localAddress, ":")
-		if len(parts) != 2 {
-			continue
-		}
-		p, err := strconv.ParseInt(parts[1], 16, 32)
-		if err != nil || int(p) != port {
-			continue
-		}
-		return fields[9], nil
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	return "", errors.New("socket not found")
-}
-
-func findProcessBySocketInode(inode string) (int, string, error) {
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return 0, "", err
-	}
-	target := "socket:[" + inode + "]"
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		pid, err := strconv.Atoi(entry.Name())
-		if err != nil {
-			continue
-		}
-		fdDir := filepath.Join("/proc", entry.Name(), "fd")
-		fds, err := os.ReadDir(fdDir)
-		if err != nil {
-			continue
-		}
-		for _, fd := range fds {
-			linkPath := filepath.Join(fdDir, fd.Name())
-			link, err := os.Readlink(linkPath)
-			if err != nil {
-				continue
-			}
-			if link != target {
-				continue
-			}
-			nameBytes, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "comm"))
-			if err != nil {
-				return pid, "", nil
-			}
-			return pid, strings.TrimSpace(string(nameBytes)), nil
-		}
-	}
-	return 0, "", errors.New("process not found")
-}
-
-// MemoryStore returns the memory store, or nil if none was configured.
-func (s *Service) MemoryStore() *memory.Store { return s.memoryStore }
-
-// autoMountMemories mounts all memory links for an agent on start.
-func (s *Service) autoMountMemories(agentID string) {
-	if s.memoryStore == nil {
-		return
-	}
-	s.mu.RLock()
-	links := append([]string(nil), s.memoryLinks[agentID]...)
-	s.mu.RUnlock()
-
-	for _, memID := range links {
-		if _, err := s.memoryStore.Mount(memID, agentID, memory.AccessReadOnly); err != nil {
-			s.appendLog(agentID, fmt.Sprintf("memory auto-mount %s failed: %v", memID, err))
-		} else {
-			s.appendLog(agentID, fmt.Sprintf("memory auto-mounted %s", memID))
-		}
-	}
-}
-
-// autoUnmountMemories unmounts all memories for an agent on stop.
-func (s *Service) autoUnmountMemories(agentID string) {
-	if s.memoryStore == nil {
-		return
-	}
-	n := s.memoryStore.UnmountAll(agentID)
-	if n > 0 {
-		s.appendLog(agentID, fmt.Sprintf("memory auto-unmounted %d memories", n))
-	}
-}
-
-// SetMemoryAttachments sets the memory links for an agent (alias for setMemoryAttachments).
-func (s *Service) SetMemoryAttachments(agentID string, attachments []string) {
-	s.setMemoryAttachments(agentID, attachments)
-}
-
-// GetMemoryAttachments returns the memory links for an agent (alias for getMemoryAttachments).
-func (s *Service) GetMemoryAttachments(agentID string) []string {
-	return s.getMemoryAttachments(agentID)
-}
-
-func (s *Service) getManifestAndState(agentID string) (manifest.Manifest, AgentState, error) {
+func (s *Service) DiagnosisHandoffs() []DiagnosisHandoff {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	m, ok := s.manifests[agentID]
-	if !ok {
-		return manifest.Manifest{}, AgentState{}, ErrAgentNotFound
+	out := make([]DiagnosisHandoff, 0, len(s.handoffs))
+	for _, h := range s.handoffs {
+		out = append(out, h)
 	}
-	state := s.states[agentID]
-	return m, state, nil
-}
-
-func (s *Service) appendCommandLog(agentID, action, command string, result commandexec.Result, runErr error) {
-	line := fmt.Sprintf("[%s] command=%q exit=%d", action, command, result.ExitCode)
-	s.appendLog(agentID, line)
-	if result.CombinedOutput != "" {
-		s.appendLog(agentID, fmt.Sprintf("[%s] output=%s", action, result.CombinedOutput))
-	}
-	if runErr != nil {
-		s.appendLog(agentID, fmt.Sprintf("[%s] error=%v", action, runErr))
-	}
-}
-
-func (s *Service) getMemoryAttachments(agentID string) []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	attachments := s.memoryLinks[agentID]
-	return append([]string(nil), attachments...)
-}
-
-func (s *Service) setMemoryAttachments(agentID string, attachments []string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.memoryLinks[agentID] = append([]string(nil), attachments...)
-}
-
-func (s *Service) envVarKeys(m manifest.Manifest) []string {
-	seen := make(map[string]struct{}, len(m.Env.Required)+len(m.Env.Optional))
-	keys := make([]string, 0, len(m.Env.Required)+len(m.Env.Optional))
-	for _, envVar := range m.Env.Required {
-		if _, ok := seen[envVar.Name]; !ok {
-			seen[envVar.Name] = struct{}{}
-			keys = append(keys, envVar.Name)
-		}
-	}
-	for _, envVar := range m.Env.Optional {
-		if _, ok := seen[envVar.Name]; !ok {
-			seen[envVar.Name] = struct{}{}
-			keys = append(keys, envVar.Name)
-		}
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func (s *Service) createUpgradeBackup(agentID string, m manifest.Manifest, state AgentState, attachments []string) (string, error) {
-	if err := os.MkdirAll(s.diagnoseDir, 0o755); err != nil {
-		return "", fmt.Errorf("create diagnose dir: %w", err)
-	}
-
-	fileName := fmt.Sprintf("%s-pre-upgrade-%s.json", agentID, s.now().UTC().Format("2006-01-02T15-04-05Z"))
-	filePath := filepath.Join(s.diagnoseDir, fileName)
-	backup := upgradeBackup{
-		AgentID:           agentID,
-		CreatedAt:         s.now().UTC(),
-		CurrentVersion:    state.Version,
-		EnvVarKeys:        s.envVarKeys(m),
-		MemoryAttachments: append([]string(nil), attachments...),
-		RuntimeState:      state,
-		Config:            m,
-	}
-
-	content, err := json.MarshalIndent(backup, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal upgrade backup: %w", err)
-	}
-	if err := os.WriteFile(filePath, content, 0o644); err != nil {
-		return "", fmt.Errorf("write upgrade backup: %w", err)
-	}
-
-	return filePath, nil
-}
-
-func (s *Service) appendLog(agentID, line string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	entries, ok := s.logs[agentID]
-	if !ok {
-		return
-	}
-	entry := fmt.Sprintf("%s %s", s.now().UTC().Format(time.RFC3339), line)
-	entries = append(entries, entry)
-	if len(entries) > s.logLimit {
-		entries = entries[len(entries)-s.logLimit:]
-	}
-	s.logs[agentID] = entries
-}
-
-func (s *Service) recordAudit(requestID, actor, action, target string, result AuditResult, errorCode, message string) {
-	if actor == "" {
-		actor = "system"
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.auditLogs = append(s.auditLogs, AuditLog{
-		RequestID: requestID,
-		Actor:     actor,
-		Action:    action,
-		Target:    target,
-		Result:    result,
-		ErrorCode: errorCode,
-		Message:   message,
-		Timestamp: s.now(),
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
 	})
-	if len(s.auditLogs) > s.auditLogLimit {
-		s.auditLogs = s.auditLogs[len(s.auditLogs)-s.auditLogLimit:]
-	}
+	return out
 }
 
-func (s *Service) writeDiagnoseZip(path string, m manifest.Manifest, state AgentState, logs []string, createdAt time.Time) error {
-	file, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("create diagnose zip: %w", err)
-	}
-	defer file.Close()
+func (s *Service) CleanupExpiredDiagnosisHandoffs() int {
+	cutoff := s.now().Add(-s.handoffTTL)
 
-	zipWriter := zip.NewWriter(file)
-
-	stateJSON, err := json.MarshalIndent(state, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal state: %w", err)
-	}
-	manifestJSON, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal manifest: %w", err)
-	}
-
-	redactedEnvJSON, err := json.MarshalIndent(redact.RedactEnviron(os.Environ()), "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal env: %w", err)
-	}
-
-	artifacts := map[string][]byte{
-		"state.json":    []byte(redact.RedactText(string(stateJSON))),
-		"manifest.json": []byte(redact.RedactText(string(manifestJSON))),
-		"logs.txt":      []byte(redact.RedactText(strings.Join(logs, "\n"))),
-		"env.json":      redactedEnvJSON,
-	}
-
-	metadataJSON, err := redact.MetadataJSON(createdAt, 24*time.Hour, artifacts)
-	if err != nil {
-		return fmt.Errorf("marshal metadata: %w", err)
-	}
-	artifacts["metadata.json"] = metadataJSON
-
-	names := make([]string, 0, len(artifacts))
-	for name := range artifacts {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		if err := addZipFile(zipWriter, name, artifacts[name]); err != nil {
-			return err
+	s.mu.Lock()
+	removed := 0
+	for id, h := range s.handoffs {
+		if h.CreatedAt.Before(cutoff) {
+			delete(s.handoffs, id)
+			removed++
 		}
 	}
+	s.mu.Unlock()
 
-	if err := zipWriter.Close(); err != nil {
-		return fmt.Errorf("close zip writer: %w", err)
+	if removed > 0 {
+		s.recordAudit("", "system", "handoff_cleanup", "diagnosis_handoffs", AuditResultSuccess, "", fmt.Sprintf("removed=%d", removed))
 	}
-
-	return nil
-}
-
-func addZipFile(zw *zip.Writer, name string, content []byte) error {
-	w, err := zw.Create(name)
-	if err != nil {
-		return fmt.Errorf("create zip entry %s: %w", name, err)
-	}
-	if _, err := w.Write(content); err != nil {
-		return fmt.Errorf("write zip entry %s: %w", name, err)
-	}
-	return nil
+	return removed
 }

--- a/daemon/internal/lifecycle/start_stop.go
+++ b/daemon/internal/lifecycle/start_stop.go
@@ -1,0 +1,121 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"carrier/daemon/internal/runtimecheck"
+)
+
+func (s *Service) Start(ctx context.Context, agentID string) error {
+	m, state, err := s.getManifestAndState(agentID)
+	if err != nil {
+		return err
+	}
+	if state.Install != InstallStateInstalled {
+		return ErrNotInstalled
+	}
+	if state.Runtime == RuntimeStateRunning {
+		return ErrAlreadyRunning
+	}
+	if err := s.blockIfCrashLoopCoolingDown(agentID, state); err != nil {
+		return err
+	}
+
+	if pf, ok := s.checker.(runtimecheck.PreFlighter); ok {
+		pfResult := pf.PreFlight(m)
+		if !pfResult.Passed {
+			failMsg := formatPreFlightFailures(pfResult)
+			errCode := firstFailedCode(pfResult)
+			pfErr := fmt.Errorf("pre-flight checks failed: %s", failMsg)
+			s.updateStateOnStartError(agentID, pfErr)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, errCode, failMsg)
+			return pfErr
+		}
+	} else {
+		if err := s.checkRuntimePrerequisites(m); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_RUNTIME_PREREQUISITES", err.Error())
+			return err
+		}
+		if err := s.validateRequiredEnv(m); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_ENV_MISSING", err.Error())
+			return err
+		}
+		if err := s.ensurePortsAvailable(m.Network.Ports); err != nil {
+			s.updateStateOnStartError(agentID, err)
+			s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_PORT_CONFLICT", err.Error())
+			return err
+		}
+	}
+
+	result, runErr := s.runner.Run(ctx, m.Runtime.Start.Command)
+	s.appendCommandLog(agentID, "start", m.Runtime.Start.Command, result, runErr)
+	if runErr != nil {
+		triage, triageErr := s.HandleFailure(ctx, agentID, runErr.Error())
+		if triageErr == nil {
+			s.appendLog(agentID, fmt.Sprintf("triage summary: %s", triage.Summary))
+		}
+		s.updateStateOnStartError(agentID, runErr)
+		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_START_FAILED", runErr.Error())
+		return runErr
+	}
+
+	// Auto-mount memories linked to this agent.
+	s.autoMountMemories(agentID)
+
+	s.mu.Lock()
+	state = s.states[agentID]
+	state.Runtime = RuntimeStateRunning
+	state.Health = HealthStateHealthy
+	state.LastError = ""
+	state.LastTriageSummary = ""
+	state.NeedsRemoteDiagnosis = false
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+	delete(s.restarts, agentID)
+	delete(s.cooldowns, agentID)
+	s.mu.Unlock()
+	s.recordAudit("", "system", "start", agentID, AuditResultSuccess, "", "start completed")
+
+	return nil
+}
+
+func (s *Service) Stop(ctx context.Context, agentID string) error {
+	m, state, err := s.getManifestAndState(agentID)
+	if err != nil {
+		return err
+	}
+	if state.Runtime == RuntimeStateStopped {
+		return ErrAlreadyStopped
+	}
+
+	result, runErr := s.runner.Run(ctx, m.Runtime.Stop.Command)
+	s.appendCommandLog(agentID, "stop", m.Runtime.Stop.Command, result, runErr)
+	if runErr != nil {
+		s.mu.Lock()
+		state = s.states[agentID]
+		state.LastError = runErr.Error()
+		state.UpdatedAt = s.now()
+		s.states[agentID] = state
+		s.mu.Unlock()
+		s.recordAudit("", "system", "stop", agentID, AuditResultFailure, "E_STOP_FAILED", runErr.Error())
+		return runErr
+	}
+
+	// Auto-unmount all memories for this agent.
+	s.autoUnmountMemories(agentID)
+
+	s.mu.Lock()
+	state = s.states[agentID]
+	state.Runtime = RuntimeStateStopped
+	state.Health = HealthStateUnknown
+	state.LastError = ""
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+	s.mu.Unlock()
+	s.recordAudit("", "system", "stop", agentID, AuditResultSuccess, "", "stop completed")
+
+	return nil
+}

--- a/daemon/internal/lifecycle/upgrade.go
+++ b/daemon/internal/lifecycle/upgrade.go
@@ -1,0 +1,188 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"carrier/daemon/internal/manifest"
+)
+
+type upgradeBackup struct {
+	AgentID           string            `json:"agent_id"`
+	CreatedAt         time.Time         `json:"created_at"`
+	CurrentVersion    string            `json:"current_version"`
+	EnvVarKeys        []string          `json:"env_var_keys"`
+	MemoryAttachments []string          `json:"memory_attachments"`
+	RuntimeState      AgentState        `json:"runtime_state"`
+	Config            manifest.Manifest `json:"config"`
+}
+
+func (s *Service) Upgrade(ctx context.Context, agentID string) (UpgradeResult, error) {
+	m, state, err := s.getManifestAndState(agentID)
+	if err != nil {
+		return UpgradeResult{}, err
+	}
+	fromVersion := state.Version
+	if state.Install != InstallStateInstalled {
+		return UpgradeResult{}, ErrNotInstalled
+	}
+	if state.Runtime == RuntimeStateRunning {
+		return UpgradeResult{}, ErrAgentRunning
+	}
+	if strings.TrimSpace(m.Runtime.Upgrade.Command) == "" {
+		return UpgradeResult{}, ErrUpgradeNotSupported
+	}
+
+	strategy := strings.TrimSpace(m.Upgrade.Strategy)
+	if strategy == "" {
+		strategy = manifest.UpgradeStrategyInPlaceOrReinstall
+	}
+	if strategy != manifest.UpgradeStrategyInPlaceOrReinstall {
+		return UpgradeResult{}, fmt.Errorf("%w: unsupported strategy %q; supported: %q", ErrUpgradeStrategyUnsupported, strategy, manifest.UpgradeStrategyInPlaceOrReinstall)
+	}
+
+	toVersion, err := nextPatchVersion(fromVersion)
+	if err != nil {
+		s.updateStateOnUpgradeError(agentID, fmt.Errorf("upgrade target version calculation failed: %w", err))
+		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_VERSION", err.Error())
+		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, err
+	}
+
+	if err := s.checkRuntimePrerequisites(m); err != nil {
+		updateErr := fmt.Errorf("%w: %v", ErrUpgradeFailed, err)
+		s.updateStateOnUpgradeError(agentID, updateErr)
+		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_PREREQUISITES", err.Error())
+		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, updateErr
+	}
+
+	attachments := s.getMemoryAttachments(agentID)
+	backupPath, backupErr := s.createUpgradeBackup(agentID, m, state, attachments)
+	if backupErr != nil {
+		updateErr := fmt.Errorf("%w: backup failed: %v", ErrUpgradeFailed, backupErr)
+		s.updateStateOnUpgradeError(agentID, updateErr)
+		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_BACKUP", backupErr.Error())
+		return UpgradeResult{AgentID: agentID, FromVersion: fromVersion}, updateErr
+	}
+	s.recordAudit("", "system", "upgrade", agentID, AuditResultSuccess, "", fmt.Sprintf("upgrade_start backup=%q command=%q", backupPath, m.Runtime.Upgrade.Command))
+
+	result, runErr := s.runner.Run(ctx, m.Runtime.Upgrade.Command)
+	s.appendCommandLog(agentID, "upgrade", m.Runtime.Upgrade.Command, result, runErr)
+	if runErr != nil {
+		updateErr := s.formatUpgradeFailure(runErr, backupPath)
+		s.updateStateOnUpgradeError(agentID, updateErr)
+		s.recordAudit("", "system", "upgrade", agentID, AuditResultFailure, "E_UPGRADE_FAILED", fmt.Sprintf("upgrade_failure backup=%q error=%q", backupPath, runErr.Error()))
+		return UpgradeResult{
+			AgentID:     agentID,
+			FromVersion: fromVersion,
+			ToVersion:   fromVersion,
+			BackupPath:  backupPath,
+		}, updateErr
+	}
+
+	s.mu.Lock()
+	state = s.states[agentID]
+	state.Version = toVersion
+	state.LastError = ""
+	state.Runtime = RuntimeStateStopped
+	state.Health = HealthStateUnknown
+	state.LastTriageSummary = ""
+	state.NeedsRemoteDiagnosis = false
+	state.UpdatedAt = s.now()
+	s.states[agentID] = state
+	s.restarts[agentID] = nil
+	delete(s.cooldowns, agentID)
+	s.memoryLinks[agentID] = append([]string(nil), attachments...)
+	s.mu.Unlock()
+
+	s.recordAudit("", "system", "upgrade", agentID, AuditResultSuccess, "", fmt.Sprintf("upgrade_success from=%s to=%s backup=%q", fromVersion, toVersion, backupPath))
+	return UpgradeResult{
+		AgentID:     agentID,
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+		BackupPath:  backupPath,
+	}, nil
+}
+
+func (s *Service) formatUpgradeFailure(runErr error, backupPath string) error {
+	detail := fmt.Sprintf("upgrade failed: %v", runErr)
+	if backupPath != "" {
+		return fmt.Errorf("%s. backup captured at %s; manual rollback guidance: restore from this backup path before retrying", detail, backupPath)
+	}
+	return fmt.Errorf("%s. no backup was captured; manual rollback guidance unavailable", detail)
+}
+
+func nextPatchVersion(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid version format %q, expected MAJOR.MINOR.PATCH", version)
+	}
+
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid patch version %q: %w", parts[2], err)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("invalid major version %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("invalid minor version %q: %w", parts[1], err)
+	}
+
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch+1), nil
+}
+
+func (s *Service) envVarKeys(m manifest.Manifest) []string {
+	seen := make(map[string]struct{}, len(m.Env.Required)+len(m.Env.Optional))
+	keys := make([]string, 0, len(m.Env.Required)+len(m.Env.Optional))
+	for _, envVar := range m.Env.Required {
+		if _, ok := seen[envVar.Name]; !ok {
+			seen[envVar.Name] = struct{}{}
+			keys = append(keys, envVar.Name)
+		}
+	}
+	for _, envVar := range m.Env.Optional {
+		if _, ok := seen[envVar.Name]; !ok {
+			seen[envVar.Name] = struct{}{}
+			keys = append(keys, envVar.Name)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *Service) createUpgradeBackup(agentID string, m manifest.Manifest, state AgentState, attachments []string) (string, error) {
+	if err := os.MkdirAll(s.diagnoseDir, 0o755); err != nil {
+		return "", fmt.Errorf("create diagnose dir: %w", err)
+	}
+
+	fileName := fmt.Sprintf("%s-pre-upgrade-%s.json", agentID, s.now().UTC().Format("2006-01-02T15-04-05Z"))
+	filePath := filepath.Join(s.diagnoseDir, fileName)
+	backup := upgradeBackup{
+		AgentID:           agentID,
+		CreatedAt:         s.now().UTC(),
+		CurrentVersion:    state.Version,
+		EnvVarKeys:        s.envVarKeys(m),
+		MemoryAttachments: append([]string(nil), attachments...),
+		RuntimeState:      state,
+		Config:            m,
+	}
+
+	content, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal upgrade backup: %w", err)
+	}
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		return "", fmt.Errorf("write upgrade backup: %w", err)
+	}
+
+	return filePath, nil
+}


### PR DESCRIPTION
Closes #231

Split the ~1200-line `service.go` into 7 focused files:
- `service.go` — Service struct, New(), Options, core state management
- `install.go` — Install logic
- `start_stop.go` — Start/Stop logic
- `upgrade.go` — Upgrade logic, version helpers, backup
- `memory.go` — Memory attachment methods
- `audit.go` — Audit buffer and logging
- `helpers.go` — Internal helper functions

No logic changes — pure file reorganization. All tests pass.