### PR TITLE
test(gateway): add webhook parser error-path coverage for malformed/missing fields

### DIFF
--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -97,3 +97,100 @@ describe("gateway HTTP server", () => {
     expect(body.fileRef).toBe("/tmp/test.zip");
   });
 });
+
+describe("webhook parser error paths", () => {
+  test("telegram - missing message field -> 400 parse error", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/telegram`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ update_id: 123 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("could not parse webhook body");
+  });
+
+  test("telegram - missing chat.id -> 400 parse error", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/telegram`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { text: "/help" } }),
+    });
+    // chat is undefined so chatId becomes "" which triggers null return
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("could not parse webhook body");
+  });
+
+  test("telegram - missing text -> non-command acknowledged", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/telegram`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { chat: { id: 1 } } }),
+    });
+    // text defaults to "" via String(undefined ?? ""), chatId = "1"
+    // Parser returns null when text is empty
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("could not parse webhook body");
+  });
+
+  test("discord - empty payload -> 400 parse error", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/discord`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("could not parse webhook body");
+  });
+
+  test("feishu - missing event.message -> 400 parse error", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/feishu`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: {} }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("could not parse webhook body");
+  });
+
+  test("feishu - malformed message.content JSON -> handles gracefully", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/feishu`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: {
+          message: {
+            chat_id: "chat1",
+            content: "{not valid json",
+          },
+        },
+      }),
+    });
+    // Malformed JSON falls through to raw content, which doesn't start with /
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("invalid JSON body -> 400", async () => {
+    const { base } = setup();
+    const res = await fetch(`${base}/webhook/telegram`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json at all",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid JSON body");
+  });
+});


### PR DESCRIPTION
Adds error-path tests for webhook parsers:
- Telegram: missing message, missing chat.id, missing text, invalid JSON
- Discord: empty payload
- Feishu: missing event.message, malformed content JSON

All 14 server tests pass. Depends on #435.

Closes #437