### PR TITLE
feat: add gateway server runtime and HTTP daemon client path

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,29 @@ See `CONTRIBUTING.md` for command examples and required process. For security vu
 - Gateway checks:
   - `cd gateway`
   - `bun run check`
+  - `bun test`
 - Full local flow from repo root (mandatory before pushing):
   - `./scripts/run-all-tests.sh`
 
 Optional local flow from repo root:
   - `cd gateway && bun install && bun run check && cd ../daemon && go test ./...`
+
+### Gateway runtime server (Bun)
+
+- Start gateway runtime HTTP server:
+  - `cd gateway`
+  - `bun run dev`
+- Health route:
+  - `GET /healthz`
+- Command ingress route:
+  - `POST /command` with JSON body `{ "input": "<provider> <chat_id> <request_id> <command> [...args]" }`
+- Artifact download route:
+  - `GET /downloads/<token>/<filename>`
+
+Runtime environment variables:
+- `CARRIER_DAEMON_BASE_URL` (default: `http://127.0.0.1:9090`)
+- `CARRIER_GATEWAY_HOST` (default: `127.0.0.1`)
+- `CARRIER_GATEWAY_PORT` (default: `8787`)
 
 #### Merge Queue
 - This repository supports GitHub Merge Queue for `main`.

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "bun run src/example.ts",
+    "dev": "bun run src/server.ts",
+    "example": "bun run src/example.ts",
     "check": "bunx tsc --noEmit",
     "test": "bun test",
     "ci": "bun run check && bun test"

--- a/gateway/src/daemon/http_client.test.ts
+++ b/gateway/src/daemon/http_client.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { DaemonClientError, RemoteDiagnosisNotNeededError } from "./client";
+import { HttpDaemonClient, loadDaemonBaseUrl } from "./http_client";
+
+function makeFetch(response: Response): typeof fetch {
+  return (async () => response.clone()) as unknown as typeof fetch;
+}
+
+describe("loadDaemonBaseUrl", () => {
+  test("uses default when env is missing", () => {
+    expect(loadDaemonBaseUrl({})).toBe("http://127.0.0.1:9090");
+  });
+
+  test("trims trailing slash from env value", () => {
+    expect(loadDaemonBaseUrl({ CARRIER_DAEMON_BASE_URL: "http://localhost:8080/" })).toBe("http://localhost:8080");
+  });
+});
+
+describe("HttpDaemonClient", () => {
+  test("listAgents parses envelope payload", async () => {
+    const fetchMock = makeFetch(new Response(JSON.stringify({
+      agents: [
+        {
+          id: "openclaw",
+          name: "OpenClaw",
+          version: "1.0.0",
+          installed: true,
+          runtimeState: "running",
+          health: "healthy",
+          needsRemoteDiagnosis: false,
+          updatedAt: "2026-02-14T16:00:00.000Z",
+        },
+      ],
+    }), { status: 200 }));
+    const client = new HttpDaemonClient("http://daemon.local", fetchMock);
+
+    const agents = await client.listAgents({ actor: "telegram:100", requestId: "req-1" });
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.id).toBe("openclaw");
+    expect(agents[0]?.runtimeState).toBe("running");
+  });
+
+  test("maps daemon error envelope to DaemonClientError", async () => {
+    const fetchMock = makeFetch(new Response(JSON.stringify({
+      error: {
+        code: "E_ALREADY_STOPPED",
+        message: "agent is already stopped",
+      },
+    }), { status: 409 }));
+    const client = new HttpDaemonClient("http://daemon.local", fetchMock);
+
+    await expect(client.stopAgent("openclaw", { actor: "telegram:100", requestId: "req-2" }))
+      .rejects.toBeInstanceOf(DaemonClientError);
+
+    try {
+      await client.stopAgent("openclaw", { actor: "telegram:100", requestId: "req-2" });
+    } catch (error) {
+      const daemonError = error as DaemonClientError;
+      expect(daemonError.code).toBe("E_ALREADY_STOPPED");
+      expect(daemonError.message).toContain("already stopped");
+    }
+  });
+
+  test("maps status-only error to fallback code", async () => {
+    const fetchMock = makeFetch(new Response("not found", { status: 404 }));
+    const client = new HttpDaemonClient("http://daemon.local", fetchMock);
+
+    try {
+      await client.listAgents({ actor: "telegram:100", requestId: "req-3" });
+    } catch (error) {
+      const daemonError = error as DaemonClientError;
+      expect(daemonError.code).toBe("E_AGENT_NOT_FOUND");
+    }
+  });
+
+  test("maps E_REMOTE_DIAG_NOT_NEEDED to specialized error", async () => {
+    const fetchMock = makeFetch(new Response(JSON.stringify({
+      error: {
+        code: "E_REMOTE_DIAG_NOT_NEEDED",
+        message: "remote diagnosis is not required for this agent",
+      },
+    }), { status: 400 }));
+    const client = new HttpDaemonClient("http://daemon.local", fetchMock);
+
+    await expect(client.createRemoteDiagnosisHandoff({
+      agentId: "openclaw",
+      consent: true,
+      actor: "telegram:100",
+      requestId: "req-4",
+    })).rejects.toBeInstanceOf(RemoteDiagnosisNotNeededError);
+  });
+});

--- a/gateway/src/daemon/http_client.ts
+++ b/gateway/src/daemon/http_client.ts
@@ -1,0 +1,184 @@
+import {
+  DaemonClientError,
+  RemoteDiagnosisNotNeededError,
+  type CreateRemoteDiagnosisHandoffInput,
+  type DaemonAgentState,
+  type DaemonClient,
+  type DiagnoseResult,
+  type LogsResult,
+  type RemoteDiagnosisHandoff,
+  type RequestContext,
+  type UpgradeResult,
+} from "./client";
+
+const DEFAULT_DAEMON_BASE_URL = "http://127.0.0.1:9090";
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type DaemonErrorEnvelope = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+type DaemonAgentsResponse = {
+  agents?: DaemonAgentState[];
+};
+
+type DaemonStatusesResponse = {
+  statuses?: DaemonAgentState[];
+};
+
+export function loadDaemonBaseUrl(env: Record<string, string | undefined> = process.env): string {
+  const raw = env.CARRIER_DAEMON_BASE_URL?.trim() || DEFAULT_DAEMON_BASE_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+export class HttpDaemonClient implements DaemonClient {
+  constructor(
+    private readonly baseUrl = loadDaemonBaseUrl(),
+    private readonly fetchImpl: FetchLike = fetch,
+  ) {}
+
+  async listAgents(ctx: RequestContext): Promise<DaemonAgentState[]> {
+    const data = await this.requestJSON<DaemonAgentsResponse | DaemonAgentState[]>(
+      "GET",
+      "/api/v1/agents",
+      undefined,
+      ctx,
+    );
+    if (Array.isArray(data)) {
+      return data;
+    }
+    return data.agents ?? [];
+  }
+
+  async installAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    await this.requestJSON("POST", `/api/v1/agents/${encodeURIComponent(agentId)}/install`, undefined, ctx);
+  }
+
+  async startAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    await this.requestJSON("POST", `/api/v1/agents/${encodeURIComponent(agentId)}/start`, undefined, ctx);
+  }
+
+  async stopAgent(agentId: string, ctx: RequestContext): Promise<void> {
+    await this.requestJSON("POST", `/api/v1/agents/${encodeURIComponent(agentId)}/stop`, undefined, ctx);
+  }
+
+  async getStatus(agentId: string | undefined, ctx: RequestContext): Promise<DaemonAgentState[]> {
+    const path = agentId
+      ? `/api/v1/agents/${encodeURIComponent(agentId)}/status`
+      : "/api/v1/agents/status";
+    const data = await this.requestJSON<DaemonStatusesResponse | DaemonAgentState[]>( "GET", path, undefined, ctx);
+    if (Array.isArray(data)) {
+      return data;
+    }
+    return data.statuses ?? [];
+  }
+
+  async getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult> {
+    const safeTail = Number.isFinite(tail) && tail > 0 ? Math.floor(tail) : 200;
+    return await this.requestJSON<LogsResult>(
+      "GET",
+      `/api/v1/agents/${encodeURIComponent(agentId)}/logs?tail=${safeTail}`,
+      undefined,
+      ctx,
+    );
+  }
+
+  async upgradeAgent(agentId: string, ctx: RequestContext): Promise<UpgradeResult> {
+    return await this.requestJSON<UpgradeResult>(
+      "POST",
+      `/api/v1/agents/${encodeURIComponent(agentId)}/upgrade`,
+      undefined,
+      ctx,
+    );
+  }
+
+  async diagnoseAgent(agentId: string, ctx: RequestContext): Promise<DiagnoseResult> {
+    return await this.requestJSON<DiagnoseResult>(
+      "POST",
+      `/api/v1/agents/${encodeURIComponent(agentId)}/diagnose`,
+      undefined,
+      ctx,
+    );
+  }
+
+  async createRemoteDiagnosisHandoff(input: CreateRemoteDiagnosisHandoffInput): Promise<RemoteDiagnosisHandoff> {
+    return await this.requestJSON<RemoteDiagnosisHandoff>(
+      "POST",
+      "/api/v1/diagnosis/handoffs",
+      input,
+      {
+        actor: input.actor,
+        requestId: input.requestId,
+      },
+    );
+  }
+
+  private async requestJSON<T>(
+    method: string,
+    path: string,
+    body: unknown,
+    ctx: RequestContext,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchImpl(url, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        "x-carrier-actor": ctx.actor,
+        "x-carrier-request-id": ctx.requestId,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw await this.toClientError(response);
+    }
+
+    const raw = await response.text();
+    if (!raw.trim()) {
+      return {} as T;
+    }
+    return JSON.parse(raw) as T;
+  }
+
+  private async toClientError(response: Response): Promise<DaemonClientError> {
+    const fallbackCode = this.mapStatusToCode(response.status);
+    let message = `daemon request failed with status ${response.status}`;
+    let code = fallbackCode;
+
+    try {
+      const payload = (await response.json()) as DaemonErrorEnvelope;
+      if (payload?.error?.code) {
+        code = payload.error.code;
+      }
+      if (payload?.error?.message) {
+        message = payload.error.message;
+      }
+    } catch {
+      // Keep fallback code/message when response is not JSON.
+    }
+
+    if (code === "E_REMOTE_DIAG_NOT_NEEDED") {
+      return new RemoteDiagnosisNotNeededError(message);
+    }
+    return new DaemonClientError(code, message);
+  }
+
+  private mapStatusToCode(status: number): string {
+    switch (status) {
+      case 400:
+        return "E_USAGE";
+      case 401:
+      case 403:
+        return "E_SESSION_REQUIRED";
+      case 404:
+        return "E_AGENT_NOT_FOUND";
+      default:
+        return "E_COMMAND_FAILED";
+    }
+  }
+}

--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryDaemonClient } from "./daemon/client";
+import { HttpDaemonClient } from "./daemon/http_client";
+import { DownloadTokenStore } from "./downloads/token_store";
+import { SessionStore } from "./session/store";
+import {
+  composeMiddleware,
+  createGatewayRuntime,
+  createRuntimeDependencies,
+  requestIdMiddleware,
+  type GatewayRequestContext,
+} from "./server";
+
+function makeDeps() {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+describe("composeMiddleware", () => {
+  test("runs middleware in deterministic order", async () => {
+    const trace: string[] = [];
+    const deps = makeDeps();
+
+    const middlewares = [
+      async (_ctx: GatewayRequestContext, next: () => Promise<Response>) => {
+        trace.push("mw1:before");
+        const response = await next();
+        trace.push("mw1:after");
+        return response;
+      },
+      async (_ctx: GatewayRequestContext, next: () => Promise<Response>) => {
+        trace.push("mw2:before");
+        const response = await next();
+        trace.push("mw2:after");
+        return response;
+      },
+    ];
+
+    const handler = composeMiddleware(middlewares, async () => {
+      trace.push("handler");
+      return new Response("ok");
+    });
+
+    await handler({
+      request: new Request("http://gateway.local/healthz"),
+      requestId: "",
+      deps,
+    });
+
+    expect(trace).toEqual([
+      "mw1:before",
+      "mw2:before",
+      "handler",
+      "mw2:after",
+      "mw1:after",
+    ]);
+  });
+});
+
+describe("runtime dependencies", () => {
+  test("uses HTTP daemon client by default for runtime path", () => {
+    const deps = createRuntimeDependencies();
+    expect(deps.daemon).toBeInstanceOf(HttpDaemonClient);
+    deps.downloads.stopPeriodicCleanup();
+  });
+});
+
+describe("gateway runtime routes", () => {
+  test("requestId middleware sets header", async () => {
+    const deps = makeDeps();
+    const runtime = createGatewayRuntime({
+      deps,
+      middlewares: [requestIdMiddleware],
+    });
+
+    const response = await runtime.fetch(new Request("http://gateway.local/healthz", {
+      headers: {
+        "x-request-id": "req-fixed",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-request-id")).toBe("req-fixed");
+  });
+
+  test("download route resolves valid token and enforces single-use", async () => {
+    const deps = makeDeps();
+    const filePath = `/tmp/gateway-download-${crypto.randomUUID()}.txt`;
+    await Bun.write(filePath, "hello-download");
+    const token = deps.downloads.issue(filePath, 300, true);
+    const runtime = createGatewayRuntime({ deps });
+
+    const first = await runtime.fetch(new Request(`http://gateway.local${deps.downloads.toDownloadURL(token)}`));
+    expect(first.status).toBe(200);
+    expect(await first.text()).toBe("hello-download");
+
+    const second = await runtime.fetch(new Request(`http://gateway.local${deps.downloads.toDownloadURL(token)}`));
+    expect(second.status).toBe(404);
+  });
+
+  test("download route rejects token filename mismatch", async () => {
+    const deps = makeDeps();
+    const filePath = `/tmp/gateway-download-${crypto.randomUUID()}.txt`;
+    await Bun.write(filePath, "file-content");
+    const token = deps.downloads.issue(filePath, 300, false);
+    const runtime = createGatewayRuntime({ deps });
+
+    const response = await runtime.fetch(new Request(`http://gateway.local/downloads/${token.token}/wrong-name.txt`));
+    expect(response.status).toBe(400);
+    const payload = await response.json() as { errorCode?: string };
+    expect(payload.errorCode).toBe("E_DOWNLOAD_FILE_MISMATCH");
+  });
+
+  test("command route executes command pipeline", async () => {
+    const deps = makeDeps();
+    deps.sessions.registerPairCode("pair-ok", 300);
+    const runtime = createGatewayRuntime({ deps });
+
+    const pairResponse = await runtime.fetch(new Request("http://gateway.local/command", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: "telegram 100 req-1 /pair pair-ok" }),
+    }));
+    const pairPayload = await pairResponse.json() as { result: string };
+    expect(pairPayload.result).toBe("ok");
+
+    const agentsResponse = await runtime.fetch(new Request("http://gateway.local/command", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: "telegram 100 req-2 /agents" }),
+    }));
+    const agentsPayload = await agentsResponse.json() as { result: string; message: string };
+    expect(agentsPayload.result).toBe("ok");
+    expect(agentsPayload.message).toContain("listed");
+  });
+});

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -1,0 +1,241 @@
+import { safeHandleCommand, type GatewayDependencies } from "./index";
+import { HttpDaemonClient } from "./daemon/http_client";
+import { DownloadTokenStore } from "./downloads/token_store";
+import { SessionStore } from "./session/store";
+
+export type GatewayRequestContext = {
+  request: Request;
+  requestId: string;
+  deps: GatewayDependencies;
+};
+
+export type GatewayHandler = (ctx: GatewayRequestContext) => Promise<Response>;
+
+export type GatewayMiddleware = (
+  ctx: GatewayRequestContext,
+  next: () => Promise<Response>,
+) => Promise<Response>;
+
+type ReadFileFn = (fileRef: string) => Promise<Blob | null>;
+
+export type GatewayRuntimeOptions = {
+  deps?: Partial<GatewayDependencies>;
+  middlewares?: GatewayMiddleware[];
+  readFile?: ReadFileFn;
+};
+
+export type GatewayRuntime = {
+  deps: GatewayDependencies;
+  fetch: (request: Request) => Promise<Response>;
+};
+
+export function composeMiddleware(middlewares: GatewayMiddleware[], handler: GatewayHandler): GatewayHandler {
+  return async (ctx: GatewayRequestContext): Promise<Response> => {
+    let index = -1;
+    const dispatch = async (middlewareIndex: number): Promise<Response> => {
+      if (middlewareIndex <= index) {
+        throw new Error("next() called multiple times");
+      }
+      index = middlewareIndex;
+      const middleware = middlewares[middlewareIndex];
+      if (!middleware) {
+        return handler(ctx);
+      }
+      return await middleware(ctx, () => dispatch(middlewareIndex + 1));
+    };
+    return await dispatch(0);
+  };
+}
+
+export const requestIdMiddleware: GatewayMiddleware = async (ctx, next) => {
+  const incoming = ctx.request.headers.get("x-request-id")?.trim();
+  ctx.requestId = incoming && incoming.length > 0 ? incoming : crypto.randomUUID();
+  const response = await next();
+  response.headers.set("x-request-id", ctx.requestId);
+  return response;
+};
+
+export function createRuntimeDependencies(overrides: Partial<GatewayDependencies> = {}): GatewayDependencies {
+  return {
+    daemon: overrides.daemon ?? new HttpDaemonClient(),
+    sessions: overrides.sessions ?? new SessionStore(),
+    downloads: overrides.downloads ?? new DownloadTokenStore().startPeriodicCleanup(),
+    rateLimiter: overrides.rateLimiter,
+  };
+}
+
+export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): GatewayRuntime {
+  const deps = createRuntimeDependencies(options.deps);
+  const readFile = options.readFile ?? defaultReadFile;
+  const middlewares = options.middlewares ?? [requestIdMiddleware];
+
+  const router: GatewayHandler = async (ctx) => {
+    const url = new URL(ctx.request.url);
+    if (ctx.request.method === "GET" && url.pathname === "/healthz") {
+      return jsonResponse({
+        status: "ok",
+      });
+    }
+
+    if (ctx.request.method === "POST" && url.pathname === "/command") {
+      const commandInput = await parseCommandInput(ctx.request);
+      if (!commandInput) {
+        return jsonResponse({
+          requestId: ctx.requestId,
+          result: "error",
+          errorCode: "E_USAGE",
+          message: "request body must provide command input",
+        }, 400);
+      }
+      const response = await safeHandleCommand(commandInput, deps);
+      return jsonResponse(response);
+    }
+
+    if (ctx.request.method === "GET" && url.pathname.startsWith("/downloads/")) {
+      return await handleDownloadRequest(ctx, url, readFile);
+    }
+
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_NOT_FOUND",
+      message: "route not found",
+    }, 404);
+  };
+
+  const handler = composeMiddleware(middlewares, router);
+
+  return {
+    deps,
+    fetch: async (request: Request) => await handler({
+      request,
+      requestId: "",
+      deps,
+    }),
+  };
+}
+
+export type StartGatewayServerOptions = {
+  port?: number;
+  hostname?: string;
+  deps?: Partial<GatewayDependencies>;
+  middlewares?: GatewayMiddleware[];
+};
+
+export function startGatewayServer(options: StartGatewayServerOptions = {}): ReturnType<typeof Bun.serve> {
+  const runtime = createGatewayRuntime({
+    deps: options.deps,
+    middlewares: options.middlewares,
+  });
+  const port = options.port ?? parsePort(process.env.CARRIER_GATEWAY_PORT, 8787);
+  const hostname = options.hostname ?? process.env.CARRIER_GATEWAY_HOST ?? "127.0.0.1";
+  return Bun.serve({
+    port,
+    hostname,
+    fetch: runtime.fetch,
+  });
+}
+
+async function handleDownloadRequest(
+  ctx: GatewayRequestContext,
+  url: URL,
+  readFile: ReadFileFn,
+): Promise<Response> {
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 3 || parts[0] !== "downloads") {
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_USAGE",
+      message: "invalid download path",
+    }, 400);
+  }
+
+  const token = parts[1] ?? "";
+  const requestedFileName = decodeURIComponent(parts[2] ?? "");
+  const resolved = ctx.deps.downloads.consume(token);
+  if (!resolved) {
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_DOWNLOAD_TOKEN_INVALID",
+      message: "download token is invalid or expired",
+    }, 404);
+  }
+
+  const expectedFileName = resolved.fileRef.split("/").pop() || "artifact.bin";
+  if (requestedFileName !== expectedFileName) {
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_DOWNLOAD_FILE_MISMATCH",
+      message: "requested filename does not match token artifact",
+    }, 400);
+  }
+
+  const blob = await readFile(resolved.fileRef);
+  if (!blob) {
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_DOWNLOAD_NOT_FOUND",
+      message: "artifact file was not found",
+    }, 404);
+  }
+
+  const headers = new Headers();
+  headers.set("content-type", blob.type || "application/octet-stream");
+  headers.set("content-disposition", `attachment; filename="${expectedFileName}"`);
+  return new Response(blob, {
+    status: 200,
+    headers,
+  });
+}
+
+async function defaultReadFile(fileRef: string): Promise<Blob | null> {
+  const file = Bun.file(fileRef);
+  if (!(await file.exists())) {
+    return null;
+  }
+  return file;
+}
+
+async function parseCommandInput(request: Request): Promise<string | null> {
+  const contentType = request.headers.get("content-type")?.toLowerCase() || "";
+  if (contentType.includes("application/json")) {
+    try {
+      const payload = await request.json() as { input?: unknown };
+      if (typeof payload.input === "string" && payload.input.trim().length > 0) {
+        return payload.input;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  const raw = (await request.text()).trim();
+  return raw.length > 0 ? raw : null;
+}
+
+function parsePort(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(raw || "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+if (import.meta.main) {
+  const server = startGatewayServer();
+  console.log(`gateway server listening on http://${server.hostname}:${server.port}`);
+}


### PR DESCRIPTION
## Summary
- add a Bun gateway server runtime entrypoint in `gateway/src/server.ts`
- add request middleware composition and default `x-request-id` middleware with deterministic order coverage
- implement download-token HTTP route `GET /downloads/<token>/<filename>` with token consume + filename validation
- implement daemon HTTP transport client with base URL config (`CARRIER_DAEMON_BASE_URL`) in `gateway/src/daemon/http_client.ts`
- add daemon error-envelope/status mapping to gateway command-contract errors
- switch non-test runtime dependency defaults to real `HttpDaemonClient` (tests can still inject in-memory daemon client)
- update gateway scripts: `bun run dev` now starts the runtime server, keep `bun run example`
- update README runtime docs for gateway server routes and env vars

## Test Commands and Output Evidence
- `cd gateway && bun run check` ✅ passed
- `cd gateway && bun test` ✅ passed
  - `111 pass`
  - `0 fail`

Closes #397
Closes #398
Closes #399
Closes #401
Closes #402
