### PR TITLE
test(automation): add unit coverage for kanban bucket classification rules

### DIFF
--- a/scripts/classify-bucket.js
+++ b/scripts/classify-bucket.js
@@ -1,0 +1,56 @@
+/**
+ * classifyBucket — Classify a GitHub issue into a kanban bucket.
+ *
+ * Extracted from .github/workflows/carrier-one-hour-kanban.yml for testability.
+ *
+ * @param {{ title?: string; labels?: Array<{ name?: string }> }} item
+ * @returns {'Hotfix' | 'Decomposition' | 'Unscheduled'}
+ */
+function classifyBucket(item) {
+  const title = String(item.title || "").toLowerCase();
+  const labels = new Set(
+    (item.labels || []).map((label) => String(label.name || "").toLowerCase()),
+  );
+
+  if (
+    labels.has("unscheduled") ||
+    labels.has("backlog") ||
+    labels.has("pending") ||
+    title.includes("pending")
+  ) {
+    return "Unscheduled";
+  }
+
+  if (
+    labels.has("review") ||
+    labels.has("review-followup") ||
+    labels.has("review followup") ||
+    labels.has("review_followup") ||
+    labels.has("quickfix") ||
+    labels.has("hotfix") ||
+    labels.has("test") ||
+    title.includes("[review-followup]") ||
+    title.includes("review-followup") ||
+    title.startsWith("test:") ||
+    title.startsWith("[phase 1][risk]")
+  ) {
+    return "Hotfix";
+  }
+
+  if (
+    labels.has("plan") ||
+    labels.has("planning") ||
+    labels.has("decomposition") ||
+    /^\[(plan|task)\]/i.test(item.title || "") ||
+    /^\[task\]|^\[plan\]/i.test(item.title || "") ||
+    /^\[phase [0-9]/i.test(item.title || "") ||
+    /release\s+workflow\s+follow-up/i.test(title) ||
+    /\[(?:A|B|C)\d+\]/i.test(item.title || "")
+  ) {
+    return "Decomposition";
+  }
+
+  return "Hotfix";
+}
+
+module.exports = { classifyBucket };

--- a/scripts/classify-bucket.test.js
+++ b/scripts/classify-bucket.test.js
@@ -1,0 +1,122 @@
+const { classifyBucket } = require("./classify-bucket");
+
+// Simple test runner
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`FAIL: ${message}`);
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  assert(
+    actual === expected,
+    `${label}: expected "${expected}", got "${actual}"`,
+  );
+}
+
+// --- Hotfix bucket ---
+assertEqual(
+  classifyBucket({ title: "fix login", labels: [{ name: "hotfix" }] }),
+  "Hotfix",
+  "hotfix label",
+);
+assertEqual(
+  classifyBucket({ title: "fix login", labels: [{ name: "review-followup" }] }),
+  "Hotfix",
+  "review-followup label",
+);
+assertEqual(
+  classifyBucket({ title: "fix login", labels: [{ name: "quickfix" }] }),
+  "Hotfix",
+  "quickfix label",
+);
+assertEqual(
+  classifyBucket({ title: "[review-followup] PR #446: something" }),
+  "Hotfix",
+  "review-followup title pattern",
+);
+assertEqual(
+  classifyBucket({ title: "test: add coverage for X" }),
+  "Hotfix",
+  "test: title prefix",
+);
+assertEqual(
+  classifyBucket({ title: "[Phase 1][Risk] something", labels: [] }),
+  "Hotfix",
+  "[phase 1][risk] title prefix",
+);
+
+// --- Decomposition bucket ---
+assertEqual(
+  classifyBucket({ title: "some plan", labels: [{ name: "plan" }] }),
+  "Decomposition",
+  "plan label",
+);
+assertEqual(
+  classifyBucket({ title: "work", labels: [{ name: "decomposition" }] }),
+  "Decomposition",
+  "decomposition label",
+);
+assertEqual(
+  classifyBucket({ title: "[Plan] breakdown of feature X" }),
+  "Decomposition",
+  "[Plan] title prefix",
+);
+assertEqual(
+  classifyBucket({ title: "[Task] implement Y" }),
+  "Decomposition",
+  "[Task] title prefix",
+);
+assertEqual(
+  classifyBucket({ title: "[Phase 2] next milestone" }),
+  "Decomposition",
+  "[Phase N] title prefix",
+);
+assertEqual(
+  classifyBucket({ title: "Release workflow follow-up tasks" }),
+  "Decomposition",
+  "release workflow follow-up title",
+);
+assertEqual(
+  classifyBucket({ title: "[A1] sub-item" }),
+  "Decomposition",
+  "[A1] code pattern",
+);
+
+// --- Unscheduled bucket ---
+assertEqual(
+  classifyBucket({ title: "future work", labels: [{ name: "unscheduled" }] }),
+  "Unscheduled",
+  "unscheduled label",
+);
+assertEqual(
+  classifyBucket({ title: "future work", labels: [{ name: "backlog" }] }),
+  "Unscheduled",
+  "backlog label",
+);
+assertEqual(
+  classifyBucket({ title: "pending review of something" }),
+  "Unscheduled",
+  "pending in title",
+);
+
+// --- Fallback / edge cases ---
+assertEqual(
+  classifyBucket({ title: "random issue with no labels" }),
+  "Hotfix",
+  "fallback to Hotfix (no matching labels or patterns)",
+);
+assertEqual(
+  classifyBucket({ title: "", labels: [] }),
+  "Hotfix",
+  "empty title and labels fallback",
+);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #458

Extracts `classifyBucket` from the kanban workflow into a testable `scripts/classify-bucket.js` module and adds 18 unit tests covering:
- 6 Hotfix positive cases (labels + title patterns)
- 7 Decomposition positive cases
- 3 Unscheduled positive cases
- 2 fallback/edge cases

Run with: `node scripts/classify-bucket.test.js`