### PR TITLE
feat(gateway): add normalized Telegram/Discord/Feishu parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Key topics covered:
 - `/pair <code>` binds provider chat sessions and enforces session checks before non-pair commands.
 - Gateway forwards `provider`, `chat_id`, and `request_id` into daemon request context for command handling.
 - Logs/diagnose responses can issue short-lived read-only download tokens and URLs.
+- Telegram/Discord/Feishu payload parsers now normalize provider events/interactions into one gateway command DTO shape.
 
 ## Development flow
 - Start work from `origin/main` using a new `codex/*` branch and worktree.

--- a/gateway/src/providers/parsers.e2e.test.ts
+++ b/gateway/src/providers/parsers.e2e.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryDaemonClient } from "../daemon/client";
+import { DownloadTokenStore } from "../downloads/token_store";
+import { safeHandleCommand, type GatewayDependencies } from "../index";
+import { SessionStore } from "../session/store";
+import {
+  parseDiscordPayloadToCommand,
+  parseFeishuEventToCommand,
+  parseTelegramUpdateToCommand,
+  toGatewayInput,
+} from "./parsers";
+
+function buildDeps(): GatewayDependencies {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+describe("provider parser e2e", () => {
+  test("telegram parser output is executable by gateway command path", async () => {
+    const deps = buildDeps();
+    deps.sessions.registerPairCode("tg-code", 300);
+
+    const normalized = parseTelegramUpdateToCommand({
+      update_id: 2001,
+      message: {
+        message_id: 3001,
+        chat: { id: "tg-chat" },
+        text: "/pair tg-code",
+      },
+    });
+    expect(normalized).not.toBeNull();
+
+    const res = await safeHandleCommand(toGatewayInput(normalized!), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("paired");
+  });
+
+  test("discord parser output is executable by gateway command path", async () => {
+    const deps = buildDeps();
+    deps.sessions.registerPairCode("dc-code", 300);
+
+    const normalized = parseDiscordPayloadToCommand({
+      id: "interaction-22",
+      type: 2,
+      channel_id: "dc-chan",
+      data: {
+        name: "pair",
+        options: [{ name: "code", value: "dc-code" }],
+      },
+    });
+    expect(normalized).not.toBeNull();
+
+    const res = await safeHandleCommand(toGatewayInput(normalized!), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("paired");
+  });
+
+  test("feishu parser output is executable by gateway command path", async () => {
+    const deps = buildDeps();
+    deps.sessions.registerPairCode("fs-code", 300);
+
+    const normalized = parseFeishuEventToCommand({
+      header: { event_id: "evt-20" },
+      event: {
+        message: {
+          message_id: "msg-20",
+          chat_id: "fs-chat",
+          content: JSON.stringify({ text: "/pair fs-code" }),
+        },
+      },
+    });
+    expect(normalized).not.toBeNull();
+
+    const res = await safeHandleCommand(toGatewayInput(normalized!), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("paired");
+  });
+});

--- a/gateway/src/providers/parsers.test.ts
+++ b/gateway/src/providers/parsers.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseDiscordPayloadToCommand,
+  parseFeishuEventToCommand,
+  parseTelegramUpdateToCommand,
+  toGatewayInput,
+} from "./parsers";
+
+describe("parseTelegramUpdateToCommand", () => {
+  test("parses basic command update", () => {
+    const parsed = parseTelegramUpdateToCommand({
+      update_id: 1001,
+      message: {
+        message_id: 777,
+        chat: { id: 123456 },
+        text: "/agents",
+      },
+    });
+
+    expect(parsed?.provider).toBe("telegram");
+    expect(parsed?.chatId).toBe("123456");
+    expect(parsed?.command).toBe("/agents");
+    expect(parsed?.args).toEqual([]);
+    expect(parsed?.requestId).toBe("tg-1001-777");
+  });
+
+  test("strips telegram bot suffix from command", () => {
+    const parsed = parseTelegramUpdateToCommand({
+      update_id: 1002,
+      message: {
+        message_id: 778,
+        chat: { id: "chat-1" },
+        text: "/status@CarrierBot openclaw",
+      },
+    });
+
+    expect(parsed?.command).toBe("/status");
+    expect(parsed?.args).toEqual(["openclaw"]);
+  });
+
+  test("returns null when message text is not command", () => {
+    const parsed = parseTelegramUpdateToCommand({
+      update_id: 1003,
+      message: {
+        message_id: 779,
+        chat: { id: "chat-2" },
+        text: "hello",
+      },
+    });
+    expect(parsed).toBeNull();
+  });
+});
+
+describe("parseDiscordPayloadToCommand", () => {
+  test("parses slash interaction payload with option values", () => {
+    const parsed = parseDiscordPayloadToCommand({
+      id: "interaction-1",
+      type: 2,
+      channel_id: "channel-9",
+      data: {
+        name: "upgrade",
+        options: [
+          { name: "agent", value: "openclaw" },
+        ],
+      },
+    });
+
+    expect(parsed?.provider).toBe("discord");
+    expect(parsed?.chatId).toBe("channel-9");
+    expect(parsed?.command).toBe("/upgrade");
+    expect(parsed?.args).toEqual(["openclaw"]);
+    expect(parsed?.requestId).toBe("dc-interaction-1");
+  });
+
+  test("parses message payload with leading mention", () => {
+    const parsed = parseDiscordPayloadToCommand({
+      id: "message-1",
+      channel_id: "channel-7",
+      content: "<@12345> /logs openclaw 50",
+    });
+
+    expect(parsed?.command).toBe("/logs");
+    expect(parsed?.args).toEqual(["openclaw", "50"]);
+  });
+
+  test("returns null when payload has no command text", () => {
+    const parsed = parseDiscordPayloadToCommand({
+      id: "message-2",
+      channel_id: "channel-7",
+      content: "just a text message",
+    });
+    expect(parsed).toBeNull();
+  });
+});
+
+describe("parseFeishuEventToCommand", () => {
+  test("parses text command from feishu message event", () => {
+    const parsed = parseFeishuEventToCommand({
+      header: { event_id: "evt-1" },
+      event: {
+        message: {
+          message_id: "msg-1",
+          chat_id: "oc_chat_1",
+          content: JSON.stringify({ text: "/pair pair-code" }),
+        },
+      },
+    });
+
+    expect(parsed?.provider).toBe("feishu");
+    expect(parsed?.chatId).toBe("oc_chat_1");
+    expect(parsed?.command).toBe("/pair");
+    expect(parsed?.args).toEqual(["pair-code"]);
+    expect(parsed?.requestId).toBe("fs-evt-1-msg-1");
+  });
+
+  test("strips leading mention token in feishu text", () => {
+    const parsed = parseFeishuEventToCommand({
+      header: { event_id: "evt-2" },
+      event: {
+        message: {
+          message_id: "msg-2",
+          chat_id: "oc_chat_2",
+          content: JSON.stringify({ text: "@_user_1 /agents" }),
+        },
+      },
+    });
+
+    expect(parsed?.command).toBe("/agents");
+  });
+
+  test("returns null for non-command feishu payload", () => {
+    const parsed = parseFeishuEventToCommand({
+      type: "url_verification",
+      challenge: "challenge-token",
+    });
+    expect(parsed).toBeNull();
+  });
+});
+
+describe("toGatewayInput", () => {
+  test("renders normalized command into gateway command text", () => {
+    const parsed = parseTelegramUpdateToCommand({
+      update_id: 1004,
+      message: {
+        message_id: 780,
+        chat: { id: 123 },
+        text: "/diagnose openclaw",
+      },
+    });
+    expect(parsed).not.toBeNull();
+    expect(toGatewayInput(parsed!)).toBe("telegram 123 tg-1004-780 /diagnose openclaw");
+  });
+});

--- a/gateway/src/providers/parsers.ts
+++ b/gateway/src/providers/parsers.ts
@@ -1,0 +1,281 @@
+import type { Provider } from "../contracts/commands";
+
+export type NormalizedGatewayCommand = {
+  provider: Provider;
+  chatId: string;
+  requestId: string;
+  command: string;
+  args: string[];
+  rawText: string;
+};
+
+export function toGatewayInput(command: NormalizedGatewayCommand): string {
+  return [
+    command.provider,
+    command.chatId,
+    command.requestId,
+    command.command,
+    ...command.args,
+  ].join(" ");
+}
+
+export function parseTelegramUpdateToCommand(payload: unknown): NormalizedGatewayCommand | null {
+  const update = asRecord(payload);
+  if (!update) {
+    return null;
+  }
+
+  const message =
+    asRecord(update.message) ??
+    asRecord(update.edited_message) ??
+    asRecord(update.channel_post) ??
+    asRecord(update.edited_channel_post);
+  if (!message) {
+    return null;
+  }
+
+  const chat = asRecord(message.chat);
+  const chatId = toID(chat?.id);
+  const rawText = firstString(message.text, message.caption);
+  if (!chatId || !rawText) {
+    return null;
+  }
+
+  const parsed = parseCommandText(rawText);
+  if (!parsed) {
+    return null;
+  }
+
+  const requestId = buildRequestId("tg", toID(update.update_id), toID(message.message_id));
+  return {
+    provider: "telegram",
+    chatId,
+    requestId,
+    command: parsed.command,
+    args: parsed.args,
+    rawText,
+  };
+}
+
+export function parseDiscordPayloadToCommand(payload: unknown): NormalizedGatewayCommand | null {
+  const data = asRecord(payload);
+  if (!data) {
+    return null;
+  }
+
+  // Slash-command interaction payload
+  if (toNumber(data.type) === 2) {
+    const interaction = asRecord(data.data);
+    const commandName = firstString(interaction?.name);
+    if (!commandName) {
+      return null;
+    }
+
+    const options = flattenDiscordOptionValues(interaction?.options);
+    const chatId = toID(data.channel_id) ?? toID(data.guild_id);
+    if (!chatId) {
+      return null;
+    }
+
+    const requestId = buildRequestId("dc", toID(data.id));
+    return {
+      provider: "discord",
+      chatId,
+      requestId,
+      command: normalizeCommandName(`/${commandName}`),
+      args: options,
+      rawText: `/${commandName} ${options.join(" ")}`.trim(),
+    };
+  }
+
+  // Message-create style payload
+  const content = firstString(data.content);
+  const chatId = toID(data.channel_id) ?? toID(data.guild_id);
+  if (!content || !chatId) {
+    return null;
+  }
+  const parsed = parseCommandText(content);
+  if (!parsed) {
+    return null;
+  }
+
+  const requestId = buildRequestId("dc", toID(data.id), toID(asRecord(data.interaction)?.id));
+  return {
+    provider: "discord",
+    chatId,
+    requestId,
+    command: parsed.command,
+    args: parsed.args,
+    rawText: content,
+  };
+}
+
+export function parseFeishuEventToCommand(payload: unknown): NormalizedGatewayCommand | null {
+  const root = asRecord(payload);
+  if (!root) {
+    return null;
+  }
+  if (firstString(root.type) === "url_verification") {
+    return null;
+  }
+
+  const header = asRecord(root.header);
+  const event = asRecord(root.event);
+  const message = asRecord(event?.message);
+  if (!message) {
+    return null;
+  }
+
+  const chatId = toID(message.chat_id) ?? toID(message.open_chat_id);
+  if (!chatId) {
+    return null;
+  }
+
+  const rawText = parseFeishuTextContent(message.content);
+  if (!rawText) {
+    return null;
+  }
+
+  const parsed = parseCommandText(rawText);
+  if (!parsed) {
+    return null;
+  }
+
+  const requestId = buildRequestId("fs", toID(header?.event_id), toID(message.message_id), toID(root.uuid));
+  return {
+    provider: "feishu",
+    chatId,
+    requestId,
+    command: parsed.command,
+    args: parsed.args,
+    rawText,
+  };
+}
+
+type ParsedCommandText = {
+  command: string;
+  args: string[];
+};
+
+function parseCommandText(rawText: string): ParsedCommandText | null {
+  const normalized = stripLeadingMentions(rawText).trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const parts = normalized.split(/\s+/);
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const rawCommand = normalizeCommandName(parts[0] ?? "");
+  if (!rawCommand.startsWith("/") || rawCommand === "/") {
+    return null;
+  }
+
+  return {
+    command: rawCommand,
+    args: parts.slice(1),
+  };
+}
+
+function stripLeadingMentions(input: string): string {
+  return input
+    .replace(/^<@!?[0-9]+>\s*/g, "")
+    .replace(/^@\S+\s+/g, "")
+    .trim();
+}
+
+function normalizeCommandName(input: string): string {
+  const lowered = input.trim().toLowerCase();
+  return lowered.replace(/@[\w.-]+$/, "");
+}
+
+function flattenDiscordOptionValues(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const out: string[] = [];
+  for (const item of value) {
+    const option = asRecord(item);
+    if (!option) {
+      continue;
+    }
+
+    if ("value" in option) {
+      out.push(String(option.value));
+      continue;
+    }
+
+    out.push(...flattenDiscordOptionValues(option.options));
+  }
+  return out;
+}
+
+function parseFeishuTextContent(raw: unknown): string | null {
+  if (typeof raw === "string") {
+    try {
+      const decoded = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof decoded.text === "string") {
+        return decoded.text;
+      }
+      return null;
+    } catch {
+      return raw;
+    }
+  }
+
+  const direct = asRecord(raw);
+  if (typeof direct?.text === "string") {
+    return direct.text;
+  }
+  return null;
+}
+
+function buildRequestId(prefix: string, ...parts: Array<string | null>): string {
+  const compact = parts.filter((value) => value && value.trim().length > 0);
+  if (compact.length === 0) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${compact.join("-")}`;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function toID(value: unknown): string | null {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add a unified provider parser module at `gateway/src/providers/parsers.ts` to normalize Telegram/Discord/Feishu payloads into one command DTO (`NormalizedGatewayCommand`)
- add per-provider parser functions:
  - `parseTelegramUpdateToCommand`
  - `parseDiscordPayloadToCommand`
  - `parseFeishuEventToCommand`
- add conversion utility `toGatewayInput` so normalized DTO can be executed by existing gateway command path
- cover parser edge cases (mentions, slash interaction options, bot-suffixed commands, non-command payloads)
- add parser E2E tests that run parser output through `safeHandleCommand` end-to-end
- update README gateway status note for normalized provider parser support

## Test Commands and Output Evidence
- `cd gateway && bun run check` ✅ passed
- `cd gateway && bun test` ✅ passed
  - `112 pass`
  - `0 fail`

Closes #413
Closes #416
Closes #419
