### PR TITLE
fix(gateway): unify leading mention stripping in parser

### DIFF
--- a/gateway/src/providers/parsers.test.ts
+++ b/gateway/src/providers/parsers.test.ts
@@ -83,6 +83,17 @@ describe("parseDiscordPayloadToCommand", () => {
     expect(parsed?.args).toEqual(["openclaw", "50"]);
   });
 
+  test("parses message payload with mixed leading mentions", () => {
+    const parsed = parseDiscordPayloadToCommand({
+      id: "message-1b",
+      channel_id: "channel-7",
+      content: "<@!999> @carrier-bot /status",
+    });
+
+    expect(parsed?.command).toBe("/status");
+    expect(parsed?.args).toEqual([]);
+  });
+
   test("returns null when payload has no command text", () => {
     const parsed = parseDiscordPayloadToCommand({
       id: "message-2",

--- a/gateway/src/providers/parsers.ts
+++ b/gateway/src/providers/parsers.ts
@@ -181,8 +181,7 @@ function parseCommandText(rawText: string): ParsedCommandText | null {
 
 function stripLeadingMentions(input: string): string {
   return input
-    .replace(/^<@!?[0-9]+>\s*/g, "")
-    .replace(/^@\S+\s+/g, "")
+    .replace(/^(?:(?:<@!?[0-9]+>|@\S+)\s*)+/, "")
     .trim();
 }
 


### PR DESCRIPTION
## Summary
- replace two-step leading mention stripping with one unified regex
- support mixed leading mention prefixes (e.g. `<@!id> @bot /cmd`)
- add parser test coverage for mixed mention prefixes

## Testing
- `cd gateway && bun test src/providers/parsers.test.ts`

Closes #488
