### PR TITLE
fix(ci): stabilize kanban workflows and avoid config-blocking failures

### DIFF
--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const projectId = process.env.CARRIER_PROJECT_ID || 'PVT_kwHOAG7zoc4BPLc6';
+            const fs = require('fs');
+            const configPath = '.github/kanban-config.json';
+            const config = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, 'utf8')) : {};
+            const projectId = process.env.CARRIER_PROJECT_ID || config.projectId;
             const statusFieldNames = ['Status', '状态'];
             const fieldAliases = {
               priority: ['Priority', '优先级'],
@@ -33,9 +36,16 @@ jobs:
 
             const eventName = context.eventName;
             const payload = context.payload;
-            const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
-            // Fallback `github` comes from @actions/github and uses the default GITHUB_TOKEN context.
-            const ghClient = token ? github.getOctokit(token) : github;
+            const projectToken = process.env.CARRIER_PROJECTS_TOKEN;
+            if (!projectToken) {
+              core.warning('Skipping Kanban sync: CARRIER_PROJECTS_TOKEN is not configured.');
+              return;
+            }
+            if (!projectId) {
+              core.warning('Skipping Kanban sync: missing projectId. Set CARRIER_PROJECT_ID or config.projectId.');
+              return;
+            }
+            const ghClient = github.getOctokit(projectToken);
 
             const getStatusCandidates = (item, labels) => {
               const hasLabel = (target) => labels.includes(target.toLowerCase());
@@ -173,16 +183,22 @@ jobs:
               }
             }`;
 
-            const preflight = await ghClient.graphql(preflightQuery, { projectId });
+            let preflight;
+            try {
+              preflight = await ghClient.graphql(preflightQuery, { projectId });
+            } catch (error) {
+              core.warning(`Skipping Kanban sync: cannot read ProjectV2 ${projectId}. ${error.message}`);
+              return;
+            }
             if (!preflight?.node) {
-              core.setFailed(`Unable to read project ${projectId}. Verify the token and projectId are valid.`);
+              core.warning(`Skipping Kanban sync: unable to read project ${projectId}. Verify token and project ID.`);
               return;
             }
 
             if (!preflight.node.viewerCanUpdate) {
-              core.setFailed([
+              core.warning([
                 'Project token does not have write access for this Project.',
-                'Use CARRIER_PROJECTS_TOKEN with project:write scope, then re-run.',
+                'Skipping Kanban sync for this event.',
               ].join(' '));
               return;
             }
@@ -217,7 +233,7 @@ jobs:
 
             const statusField = findField(statusFieldNames);
             if (!statusField) {
-              core.setFailed('Project status field was not found or is not accessible. Ensure there is a single-select field named "Status".');
+              core.warning('Skipping Kanban sync: project status field is missing or inaccessible.');
               return;
             }
 

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -36,10 +36,12 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const dryRunInput = String((context.payload.inputs?.dry_run || process.env.DRY_RUN || 'false')).toLowerCase() === 'true';
-            const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
-            // Fallback `github` comes from @actions/github and is a pre-authenticated Octokit client
-            // scoped to the current repo context (default GITHUB_TOKEN), so graphql/rest calls still work.
-            const ghClient = token ? github.getOctokit(token) : github;
+            const projectToken = process.env.CARRIER_PROJECTS_TOKEN;
+            if (!projectToken) {
+              core.warning('Skipping Kanban operations: CARRIER_PROJECTS_TOKEN is not configured.');
+              return;
+            }
+            const ghClient = github.getOctokit(projectToken);
 
             const repoMeta = await ghClient.graphql(`
               query($owner: String!, $repo: String!) {
@@ -65,38 +67,44 @@ jobs:
             const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
             const projectId = process.env.CARRIER_PROJECT_ID || (context.payload.inputs && context.payload.inputs.project_id) || config.projectId;
             if (!projectId) {
-              core.setFailed('Missing projectId. Set CARRIER_PROJECT_ID secret or pass workflow input project_id.');
+              core.warning('Skipping Kanban operations: missing projectId. Set CARRIER_PROJECT_ID or config.projectId.');
               return;
             }
 
-            const preflight = await ghClient.graphql(`
-              query($projectId: ID!) {
-                node(id: $projectId) {
-                  ... on ProjectV2 {
-                    id
-                    title
-                    fields(first: 200) {
-                      nodes {
-                        ... on ProjectV2Field {
-                          id
-                          name
-                          dataType
-                        }
-                        ... on ProjectV2SingleSelectField {
-                          options {
+            let preflight;
+            try {
+              preflight = await ghClient.graphql(`
+                query($projectId: ID!) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      id
+                      title
+                      fields(first: 200) {
+                        nodes {
+                          ... on ProjectV2Field {
                             id
                             name
+                            dataType
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            options {
+                              id
+                              name
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
-              }
-            `, { projectId });
+              `, { projectId });
+            } catch (error) {
+              core.warning(`Skipping Kanban operations: cannot read ProjectV2 ${projectId}. ${error.message}`);
+              return;
+            }
 
             if (!preflight?.node) {
-              core.setFailed(`Cannot read ProjectV2 ${projectId}.`);
+              core.warning(`Skipping Kanban operations: cannot read ProjectV2 ${projectId}.`);
               return;
             }
 

--- a/README.md
+++ b/README.md
@@ -134,15 +134,13 @@ Runtime environment variables:
 
 ## Kanban workflow required secrets/env vars
 
-For `.github/workflows/carrier-kanban-operations.yml`, configure these repository-level secrets/variables before running the workflow (see workflow file: [`.github/workflows/carrier-kanban-operations.yml`](./.github/workflows/carrier-kanban-operations.yml)):
+For the Kanban workflows (`.github/workflows/carrier-kanban-operations.yml`, `.github/workflows/carrier-kanban-automation.yml`), configure these repository-level secrets/variables (see workflow files under [`.github/workflows/`](./.github/workflows/)):
 
-- `CARRIER_PROJECT_ID` (required): GitHub Project (v2) ID used by the workflow.
-- `CARRIER_PROJECTS_TOKEN` (required): token with project read/write permissions for field/view operations.
+- `CARRIER_PROJECT_ID` (recommended): GitHub Project (v2) ID used by the workflow. If omitted, workflows try `.github/kanban-config.json` `projectId`.
+- `CARRIER_PROJECTS_TOKEN` (required to execute sync/report): token with project read/write permissions for user/org ProjectV2 operations.
 - `CARRIER_DISCUSSION_CATEGORY_ID` (optional): discussion category override for workflow-generated discussion posts.
 
-Implementation note: the workflow falls back to the pre-authenticated `github` client from `@actions/github` when an explicit token is not provided, so repository-scoped operations still work with default workflow auth.
-
-Without the required values above, Kanban operations workflow runs will fail early during setup.
+Implementation note: workflows now skip with a warning when `CARRIER_PROJECTS_TOKEN` is missing or project access is unavailable, so unrelated CI checks are not blocked by Kanban configuration gaps.
 
 ## Install OpenClaw from release package (non-technical quick path)
 


### PR DESCRIPTION
## Summary
- fix both Kanban workflow files to avoid workflow-file/schema failures
  - use repository-projects permission key
  - fix script block rendering in carrier-kanban-operations.yml
  - avoid octokit redeclaration conflict in actions/github-script
  - update ProjectV2 single-select query shape to options { id name }
- harden runtime behavior when project credentials/config are missing
  - require CARRIER_PROJECTS_TOKEN for Kanban operations/sync and skip with warning when absent
  - load project ID from CARRIER_PROJECT_ID or .github/kanban-config.json
  - convert project-access setup failures to non-blocking warnings for Kanban workflows
- update README Kanban workflow configuration notes to match behavior

## Validation
- local YAML parse checks passed for both workflows
- manual workflow dispatch on this branch succeeded
  - https://github.com/Keith-CY/carrier/actions/runs/22021238609
