### PR TITLE
test(daemon): add timeout/exit-code normalization coverage

### DIFF
--- a/daemon/internal/commandexec/runner_test.go
+++ b/daemon/internal/commandexec/runner_test.go
@@ -2,7 +2,9 @@ package commandexec
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestShellRunnerSuccess(t *testing.T) {
@@ -27,5 +29,94 @@ func TestShellRunnerFailureExitCode(t *testing.T) {
 	}
 	if result.ExitCode != 17 {
 		t.Fatalf("expected exit code 17, got %d", result.ExitCode)
+	}
+}
+
+func TestShellRunnerTimeout(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Command that sleeps longer than the timeout
+	result, err := runner.Run(ctx, "sleep 5")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	// Exit code should be -1 for timeout/signal termination
+	if result.ExitCode != -1 {
+		t.Fatalf("expected exit code -1 for timeout, got %d", result.ExitCode)
+	}
+}
+
+func TestShellRunnerNonZeroExitWithStderr(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+	
+	// Command that writes to stderr and exits with non-zero code
+	result, err := runner.Run(context.Background(), "echo 'error message' >&2; exit 42")
+	if err == nil {
+		t.Fatal("expected command failure")
+	}
+
+	if result.ExitCode != 42 {
+		t.Fatalf("expected exit code 42, got %d", result.ExitCode)
+	}
+
+	if !strings.Contains(result.CombinedOutput, "error message") {
+		t.Fatalf("expected stderr output to be captured, got %q", result.CombinedOutput)
+	}
+}
+
+func TestShellRunnerCapturesBothStdoutAndStderr(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+	
+	// Command that writes to both stdout and stderr
+	result, err := runner.Run(context.Background(), "echo 'stdout'; echo 'stderr' >&2")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
+	}
+
+	if !strings.Contains(result.CombinedOutput, "stdout") {
+		t.Fatalf("expected stdout in output, got %q", result.CombinedOutput)
+	}
+
+	if !strings.Contains(result.CombinedOutput, "stderr") {
+		t.Fatalf("expected stderr in output, got %q", result.CombinedOutput)
+	}
+}
+
+func TestShellRunnerContextCancellation(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+	ctx, cancel := context.WithCancel(context.Background())
+	
+	// Cancel immediately
+	cancel()
+	
+	result, err := runner.Run(ctx, "sleep 10")
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+
+	// Exit code should be -1 for cancellation
+	if result.ExitCode != -1 {
+		t.Fatalf("expected exit code -1 for cancellation, got %d", result.ExitCode)
+	}
+}
+
+func TestShellRunnerExitCodeZeroOnSuccess(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+	
+	// Explicit exit 0 should work
+	result, err := runner.Run(context.Background(), "exit 0")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
 	}
 }


### PR DESCRIPTION
Fixes #527

Added comprehensive test coverage for command execution edge cases in the daemon runtime adapter.

**New Tests:**
- : verifies context cancellation returns exit code -1
- : ensures stderr is captured and exit code preserved
- Existing success test remains unaffected

**Testing:**
- ✅ All daemon tests pass: `go test ./...`
- ✅ New tests cover timeout, non-zero exit, and stderr capture scenarios