### PR TITLE
fix(ci-sync): remove stale project ID fallback and fail-open

### DIFF
--- a/.github/kanban-config.json
+++ b/.github/kanban-config.json
@@ -1,5 +1,5 @@
 {
-  "projectId": "PVT_kwHOAG7zoc4BPLc6",
+  "projectId": "",
   "discussionCategory": "General",
   "fields": [
     {

--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const projectId = process.env.CARRIER_PROJECT_ID || 'PVT_kwHOAG7zoc4BPLc6';
+            const projectId = String(process.env.CARRIER_PROJECT_ID || '').trim();
             const statusFieldNames = ['Status', '状态'];
             const fieldAliases = {
               priority: ['Priority', '优先级'],
@@ -33,6 +33,10 @@ jobs:
 
             const eventName = context.eventName;
             const payload = context.payload;
+            if (!projectId) {
+              core.warning('CARRIER_PROJECT_ID is not set; skipping Kanban sync for this run.');
+              return;
+            }
             const token = process.env.CARRIER_PROJECTS_TOKEN || process.env.GITHUB_TOKEN;
             // Fallback `github` comes from @actions/github and uses the default GITHUB_TOKEN context.
             const ghClient = token ? github.getOctokit(token) : github;
@@ -173,15 +177,21 @@ jobs:
               }
             }`;
 
-            const preflight = await ghClient.graphql(preflightQuery, { projectId });
+            let preflight;
+            try {
+              preflight = await ghClient.graphql(preflightQuery, { projectId });
+            } catch (err) {
+              core.warning(`Skip Kanban sync: unable to read project ${projectId} (${err.message || err}).`);
+              return;
+            }
             if (!preflight?.node) {
-              core.setFailed(`Unable to read project ${projectId}. Verify the token and projectId are valid.`);
+              core.warning(`Skip Kanban sync: project ${projectId} is not accessible.`);
               return;
             }
 
             if (!preflight.node.viewerCanUpdate) {
-              core.setFailed([
-                'Project token does not have write access for this Project.',
+              core.warning([
+                'Skip Kanban sync: token does not have write access for this Project.',
                 'Use CARRIER_PROJECTS_TOKEN with project:write scope, then re-run.',
               ].join(' '));
               return;


### PR DESCRIPTION
## Summary
- remove stale hardcoded ProjectV2 fallback ID from Kanban sync workflow
- make sync workflow fail-open when `CARRIER_PROJECT_ID` is missing/invalid (warn + skip instead of failing the PR check)
- clear stale default `projectId` in `.github/kanban-config.json`

## Why
`sync` was failing on every PR because a stale/deleted project node ID was hardcoded. This change prevents unrelated PRs from being blocked while keeping Kanban sync functional once a valid `CARRIER_PROJECT_ID` is configured.

Closes #568