### PR TITLE
chore(kanban): remove unused projectId from config

### DIFF
--- a/.github/kanban-config.json
+++ b/.github/kanban-config.json
@@ -1,5 +1,4 @@
 {
-  "projectId": "",
   "discussionCategory": "General",
   "fields": [
     {


### PR DESCRIPTION
## Summary
- remove the unused `projectId` key from `.github/kanban-config.json`
- keep project resolution solely in workflow env/fallback logic to avoid duplicate source-of-truth confusion

## Testing
- `python3 -m json.tool .github/kanban-config.json`

Closes #580
