### PR TITLE
fix(gateway): strict parsePort validation for env input

### DIFF
--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -464,8 +464,7 @@ describe("port resolution fallback behavior", () => {
       port: undefined,
     });
     
-    // parseInt truncates to 8080, which is valid
-    expect(server.port).toBe(8080);
+    expect(server.port).toBe(8787);
     server.stop();
     
     if (originalEnv !== undefined) {
@@ -485,10 +484,49 @@ describe("port resolution fallback behavior", () => {
       port: undefined,
     });
     
-    // parseInt parses "8080" before hitting special chars
-    expect(server.port).toBe(8080);
+    expect(server.port).toBe(8787);
     server.stop();
     
+    if (originalEnv !== undefined) {
+      process.env.CARRIER_GATEWAY_PORT = originalEnv;
+    } else {
+      delete process.env.CARRIER_GATEWAY_PORT;
+    }
+  });
+
+  test("uses default port when env is above max port range", async () => {
+    const deps = makeDeps();
+    const originalEnv = process.env.CARRIER_GATEWAY_PORT;
+    process.env.CARRIER_GATEWAY_PORT = "65536";
+
+    const server = startGatewayServer({
+      deps,
+      port: undefined,
+    });
+
+    expect(server.port).toBe(8787);
+    server.stop();
+
+    if (originalEnv !== undefined) {
+      process.env.CARRIER_GATEWAY_PORT = originalEnv;
+    } else {
+      delete process.env.CARRIER_GATEWAY_PORT;
+    }
+  });
+
+  test("uses env port when env is max valid port", async () => {
+    const deps = makeDeps();
+    const originalEnv = process.env.CARRIER_GATEWAY_PORT;
+    process.env.CARRIER_GATEWAY_PORT = "65535";
+
+    const server = startGatewayServer({
+      deps,
+      port: undefined,
+    });
+
+    expect(server.port).toBe(65535);
+    server.stop();
+
     if (originalEnv !== undefined) {
       process.env.CARRIER_GATEWAY_PORT = originalEnv;
     } else {

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -247,8 +247,13 @@ async function parseCommandInput(request: Request): Promise<string | null> {
 }
 
 function parsePort(raw: string | undefined, fallback: number): number {
-  const parsed = Number.parseInt(raw || "", 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const value = (raw ?? "").trim();
+  if (!/^[0-9]+$/.test(value)) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
     return fallback;
   }
   return parsed;


### PR DESCRIPTION
## Summary
- enforce strict full-string decimal parsing for `CARRIER_GATEWAY_PORT`
- reject malformed numeric prefixes (e.g. `8080.5`, `8080abc`) by falling back to default port
- reject out-of-range values outside `1..65535`
- add regression tests for malformed and boundary values

## Validation
- `bun test src/server.test.ts` (pass)
- `bun run check` (fails in this environment: missing Bun type definition `TS2688`)

Closes #597
