### PR TITLE
fix(gateway): handle malformed encoded download filename paths

### DIFF
--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -116,6 +116,19 @@ describe("gateway runtime routes", () => {
     expect(payload.errorCode).toBe("E_DOWNLOAD_FILE_MISMATCH");
   });
 
+  test("download route rejects malformed percent-encoded filename path", async () => {
+    const deps = makeDeps();
+    const filePath = `/tmp/gateway-download-${crypto.randomUUID()}.txt`;
+    await Bun.write(filePath, "file-content");
+    const token = deps.downloads.issue(filePath, 300, false);
+    const runtime = createGatewayRuntime({ deps });
+
+    const response = await runtime.fetch(new Request(`http://gateway.local/downloads/${token.token}/bad%ZZname.txt`));
+    expect(response.status).toBe(400);
+    const payload = await response.json() as { errorCode?: string };
+    expect(payload.errorCode).toBe("E_USAGE");
+  });
+
   test("download route escapes quotes in content-disposition filename", async () => {
     const deps = makeDeps();
     // Create a file with a name containing quotes and backslashes

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -152,7 +152,18 @@ async function handleDownloadRequest(
   }
 
   const token = parts[1] ?? "";
-  const requestedFileName = decodeURIComponent(parts[2] ?? "");
+  let requestedFileName: string;
+  try {
+    requestedFileName = decodeURIComponent(parts[2] ?? "");
+  } catch {
+    return jsonResponse({
+      requestId: ctx.requestId,
+      result: "error",
+      errorCode: "E_USAGE",
+      message: "invalid download path",
+    }, 400);
+  }
+
   const resolved = ctx.deps.downloads.consume(token);
   if (!resolved) {
     return jsonResponse({


### PR DESCRIPTION
## Summary
- guard `/downloads/:token/:filename` against malformed percent-encoding in `decodeURIComponent`
- return a structured `400 E_USAGE` response instead of throwing `URIError`
- add regression test for malformed path segment (`bad%ZZname.txt`)

## Validation
- `cd gateway && bun run check`
- `cd gateway && bun test src/server.test.ts`

Closes #666
