### PR TITLE
ci(gateway): remove duplicate gateway test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,6 @@ jobs:
         working-directory: gateway
         run: bun run ci
 
-      - name: Run gateway tests
-        working-directory: gateway
-        run: bun test
-
   e2e-tests:
     name: End-to-End Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove duplicate `bun test` invocation from `gateway-check`
- keep a single `bun run ci` step (`check` + `test`) for gateway CI
- reduce redundant CI runtime while preserving coverage

Closes #679
