### PR TITLE
ci/scripts: align local shellcheck scope with CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Before opening or updating a PR, run the minimum local validation for your chang
 
 - **CI/workflow changes:** Test the workflow logic locally where possible. For GitHub Actions changes, verify YAML syntax with a linter (e.g., `actionlint`).
 
-- **Shell script changes:** Run `shellcheck scripts/*.sh` locally to catch portability/quoting issues before CI does.
+- **Shell script changes:** Run `bash scripts/run-shellcheck.sh` locally to lint the same tracked `*.sh` files that CI checks.
 
 These are minimum checks. The full local validation suite is available via `./scripts/run-all-tests.sh`.
 ## CI Troubleshooting
@@ -261,7 +261,7 @@ while IFS= read -r f; do echo "$f"; done < <(find . -name "*.sh")
 Run ShellCheck locally before pushing:
 
 ```bash
-shellcheck scripts/*.sh
+bash scripts/run-shellcheck.sh
 ```
 ### Missing Bun Type Definitions (TS2688)
 
@@ -435,7 +435,7 @@ Run shellcheck across all repository shell scripts:
 bash scripts/run-shellcheck.sh
 ```
 
-The script discovers `scripts/**/*.sh` files, runs shellcheck on each, and exits non-zero on any findings. Requires `shellcheck` to be installed locally.
+The script discovers all git-tracked `*.sh` files in the repository (same scope as CI), runs shellcheck on each, and exits non-zero on any findings. Requires `shellcheck` to be installed locally.
 ## GitHub CLI Preflight and Troubleshooting
 
 Before running review or triage automation scripts locally, verify your `gh` setup:

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -1,24 +1,29 @@
 #!/usr/bin/env bash
-# Run shellcheck consistently across all repository shell scripts.
+# Run shellcheck consistently across all tracked repository shell scripts.
 # Usage: bash scripts/run-shellcheck.sh
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-mapfile -t scripts < <(find "$REPO_ROOT/scripts" -name '*.sh' -type f | sort)
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not inside a git work tree: $REPO_ROOT"
+  exit 1
+fi
+
+mapfile -t scripts < <(git -C "$REPO_ROOT" ls-files '*.sh' | sort)
 
 if [ ${#scripts[@]} -eq 0 ]; then
-  echo "No shell scripts found under scripts/. Nothing to check."
+  echo "No tracked shell scripts found. Nothing to check."
   exit 0
 fi
 
-echo "Running shellcheck on ${#scripts[@]} script(s)..."
+echo "Running shellcheck on ${#scripts[@]} tracked script(s)..."
 echo ""
 
 errors=0
-for script in "${scripts[@]}"; do
-  rel="${script#"$REPO_ROOT/"}"
-  if shellcheck "$script"; then
+for rel in "${scripts[@]}"; do
+  abs="$REPO_ROOT/$rel"
+  if shellcheck "$abs"; then
     echo "  ✓ $rel"
   else
     echo "  ✗ $rel"

--- a/scripts/test-run-shellcheck.sh
+++ b/scripts/test-run-shellcheck.sh
@@ -8,43 +8,94 @@ fail=0
 
 echo "Testing run-shellcheck.sh..."
 
-# Test 1: Runs successfully when shellcheck is available and scripts exist
+# Test 1: Wrapper is runnable in the current repo.
 if command -v shellcheck &>/dev/null; then
   if bash "$SCRIPT_DIR/run-shellcheck.sh" >/dev/null 2>&1; then
-    echo "  PASS: exits 0 with clean scripts"
+    echo "  PASS: wrapper runs in repo"
     pass=$((pass + 1))
   else
-    echo "  INFO: shellcheck found issues (expected if scripts have warnings)"
+    echo "  INFO: shellcheck found issues in repo (acceptable for wrapper test)"
     pass=$((pass + 1))
   fi
 else
   echo "  SKIP: shellcheck not installed"
 fi
 
-# Test 2: No-file branch with empty directory
+# Test 2: Uses git-tracked *.sh scope (inside and outside scripts/) and ignores untracked files.
 tmpdir=$(mktemp -d)
-mkdir -p "$tmpdir/scripts"
-cat > "$tmpdir/scripts/run-shellcheck.sh" << 'INNER'
+mkdir -p "$tmpdir/scripts" "$tmpdir/catalog" "$tmpdir/untracked"
+
+cat > "$tmpdir/scripts/in-scripts.sh" <<'SH'
 #!/usr/bin/env bash
-set -euo pipefail
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-mapfile -t scripts < <(find "$REPO_ROOT/scripts" -name '*.sh' -not -name 'run-shellcheck.sh' -type f | sort)
-if [ ${#scripts[@]} -eq 0 ]; then
-  echo "No shell scripts found under scripts/. Nothing to check."
-  exit 0
-fi
-INNER
+echo scripts
+SH
+cat > "$tmpdir/catalog/outside-scripts.sh" <<'SH'
+#!/usr/bin/env bash
+echo catalog
+SH
+cat > "$tmpdir/untracked/ignored.sh" <<'SH'
+#!/usr/bin/env bash
+echo ignored
+SH
+chmod +x "$tmpdir/scripts/in-scripts.sh" "$tmpdir/catalog/outside-scripts.sh" "$tmpdir/untracked/ignored.sh"
+
+(
+  cd "$tmpdir"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  git add scripts/in-scripts.sh catalog/outside-scripts.sh
+  git commit -qm "init"
+)
+
+# Copy wrapper into temp repo at scripts/run-shellcheck.sh (same expected layout).
+cp "$SCRIPT_DIR/run-shellcheck.sh" "$tmpdir/scripts/run-shellcheck.sh"
 chmod +x "$tmpdir/scripts/run-shellcheck.sh"
 
-output=$(bash "$tmpdir/scripts/run-shellcheck.sh" 2>&1)
-if echo "$output" | grep -q "Nothing to check"; then
-  echo "  PASS: no-file branch prints correct message"
+# Stub shellcheck so we can verify exactly which files were checked.
+mkdir -p "$tmpdir/bin"
+cat > "$tmpdir/bin/shellcheck" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$1"
+SH
+chmod +x "$tmpdir/bin/shellcheck"
+
+output=$(PATH="$tmpdir/bin:$PATH" bash "$tmpdir/scripts/run-shellcheck.sh" 2>&1)
+
+if echo "$output" | grep -q "scripts/in-scripts.sh" \
+  && echo "$output" | grep -q "catalog/outside-scripts.sh" \
+  && ! echo "$output" | grep -q "untracked/ignored.sh"; then
+  echo "  PASS: wrapper checks tracked *.sh files across repo and skips untracked files"
   pass=$((pass + 1))
 else
-  echo "  FAIL: expected 'Nothing to check' message"
+  echo "  FAIL: wrapper did not match git-tracked *.sh scope"
   fail=$((fail + 1))
 fi
-rm -rf "$tmpdir"
+
+# Test 3: No tracked shell script branch.
+empty_repo=$(mktemp -d)
+mkdir -p "$empty_repo/scripts"
+cp "$SCRIPT_DIR/run-shellcheck.sh" "$empty_repo/scripts/run-shellcheck.sh"
+chmod +x "$empty_repo/scripts/run-shellcheck.sh"
+(
+  cd "$empty_repo"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  git add scripts/run-shellcheck.sh
+  git commit -qm "init"
+)
+
+empty_output=$(PATH="$tmpdir/bin:$PATH" bash "$empty_repo/scripts/run-shellcheck.sh" 2>&1 || true)
+if echo "$empty_output" | grep -q "scripts/run-shellcheck.sh"; then
+  echo "  PASS: repo with only wrapper still reports tracked shell scripts"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: expected tracked wrapper script to be linted"
+  fail=$((fail + 1))
+fi
+
+rm -rf "$tmpdir" "$empty_repo"
 
 echo ""
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- switch `scripts/run-shellcheck.sh` from `find scripts/**/*.sh` to `git ls-files '*.sh'` so local scope matches CI
- keep deterministic ordering and per-file output while linting tracked shell scripts across the repo
- update `scripts/test-run-shellcheck.sh` to verify tracked scope includes files outside `scripts/` and excludes untracked files
- update CONTRIBUTING guidance to use `bash scripts/run-shellcheck.sh`

## Testing
- `bash scripts/test-run-shellcheck.sh`

Closes #694
