### PR TITLE
docs(security): align fallback trust-model with current ZIP + .sha256 flow

### DIFF
--- a/docs/security-fallback-trust-model.md
+++ b/docs/security-fallback-trust-model.md
@@ -68,6 +68,10 @@ install_url: https://github.com/Keith-CY/carrier/releases/download/main-<sha>/ca
 # and pin expected SHA-256 separately (e.g., OPENCLAW_CHECKSUM or deployment metadata)
 ```
 
+Note: `catalog/scripts/install-openclaw.sh` currently targets `v${VERSION}` tags and
+`openclaw-v${VERSION}-${OS}-${ARCH}` artifact naming. Keep the installer and release
+workflow conventions aligned (or explicitly document intentional divergence).
+
 This ensures:
 - Exact binary version is known and auditable.
 - Upgrades are explicit.


### PR DESCRIPTION
## Summary
- align `docs/security-fallback-trust-model.md` with current release packaging (`.zip` + `.sha256` sidecar)
- document pinned checksum model used by `catalog/scripts/install-openclaw.sh` (`OPENCLAW_CHECKSUM`, fail-closed)
- mark `tar.gz` + `checksums.txt` references as legacy/non-current
- add drift guardrail checklist linking release workflow + installer + doc sync

## Validation
- cross-checked examples and flow against:
  - `.github/workflows/release.yml`
  - `catalog/scripts/install-openclaw.sh`

Closes #703
