### PR TITLE
test(agentd): add bearerAuthMiddleware auth/scope coverage

### DIFF
--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,5 +60,94 @@ func TestBuildHTTPHandlerMountsHealthAndAPI(t *testing.T) {
 	handler.ServeHTTP(agentsRec, agentsReq)
 	if agentsRec.Code != http.StatusOK {
 		t.Fatalf("/api/v1/agents status = %d, want 200 body=%s", agentsRec.Code, agentsRec.Body.String())
+	}
+}
+
+func TestBearerAuthMiddleware(t *testing.T) {
+	const token = "secret-token"
+
+	tests := []struct {
+		name           string
+		path           string
+		authorization  string
+		wantStatus     int
+		wantBody       string
+		wantNextCalled bool
+		wantJSON       bool
+	}{
+		{
+			name:           "api missing authorization is unauthorized",
+			path:           "/api/v1/agents",
+			wantStatus:     http.StatusUnauthorized,
+			wantBody:       `{"error":"unauthorized"}`,
+			wantNextCalled: false,
+			wantJSON:       true,
+		},
+		{
+			name:           "api wrong bearer token is unauthorized",
+			path:           "/api/v1/agents",
+			authorization:  "Bearer wrong-token",
+			wantStatus:     http.StatusUnauthorized,
+			wantBody:       `{"error":"unauthorized"}`,
+			wantNextCalled: false,
+			wantJSON:       true,
+		},
+		{
+			name:           "api correct bearer token passes through",
+			path:           "/api/v1/agents",
+			authorization:  "Bearer " + token,
+			wantStatus:     http.StatusAccepted,
+			wantBody:       "ok",
+			wantNextCalled: true,
+		},
+		{
+			name:           "non api healthz bypasses auth",
+			path:           "/healthz",
+			wantStatus:     http.StatusAccepted,
+			wantBody:       "ok",
+			wantNextCalled: true,
+		},
+		{
+			name:           "non api readyz bypasses auth",
+			path:           "/readyz",
+			wantStatus:     http.StatusAccepted,
+			wantBody:       "ok",
+			wantNextCalled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte("ok"))
+			})
+
+			handler := bearerAuthMiddleware(token, next)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.authorization != "" {
+				req.Header.Set("Authorization", tc.authorization)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if got := rec.Body.String(); got != tc.wantBody {
+				t.Fatalf("body = %q, want %q", got, tc.wantBody)
+			}
+			if nextCalled != tc.wantNextCalled {
+				t.Fatalf("nextCalled = %v, want %v", nextCalled, tc.wantNextCalled)
+			}
+			if tc.wantJSON {
+				ct := rec.Header().Get("Content-Type")
+				if !strings.HasPrefix(ct, "application/json") {
+					t.Fatalf("content-type = %q, want application/json", ct)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- add table-driven tests for `bearerAuthMiddleware` in `daemon/cmd/agentd/main_test.go`
- cover unauthorized API access (missing/wrong bearer token)
- cover authorized API pass-through and non-API bypass behavior (`/healthz`, `/readyz`)
- assert unauthorized responses return JSON content-type and expected body

## Validation
- `cd daemon && go test ./cmd/agentd -count=1`

Closes #714
