### PR TITLE
ci(gateway): enforce frozen lockfile installs in CI/release + scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install gateway dependencies
         working-directory: gateway
-        run: bun install --no-progress
+        run: bun install --frozen-lockfile --no-progress
 
       - name: Gateway CI (type check + tests)
         working-directory: gateway
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install gateway dependencies
         working-directory: gateway
-        run: bun install --no-progress
+        run: bun install --frozen-lockfile --no-progress
 
       - name: Run end-to-end tests
         run: ./scripts/run-e2e-tests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install gateway dependencies
         working-directory: gateway
-        run: bun install --no-progress
+        run: bun install --frozen-lockfile --no-progress
 
       - name: Run end-to-end tests
         run: ./scripts/run-e2e-tests.sh

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If any command fails, install the missing tool before running automation scripts
 - Daemon (Go): Go modules are loaded automatically when building or testing; no additional install command needed.
 - Gateway (TypeScript):
   - `cd gateway`
-  - `bun install`
+  - `bun install --frozen-lockfile`
 
 ### Run tests / checks
 - Daemon tests:
@@ -122,7 +122,14 @@ If any command fails, install the missing tool before running automation scripts
   - `./scripts/run-all-tests.sh`
 
 Optional local flow from repo root:
-  - `cd gateway && bun install && bun run check && cd ../daemon && go test ./...`
+  - `cd gateway && bun install --frozen-lockfile && bun run check && cd ../daemon && go test ./...`
+
+
+### Frozen lockfile policy (CI and automation)
+- CI/release automation must use lockfile-enforced installs for gateway dependencies:
+  - `bun install --frozen-lockfile --no-progress`
+- This guarantees deterministic dependency resolution from committed `gateway/bun.lock`.
+- If `gateway/package.json` and `gateway/bun.lock` drift, install must fail until lockfile is updated and committed.
 
 ### Gateway runtime server (Bun)
 

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -12,7 +12,7 @@ printf '\n=== Daemon tests ===\n'
 printf '\n=== Gateway checks and tests ===\n'
 (
   cd "$repo_root/gateway"
-  bun install --no-progress
+  bun install --frozen-lockfile --no-progress
   bun run check
   bun test
 )

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -24,7 +24,7 @@ if [[ ! -d "$repo_root/gateway/node_modules" ]]; then
   echo "gateway/node_modules not found; installing gateway dependencies..."
   (
     cd "$repo_root/gateway"
-    bun install --no-progress
+    bun install --frozen-lockfile --no-progress
   )
 fi
 


### PR DESCRIPTION
## Summary
- enforce `bun install --frozen-lockfile --no-progress` in CI/release gateway install steps
- apply the same frozen-lockfile install policy in repo automation scripts used by CI paths
- document frozen lockfile policy in README for contributors

## Validation
- `bash scripts/test-check-doc-command-sync.sh`

Closes #724
