### PR TITLE
fix(catalog): align manifest healthcheck endpoint with daemon contract

### DIFF
--- a/catalog/openclaw.manifest.json
+++ b/catalog/openclaw.manifest.json
@@ -27,12 +27,12 @@
     "ports": [
       {
         "name": "http",
-        "port": 8080
+        "port": 9090
       }
     ],
     "healthcheck": {
       "type": "http",
-      "url": "http://localhost:8080/health"
+      "url": "http://localhost:9090/healthz"
     }
   },
   "env": {

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -10,7 +10,12 @@ import (
 //go:embed openclaw-installer.sh
 var openclawInstallerScript string
 
-const openclawVersion = "1.0.0"
+const (
+	openclawVersion          = "1.0.0"
+	defaultDaemonPort        = 9090
+	defaultDaemonHealthzPath = "/healthz"
+	defaultDaemonHealthURL   = "http://localhost:9090/healthz"
+)
 
 // Pinned checksums for release artifacts, injected at build time via ldflags:
 //
@@ -82,10 +87,10 @@ func OpenClawManifest() manifest.Manifest {
 			Stop:    manifest.CommandSpec{Command: "openclaw gateway stop"},
 		},
 		Network: manifest.NetworkSpec{
-			Ports: []manifest.PortSpec{{Name: "http", Port: 8080}},
+			Ports: []manifest.PortSpec{{Name: "http", Port: defaultDaemonPort}},
 			Healthcheck: manifest.HealthcheckSpec{
 				Type: "http",
-				URL:  "http://localhost:8080/health",
+				URL:  defaultDaemonHealthURL,
 			},
 		},
 		Env: manifest.EnvSpec{

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -1,0 +1,40 @@
+package catalog
+
+import (
+	"carrier/daemon/internal/manifest"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenClawManifestUsesDaemonHealthContract(t *testing.T) {
+	m := OpenClawManifest()
+
+	if len(m.Network.Ports) == 0 {
+		t.Fatal("expected at least one network port in manifest")
+	}
+	if got := m.Network.Ports[0].Port; got != defaultDaemonPort {
+		t.Fatalf("network port = %d, want %d", got, defaultDaemonPort)
+	}
+	if got := m.Network.Healthcheck.URL; got != defaultDaemonHealthURL {
+		t.Fatalf("healthcheck url = %q, want %q", got, defaultDaemonHealthURL)
+	}
+}
+
+func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "catalog", "openclaw.manifest.json")
+	fileManifest, err := manifest.LoadFile(path)
+	if err != nil {
+		t.Fatalf("load catalog manifest: %v", err)
+	}
+
+	generated := OpenClawManifest()
+	if fileManifest.Network.Healthcheck.URL != generated.Network.Healthcheck.URL {
+		t.Fatalf("catalog healthcheck url = %q, generated = %q", fileManifest.Network.Healthcheck.URL, generated.Network.Healthcheck.URL)
+	}
+	if len(fileManifest.Network.Ports) == 0 || len(generated.Network.Ports) == 0 {
+		t.Fatal("expected network ports in both manifests")
+	}
+	if fileManifest.Network.Ports[0].Port != generated.Network.Ports[0].Port {
+		t.Fatalf("catalog port = %d, generated = %d", fileManifest.Network.Ports[0].Port, generated.Network.Ports[0].Port)
+	}
+}


### PR DESCRIPTION
## Summary
- align OpenClaw catalog manifest health endpoint with daemon defaults (`http://localhost:9090/healthz`)
- replace hardcoded network defaults in generated manifest with shared constants
- add regression tests to keep generated manifest and `catalog/openclaw.manifest.json` in sync (health URL + port)

## Testing
- `cd daemon && go test ./internal/catalog ./internal/manifest`

Closes #723
