### PR TITLE
ci/docs: gate docs-only PRs + fail-fast shellcheck prerequisite

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -1,0 +1,32 @@
+name: Docs Consistency
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'scripts/check-doc-command-sync.sh'
+      - '.github/workflows/docs-consistency.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'scripts/check-doc-command-sync.sh'
+      - '.github/workflows/docs-consistency.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-sync:
+    name: Docs Command Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Verify docs command blocks stay in sync
+        shell: bash
+        run: bash scripts/check-doc-command-sync.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Before opening or updating a PR, run the minimum local validation for your chang
   bun test
   ```
 
-- **Docs-only changes:** Verify markdown links render correctly in GitHub preview. No CI test run is required (CI skips docs-only changes via `paths-ignore`).
+- **Docs-only changes:** Verify markdown links render correctly in GitHub preview and ensure the **Docs Consistency** workflow passes (`scripts/check-doc-command-sync.sh` runs there).
 
 - **CI/workflow changes:** Test the workflow logic locally where possible. For GitHub Actions changes, verify YAML syntax with a linter (e.g., `actionlint`).
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Runtime environment variables:
 #### CI coverage note (E2E execution policy)
 - `End-to-End Tests` in `.github/workflows/ci.yml` run only on `push` to `main` (`github.event_name == 'push' && github.ref == 'refs/heads/main'`).
 - Pull requests do not run E2E in `ci.yml`.
+- Docs-only changes run `.github/workflows/docs-consistency.yml`, which executes `scripts/check-doc-command-sync.sh`.
 - Release flow also enforces mandatory end-to-end validation in `.github/workflows/release.yml` (`End-to-End Tests (Deployment)`).
 
 ## Local workflow notes

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "shellcheck is required but was not found in PATH."
+  echo "Install it first (e.g.: brew install shellcheck OR sudo apt-get install -y shellcheck),"
+  echo "or run scripts/check-tools.sh for dependency checks."
+  exit 1
+fi
+
 if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Not inside a git work tree: $REPO_ROOT"
   exit 1

--- a/scripts/test-run-shellcheck.sh
+++ b/scripts/test-run-shellcheck.sh
@@ -21,7 +21,18 @@ else
   echo "  SKIP: shellcheck not installed"
 fi
 
-# Test 2: Uses git-tracked *.sh scope (inside and outside scripts/) and ignores untracked files.
+# Test 2: Missing shellcheck fails fast with a single prerequisite error.
+missing_output=$(PATH="/usr/bin:/bin" /usr/bin/bash "$SCRIPT_DIR/run-shellcheck.sh" 2>&1 || true)
+if echo "$missing_output" | grep -q "shellcheck is required but was not found in PATH" \
+  && [ "$(echo "$missing_output" | grep -c "not found")" -eq 1 ]; then
+  echo "  PASS: missing shellcheck exits early with one actionable message"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: missing shellcheck path was not reported clearly"
+  fail=$((fail + 1))
+fi
+
+# Test 3: Uses git-tracked *.sh scope (inside and outside scripts/) and ignores untracked files.
 tmpdir=$(mktemp -d)
 mkdir -p "$tmpdir/scripts" "$tmpdir/catalog" "$tmpdir/untracked"
 
@@ -72,7 +83,7 @@ else
   fail=$((fail + 1))
 fi
 
-# Test 3: No tracked shell script branch.
+# Test 4: No tracked shell script branch.
 empty_repo=$(mktemp -d)
 mkdir -p "$empty_repo/scripts"
 cp "$SCRIPT_DIR/run-shellcheck.sh" "$empty_repo/scripts/run-shellcheck.sh"


### PR DESCRIPTION
## Summary
- add a dedicated `Docs Consistency` workflow for docs/markdown-only changes
- run `scripts/check-doc-command-sync.sh` in that workflow so docs drift is still gated when `ci.yml` is skipped by `paths-ignore`
- add fail-fast prerequisite guard in `scripts/run-shellcheck.sh` when `shellcheck` is missing
- extend `scripts/test-run-shellcheck.sh` with a missing-binary path test
- update README/CONTRIBUTING to document the docs-only CI behavior

## Validation
- `bash scripts/test-run-shellcheck.sh`
- `bash scripts/check-doc-command-sync.sh`

Closes #738
Closes #739
