### PR TITLE
docs(skill): require green CI before formal PR review

### DIFF
--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -4,10 +4,16 @@
 Guide agents to review pull requests like a human collaborator — with inline code comments on specific lines, not just summary approvals.
 
 ## Review Process
-1. Fetch the PR diff via `gh pr diff <number> --repo Keith-CY/carrier`
-2. Read the full diff before commenting
-3. Submit a review using the GitHub Review API with inline `comments` array (path, line, side, body)
-4. Apply decision rules strictly:
+1. Check CI first via `gh pr checks <number> --repo Keith-CY/carrier`.
+2. **Only perform formal code review after all required CI checks are green.**
+3. If CI is pending or failing:
+   - Do not submit Approve/Request Changes review yet.
+   - Leave at most a short status comment that review is waiting on green CI.
+   - Re-check the same PR after CI completes, even if there is no new commit.
+4. Fetch the PR diff via `gh pr diff <number> --repo Keith-CY/carrier`.
+5. Read the full diff before commenting.
+6. Submit a review using the GitHub Review API with inline `comments` array (path, line, side, body).
+7. Apply decision rules strictly:
    - If there is any **BS** (Blocking Suggestion), submit **Request Changes**.
    - If there are only **NBS** (Non-Blocking Suggestions), leave `NBS:` comments per format and keep review non-blocking.
    - If there is no BS, submit **Approve**.
@@ -31,8 +37,12 @@ Guide agents to review pull requests like a human collaborator — with inline c
 - Reference related PRs/issues when relevant (e.g., "This conflicts with the pattern in PR #14").
 
 ## Build Verification
-Before approving, confirm all CI checks have passed:
-- Check CI status: `gh pr checks <number> --repo Keith-CY/carrier`
+CI is a hard gate for review decisions:
+- Check CI status first: `gh pr checks <number> --repo Keith-CY/carrier`
+- Do not submit final review decisions until required checks are green.
+- If CI is pending/failing, queue re-check and revisit when CI completes (even without new commits).
+
+Optional local verification when needed:
 - **Daemon (Go)**: `cd daemon && go test ./...`
 - **Gateway (TypeScript)**: `cd gateway && bun run check`
 


### PR DESCRIPTION
## Summary
Update `skills/pr-review/SKILL.md` to enforce CI-gated review timing:

- Check CI first.
- Do not submit formal Approve/Request Changes while required checks are pending/failing.
- Leave only short status comments while waiting.
- Re-check and review after CI completes even if no new commit.

## Why
This closes the gap where a PR gets a "wait for CI" comment and then is skipped later because no new commit was pushed.

## Scope
- Documentation/process rule update only (`skills/pr-review/SKILL.md`).