### PR TITLE
refactor(api): use errors.Is for trailing JSON EOF check

### DIFF
--- a/daemon/internal/api/server.go
+++ b/daemon/internal/api/server.go
@@ -425,7 +425,7 @@ func readJSON(r *http.Request, dst any) error {
 	}
 
 	var trailing struct{}
-	if err := dec.Decode(&trailing); err != io.EOF {
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return fmt.Errorf("invalid json: trailing content after first json value")
 	}
 


### PR DESCRIPTION
## Summary
- replace direct `err != io.EOF` comparison with `!errors.Is(err, io.EOF)` in `readJSON`
- keeps behavior unchanged while aligning with idiomatic Go error checks

## Validation
- `cd daemon && go test ./internal/api/...`

Closes #860
