### PR TITLE
security(gateway): validate session token on all command requests

### DIFF
--- a/gateway/src/command-routing.test.ts
+++ b/gateway/src/command-routing.test.ts
@@ -14,11 +14,12 @@ function buildDeps(): GatewayDependencies {
   };
 }
 
-function pairChat(d: GatewayDependencies, provider: "telegram" | "discord" | "feishu" = "telegram", chatId = "100"): void {
+function pairChat(d: GatewayDependencies, provider: "telegram" | "discord" | "feishu" = "telegram", chatId = "100"): string {
   if (d.daemon instanceof InMemoryDaemonClient) {
     d.daemon.registerPairCode("pair-ok");
   }
-  d.sessions.createSession({ provider, chatId });
+  const session = d.sessions.createSession({ provider, chatId });
+  return session.sessionToken;
 }
 
 describe("command routing: /pair", () => {
@@ -66,13 +67,15 @@ describe("command routing: session requirement", () => {
 });
 
 describe("command routing: /agents", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("lists agents for paired chat", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /agents"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /agents`), deps);
 
     expect(res.result).toBe("ok");
     expect(res.message).toContain("listed");
@@ -80,20 +83,22 @@ describe("command routing: /agents", () => {
 });
 
 describe("command routing: /install", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("missing agent returns usage error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /install"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /install`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
 
   test("installs agent successfully and updates state", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /install openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /install openclaw`), deps);
 
     expect(res.result).toBe("ok");
     expect(res.message).toContain("install completed");
@@ -106,22 +111,24 @@ describe("command routing: /install", () => {
 });
 
 describe("command routing: /start", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("start uninstalled agent returns error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /start openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /start openclaw`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_NOT_INSTALLED");
   });
 
   test("start installed agent succeeds and agent becomes running", async () => {
-    await handleCommand(parseInput("telegram 100 req-0 /install openclaw"), deps);
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /start openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /start openclaw`), deps);
 
     expect(res.result).toBe("ok");
 
@@ -132,10 +139,10 @@ describe("command routing: /start", () => {
   });
 
   test("start already-running agent returns error", async () => {
-    await handleCommand(parseInput("telegram 100 req-0 /install openclaw"), deps);
-    await handleCommand(parseInput("telegram 100 req-0 /start openclaw"), deps);
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /start openclaw`), deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /start openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /start openclaw`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_ALREADY_RUNNING");
@@ -143,23 +150,25 @@ describe("command routing: /start", () => {
 });
 
 describe("command routing: /stop", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("stop already-stopped agent returns error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /stop openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /stop openclaw`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_ALREADY_STOPPED");
   });
 
   test("stop running agent succeeds and agent becomes stopped", async () => {
-    await handleCommand(parseInput("telegram 100 req-0 /install openclaw"), deps);
-    await handleCommand(parseInput("telegram 100 req-0 /start openclaw"), deps);
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /start openclaw`), deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /stop openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /stop openclaw`), deps);
 
     expect(res.result).toBe("ok");
 
@@ -170,60 +179,66 @@ describe("command routing: /stop", () => {
 });
 
 describe("command routing: /status", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("returns status for paired chat", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /status openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /status openclaw`), deps);
 
     expect(res.result).toBe("ok");
     expect(res.message).toContain("status");
   });
 
   test("status with no agent id returns all", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /status"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /status`), deps);
 
     expect(res.result).toBe("ok");
   });
 });
 
 describe("command routing: /logs", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("missing agent returns usage error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /logs"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /logs`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
 
   test("returns logs for agent", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /logs openclaw 10"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /logs openclaw 10`), deps);
 
     expect(res.result).toBe("ok");
   });
 });
 
 describe("command routing: /upgrade", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("missing agent returns usage error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /upgrade"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /upgrade`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
 
   test("upgrade succeeds", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /upgrade openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /upgrade openclaw`), deps);
 
     expect(res.result).toBe("ok");
     expect(res.message).toContain("upgrade completed");
@@ -231,20 +246,22 @@ describe("command routing: /upgrade", () => {
 });
 
 describe("command routing: /diagnose", () => {
+  let token: string;
+  
   beforeEach(() => {
     deps = buildDeps();
-    pairChat(deps);
+    token = pairChat(deps);
   });
 
   test("missing agent returns usage error", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose`), deps);
 
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
 
   test("diagnose returns download url", async () => {
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose openclaw"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose openclaw`), deps);
 
     expect(res.result).toBe("ok");
     expect(res.downloadUrl).toContain("/downloads/");

--- a/gateway/src/contracts/commands.ts
+++ b/gateway/src/contracts/commands.ts
@@ -16,6 +16,7 @@ export type GatewayCommand = {
   provider: Provider;
   chatId: string;
   requestId: string;
+  sessionToken?: string;
   name: CommandName;
   args: string[];
 };

--- a/gateway/src/cross-provider.test.ts
+++ b/gateway/src/cross-provider.test.ts
@@ -23,11 +23,16 @@ function buildDeps(): GatewayDependencies {
   };
 }
 
-function pairAll(deps: GatewayDependencies, chatId = "100"): void {
+function pairAll(deps: GatewayDependencies, chatId = "100"): Map<Provider, string> {
+  const tokens = new Map<Provider, string>();
   for (const provider of PROVIDERS) {
     deps.sessions.registerPairCode(`code-${provider}`, 300);
-    deps.sessions.pair({ provider, chatId, code: `code-${provider}` });
+    const session = deps.sessions.pair({ provider, chatId, code: `code-${provider}` });
+    if (session) {
+      tokens.set(provider, session.sessionToken);
+    }
   }
+  return tokens;
 }
 
 /** Strip provider-specific bits from a response so we can compare across providers. */
@@ -38,12 +43,14 @@ function normalize(res: GatewayResponse): Omit<GatewayResponse, "requestId" | "s
 
 async function runAcrossProviders(
   deps: GatewayDependencies,
+  tokens: Map<Provider, string>,
   commandSuffix: string,
   chatId = "100",
 ): Promise<GatewayResponse[]> {
   const results: GatewayResponse[] = [];
   for (const provider of PROVIDERS) {
-    const input = `${provider} ${chatId} req-${provider} ${commandSuffix}`;
+    const token = tokens.get(provider) || "";
+    const input = `${provider} ${chatId} req-${provider} ${token} ${commandSuffix}`;
     const res = await handleCommand(parseInput(input), deps);
     results.push(res);
   }
@@ -59,58 +66,59 @@ function assertAllConsistent(results: GatewayResponse[]): void {
 
 describe("cross-provider consistency", () => {
   let deps: GatewayDependencies;
+  let tokens: Map<Provider, string>;
 
   beforeEach(() => {
     deps = buildDeps();
-    pairAll(deps);
+    tokens = pairAll(deps);
   });
 
   test("/agents returns same result across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/agents");
+    const results = await runAcrossProviders(deps, tokens, "/agents");
     assertAllConsistent(results);
     expect(results[0].result).toBe("ok");
   });
 
   test("/install returns same result across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/install myagent");
+    const results = await runAcrossProviders(deps, tokens, "/install myagent");
     assertAllConsistent(results);
   });
 
   test("/start error is consistent across all providers", async () => {
     // Without installing first, all providers should get the same error
-    const results = await runAcrossProviders(deps, "/start myagent");
+    const results = await runAcrossProviders(deps, tokens, "/start myagent");
     assertAllConsistent(results);
     expect(results[0].result).toBe("error");
   });
 
   test("/stop error is consistent across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/stop myagent");
+    const results = await runAcrossProviders(deps, tokens, "/stop myagent");
     assertAllConsistent(results);
     expect(results[0].result).toBe("error");
   });
 
   test("/status returns same result across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/status");
+    const results = await runAcrossProviders(deps, tokens, "/status");
     assertAllConsistent(results);
   });
 
   test("/logs returns same result across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/logs myagent 10");
+    const results = await runAcrossProviders(deps, tokens, "/logs myagent 10");
     assertAllConsistent(results);
   });
 
   test("/upgrade returns same result across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/upgrade myagent");
+    const results = await runAcrossProviders(deps, tokens, "/upgrade myagent");
     assertAllConsistent(results);
   });
 
   test("/diagnose returns same result shape across all providers", async () => {
-    const results = await runAcrossProviders(deps, "/diagnose myagent");
+    const results = await runAcrossProviders(deps, tokens, "/diagnose myagent");
     assertAllConsistent(results);
   });
 
   test("usage errors are identical across providers", async () => {
-    const results = await runAcrossProviders(deps, "/install");
+    const results = await runAcrossProviders(deps, tokens, "/install");
     assertAllConsistent(results);
     expect(results[0].result).toBe("error");
     expect(results[0].errorCode).toBe("E_USAGE");

--- a/gateway/src/e2e.test.ts
+++ b/gateway/src/e2e.test.ts
@@ -103,14 +103,17 @@ describe("E2E slash command test suite", () => {
   });
 
   describe("2. Agent lifecycle", () => {
+    let token: string;
+    
     beforeEach(async () => {
       // Pair the session first
       const code = issuePairCode(daemon, sessions);
-      await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      const pairResult = await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      token = pairResult.sessionToken!;
     });
 
     test("/agents lists available agents", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-10 /agents");
+      const result = await sendCommand(runtime, `telegram chat1 req-10 ${token} /agents`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("listed");
@@ -118,31 +121,31 @@ describe("E2E slash command test suite", () => {
     });
 
     test("/install openclaw succeeds", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-11 /install openclaw");
+      const result = await sendCommand(runtime, `telegram chat1 req-11 ${token} /install openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("install completed for openclaw");
     });
 
     test("/start openclaw after install succeeds", async () => {
-      await sendCommand(runtime, "telegram chat1 req-12a /install openclaw");
-      const result = await sendCommand(runtime, "telegram chat1 req-12 /start openclaw");
+      await sendCommand(runtime, `telegram chat1 req-12a ${token} /install openclaw`);
+      const result = await sendCommand(runtime, `telegram chat1 req-12 ${token} /start openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("start completed for openclaw");
     });
 
     test("/start without install fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-13 /start openclaw");
+      const result = await sendCommand(runtime, `telegram chat1 req-13 ${token} /start openclaw`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_NOT_INSTALLED");
     });
 
     test("/status shows agent state", async () => {
-      await sendCommand(runtime, "telegram chat1 req-14a /install openclaw");
-      await sendCommand(runtime, "telegram chat1 req-14b /start openclaw");
-      const result = await sendCommand(runtime, "telegram chat1 req-14 /status openclaw");
+      await sendCommand(runtime, `telegram chat1 req-14a ${token} /install openclaw`);
+      await sendCommand(runtime, `telegram chat1 req-14b ${token} /start openclaw`);
+      const result = await sendCommand(runtime, `telegram chat1 req-14 ${token} /status openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("openclaw");
@@ -150,33 +153,33 @@ describe("E2E slash command test suite", () => {
     });
 
     test("/status without agent ID lists all agents", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-15 /status");
+      const result = await sendCommand(runtime, `telegram chat1 req-15 ${token} /status`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("status");
     });
 
     test("/stop openclaw succeeds when running", async () => {
-      await sendCommand(runtime, "telegram chat1 req-16a /install openclaw");
-      await sendCommand(runtime, "telegram chat1 req-16b /start openclaw");
-      const result = await sendCommand(runtime, "telegram chat1 req-16 /stop openclaw");
+      await sendCommand(runtime, `telegram chat1 req-16a ${token} /install openclaw`);
+      await sendCommand(runtime, `telegram chat1 req-16b ${token} /start openclaw`);
+      const result = await sendCommand(runtime, `telegram chat1 req-16 ${token} /stop openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("stop completed for openclaw");
     });
 
     test("/stop when already stopped fails", async () => {
-      await sendCommand(runtime, "telegram chat1 req-17a /install openclaw");
-      const result = await sendCommand(runtime, "telegram chat1 req-17 /stop openclaw");
+      await sendCommand(runtime, `telegram chat1 req-17a ${token} /install openclaw`);
+      const result = await sendCommand(runtime, `telegram chat1 req-17 ${token} /stop openclaw`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_ALREADY_STOPPED");
     });
 
     test("/start when already running fails", async () => {
-      await sendCommand(runtime, "telegram chat1 req-18a /install openclaw");
-      await sendCommand(runtime, "telegram chat1 req-18b /start openclaw");
-      const result = await sendCommand(runtime, "telegram chat1 req-18 /start openclaw");
+      await sendCommand(runtime, `telegram chat1 req-18a ${token} /install openclaw`);
+      await sendCommand(runtime, `telegram chat1 req-18b ${token} /start openclaw`);
+      const result = await sendCommand(runtime, `telegram chat1 req-18 ${token} /start openclaw`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_ALREADY_RUNNING");
@@ -184,35 +187,38 @@ describe("E2E slash command test suite", () => {
   });
 
   describe("3. Logs & diagnose", () => {
+    let token: string;
+    
     beforeEach(async () => {
       const code = issuePairCode(daemon, sessions);
-      await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
-      await sendCommand(runtime, "telegram chat1 req-setup2 /install openclaw");
+      const pairResult = await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      token = pairResult.sessionToken!;
+      await sendCommand(runtime, `telegram chat1 req-setup2 ${token} /install openclaw`);
     });
 
     test("/logs openclaw returns log lines", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-20 /logs openclaw");
+      const result = await sendCommand(runtime, `telegram chat1 req-20 ${token} /logs openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("openclaw");
     });
 
     test("/logs with tail parameter works", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-21 /logs openclaw 50");
+      const result = await sendCommand(runtime, `telegram chat1 req-21 ${token} /logs openclaw 50`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("openclaw");
     });
 
     test("/logs without agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-22 /logs");
+      const result = await sendCommand(runtime, `telegram chat1 req-22 ${token} /logs`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");
     });
 
     test("/diagnose openclaw creates artifact", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-23 /diagnose openclaw");
+      const result = await sendCommand(runtime, `telegram chat1 req-23 ${token} /diagnose openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("diagnose artifact prepared");
@@ -220,7 +226,7 @@ describe("E2E slash command test suite", () => {
     });
 
     test("/diagnose without agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-24 /diagnose");
+      const result = await sendCommand(runtime, `telegram chat1 req-24 ${token} /diagnose`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");
@@ -228,9 +234,9 @@ describe("E2E slash command test suite", () => {
 
     test("/diagnose-consent yes when needed succeeds", async () => {
       daemon.setRemoteDiagnosisState("openclaw", true);
-      await sendCommand(runtime, "telegram chat1 req-25a /diagnose openclaw");
+      await sendCommand(runtime, `telegram chat1 req-25a ${token} /diagnose openclaw`);
       
-      const result = await sendCommand(runtime, "telegram chat1 req-25 /diagnose-consent openclaw yes");
+      const result = await sendCommand(runtime, `telegram chat1 req-25 ${token} /diagnose-consent openclaw yes`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("consent recorded");
@@ -240,16 +246,16 @@ describe("E2E slash command test suite", () => {
 
     test("/diagnose-consent no when needed succeeds", async () => {
       daemon.setRemoteDiagnosisState("openclaw", true);
-      await sendCommand(runtime, "telegram chat1 req-26a /diagnose openclaw");
+      await sendCommand(runtime, `telegram chat1 req-26a ${token} /diagnose openclaw`);
       
-      const result = await sendCommand(runtime, "telegram chat1 req-26 /diagnose-consent openclaw no");
+      const result = await sendCommand(runtime, `telegram chat1 req-26 ${token} /diagnose-consent openclaw no`);
       
       expect(result.result).toBe("ok");
       expect(result.handoffStatus).toBe("declined");
     });
 
     test("/diagnose-consent when not needed fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-27 /diagnose-consent openclaw yes");
+      const result = await sendCommand(runtime, `telegram chat1 req-27 ${token} /diagnose-consent openclaw yes`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_REMOTE_DIAG_NOT_NEEDED");
@@ -257,7 +263,7 @@ describe("E2E slash command test suite", () => {
 
     test("/diagnose-consent with invalid consent flag fails", async () => {
       daemon.setRemoteDiagnosisState("openclaw", true);
-      const result = await sendCommand(runtime, "telegram chat1 req-28 /diagnose-consent openclaw maybe");
+      const result = await sendCommand(runtime, `telegram chat1 req-28 ${token} /diagnose-consent openclaw maybe`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_CONSENT_FLAG_INVALID");
@@ -265,14 +271,17 @@ describe("E2E slash command test suite", () => {
   });
 
   describe("4. Upgrade", () => {
+    let token: string;
+    
     beforeEach(async () => {
       const code = issuePairCode(daemon, sessions);
-      await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
-      await sendCommand(runtime, "telegram chat1 req-setup2 /install openclaw");
+      const pairResult = await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      token = pairResult.sessionToken!;
+      await sendCommand(runtime, `telegram chat1 req-setup2 ${token} /install openclaw`);
     });
 
     test("/upgrade openclaw succeeds", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-30 /upgrade openclaw");
+      const result = await sendCommand(runtime, `telegram chat1 req-30 ${token} /upgrade openclaw`);
       
       expect(result.result).toBe("ok");
       expect(result.message).toContain("upgrade completed");
@@ -282,14 +291,14 @@ describe("E2E slash command test suite", () => {
     });
 
     test("/upgrade without agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-31 /upgrade");
+      const result = await sendCommand(runtime, `telegram chat1 req-31 ${token} /upgrade`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");
     });
 
     test("/upgrade non-existent agent fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-32 /upgrade nonexistent");
+      const result = await sendCommand(runtime, `telegram chat1 req-32 ${token} /upgrade nonexistent`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_AGENT_NOT_FOUND");
@@ -299,9 +308,10 @@ describe("E2E slash command test suite", () => {
   describe("5. Error cases", () => {
     test("unknown command fails", async () => {
       const code = issuePairCode(daemon, sessions);
-      await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      const pairResult = await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      const token = pairResult.sessionToken!;
       
-      const result = await sendCommand(runtime, "telegram chat1 req-40 /unknown");
+      const result = await sendCommand(runtime, `telegram chat1 req-40 ${token} /unknown`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_PARSE");
@@ -366,8 +376,9 @@ describe("E2E slash command test suite", () => {
       const code = issuePairCode(daemon, sessions);
       const pairResult = await sendCommand(runtime, `telegram chat-tg req-50 /pair ${code}`);
       expect(pairResult.result).toBe("ok");
+      const token = pairResult.sessionToken!;
       
-      const agentsResult = await sendCommand(runtime, "telegram chat-tg req-51 /agents");
+      const agentsResult = await sendCommand(runtime, `telegram chat-tg req-51 ${token} /agents`);
       expect(agentsResult.result).toBe("ok");
     });
 
@@ -375,8 +386,9 @@ describe("E2E slash command test suite", () => {
       const code = issuePairCode(daemon, sessions);
       const pairResult = await sendCommand(runtime, `discord chat-dc req-52 /pair ${code}`);
       expect(pairResult.result).toBe("ok");
+      const token = pairResult.sessionToken!;
       
-      const agentsResult = await sendCommand(runtime, "discord chat-dc req-53 /agents");
+      const agentsResult = await sendCommand(runtime, `discord chat-dc req-53 ${token} /agents`);
       expect(agentsResult.result).toBe("ok");
     });
 
@@ -384,8 +396,9 @@ describe("E2E slash command test suite", () => {
       const code = issuePairCode(daemon, sessions);
       const pairResult = await sendCommand(runtime, `feishu chat-fs req-54 /pair ${code}`);
       expect(pairResult.result).toBe("ok");
+      const token = pairResult.sessionToken!;
       
-      const agentsResult = await sendCommand(runtime, "feishu chat-fs req-55 /agents");
+      const agentsResult = await sendCommand(runtime, `feishu chat-fs req-55 ${token} /agents`);
       expect(agentsResult.result).toBe("ok");
     });
 
@@ -393,15 +406,17 @@ describe("E2E slash command test suite", () => {
       const code1 = issuePairCode(daemon, sessions);
       const code2 = issuePairCode(daemon, sessions);
       
-      await sendCommand(runtime, `telegram chat1 req-56 /pair ${code1}`);
-      await sendCommand(runtime, `discord chat1 req-57 /pair ${code2}`);
+      const tgResult = await sendCommand(runtime, `telegram chat1 req-56 /pair ${code1}`);
+      const dcResult = await sendCommand(runtime, `discord chat1 req-57 /pair ${code2}`);
+      const tgToken = tgResult.sessionToken!;
+      const dcToken = dcResult.sessionToken!;
       
       // telegram:chat1 should work
-      const result1 = await sendCommand(runtime, "telegram chat1 req-58 /agents");
+      const result1 = await sendCommand(runtime, `telegram chat1 req-58 ${tgToken} /agents`);
       expect(result1.result).toBe("ok");
       
       // discord:chat1 should work
-      const result2 = await sendCommand(runtime, "discord chat1 req-59 /agents");
+      const result2 = await sendCommand(runtime, `discord chat1 req-59 ${dcToken} /agents`);
       expect(result2.result).toBe("ok");
       
       // telegram:chat2 should fail (not paired)
@@ -421,49 +436,53 @@ describe("E2E slash command test suite", () => {
         const code = issuePairCode(daemon, sessions);
         const pairResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase} /pair ${code}`);
         expect(pairResult.result).toBe("ok");
+        const token = pairResult.sessionToken!;
         
         // Install
-        const installResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 1} /install openclaw`);
+        const installResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 1} ${token} /install openclaw`);
         expect(installResult.result).toBe("ok");
         
         // Start
-        const startResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 2} /start openclaw`);
+        const startResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 2} ${token} /start openclaw`);
         expect(startResult.result).toBe("ok");
         
         // Status
-        const statusResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 3} /status openclaw`);
+        const statusResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 3} ${token} /status openclaw`);
         expect(statusResult.result).toBe("ok");
         expect(statusResult.message).toContain("running");
         
         // Stop
-        const stopResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 4} /stop openclaw`);
+        const stopResult = await sendCommand(runtime, `${provider} ${chatId} req-${reqIdBase + 4} ${token} /stop openclaw`);
         expect(stopResult.result).toBe("ok");
       }
     });
   });
 
   describe("Additional edge cases", () => {
+    let token: string;
+    
     beforeEach(async () => {
       const code = issuePairCode(daemon, sessions);
-      await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      const pairResult = await sendCommand(runtime, `telegram chat1 req-setup /pair ${code}`);
+      token = pairResult.sessionToken!;
     });
 
     test("/install with missing agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-100 /install");
+      const result = await sendCommand(runtime, `telegram chat1 req-100 ${token} /install`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");
     });
 
     test("/start with missing agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-101 /start");
+      const result = await sendCommand(runtime, `telegram chat1 req-101 ${token} /start`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");
     });
 
     test("/stop with missing agent ID fails", async () => {
-      const result = await sendCommand(runtime, "telegram chat1 req-102 /stop");
+      const result = await sendCommand(runtime, `telegram chat1 req-102 ${token} /stop`);
       
       expect(result.result).toBe("error");
       expect(result.errorCode).toBe("E_USAGE");

--- a/gateway/src/index.test.ts
+++ b/gateway/src/index.test.ts
@@ -12,9 +12,10 @@ function buildDeps(): GatewayDependencies {
   };
 }
 
-function pairTelegramChat(deps: GatewayDependencies, chatId = "100"): void {
+function pairTelegramChat(deps: GatewayDependencies, chatId = "100"): string {
   deps.sessions.registerPairCode("pair-ok", 300);
-  deps.sessions.pair({ provider: "telegram", chatId, code: "pair-ok" });
+  const session = deps.sessions.pair({ provider: "telegram", chatId, code: "pair-ok" });
+  return session?.sessionToken ?? "";
 }
 
 describe("gateway parseInput", () => {
@@ -51,40 +52,40 @@ describe("gateway parseInput", () => {
 describe("gateway diagnose-consent routing", () => {
   test("returns usage error when agent is missing", async () => {
     const deps = buildDeps();
-    pairTelegramChat(deps);
+    const token = pairTelegramChat(deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose-consent"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose-consent`), deps);
     expect(res.result).toBe("error");
     expect(res.message).toContain("usage: /diagnose-consent");
   });
 
   test("returns validation error on invalid consent flag", async () => {
     const deps = buildDeps();
-    pairTelegramChat(deps);
+    const token = pairTelegramChat(deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose-consent openclaw maybe"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose-consent openclaw maybe`), deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_CONSENT_FLAG_INVALID");
   });
 
   test("maps not-needed error with code", async () => {
     const deps = buildDeps();
-    pairTelegramChat(deps);
+    const token = pairTelegramChat(deps);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose-consent openclaw yes"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose-consent openclaw yes`), deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_REMOTE_DIAG_NOT_NEEDED");
   });
 
   test("returns handoff payload on success", async () => {
     const deps = buildDeps();
-    pairTelegramChat(deps);
+    const token = pairTelegramChat(deps);
 
     const daemon = deps.daemon as InMemoryDaemonClient;
     daemon.setDiagnoseArtifact("openclaw", "/tmp/openclaw.zip");
     daemon.setRemoteDiagnosisState("openclaw", true);
 
-    const res = await handleCommand(parseInput("telegram 100 req-1 /diagnose-consent openclaw yes"), deps);
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /diagnose-consent openclaw yes`), deps);
     expect(res.result).toBe("ok");
     expect(res.handoffId).toBeDefined();
     expect(res.handoffStatus).toBe("pending");

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -46,10 +46,28 @@ export class ParseError extends Error {
 export function parseInput(input: string): GatewayCommand {
   const parts = input.trim().split(/\s+/);
   if (parts.length < 4) {
-    throw new ParseError("unknown", "usage: <provider> <chat_id> <request_id> <command> [...args]");
+    throw new ParseError("unknown", "usage: <provider> <chat_id> <request_id> [session_token] <command> [...args]");
   }
 
-  const [provider, chatId, requestId, name, ...args] = parts;
+  const [provider, chatId, requestId, fourth, ...rest] = parts;
+  
+  // Check if fourth field is a session token (starts with "session-")
+  // If so, the command is the next field; otherwise fourth is the command
+  let sessionToken: string | undefined;
+  let name: string;
+  let args: string[];
+  
+  if (fourth && fourth.startsWith("session-")) {
+    sessionToken = fourth;
+    [name, ...args] = rest;
+    if (!name) {
+      throw new ParseError(requestId, "usage: <provider> <chat_id> <request_id> <session_token> <command> [...args]");
+    }
+  } else {
+    name = fourth;
+    args = rest;
+  }
+  
   if (!COMMAND_NAMES.has(name as CommandName)) {
     throw new ParseError(requestId, `unknown command: ${name} (requestId=${requestId})`);
   }
@@ -58,6 +76,7 @@ export function parseInput(input: string): GatewayCommand {
     provider: provider as GatewayCommand["provider"],
     chatId,
     requestId,
+    sessionToken,
     name: name as GatewayCommand["name"],
     args,
   };
@@ -108,6 +127,24 @@ export async function handleCommand(
       "chat is not paired; run /pair <code> first",
     );
   }
+  
+  // Validate session token
+  if (!cmd.sessionToken) {
+    return errorResponse(
+      cmd.requestId,
+      "E_SESSION_TOKEN_MISSING",
+      "session token is required for authenticated commands",
+    );
+  }
+  
+  if (cmd.sessionToken !== session.sessionToken) {
+    return errorResponse(
+      cmd.requestId,
+      "E_SESSION_TOKEN_INVALID",
+      "session token is invalid",
+    );
+  }
+  
   deps.sessions.touch(cmd.provider, cmd.chatId);
 
   if (deps.rateLimiter) {

--- a/gateway/src/integration.test.ts
+++ b/gateway/src/integration.test.ts
@@ -12,13 +12,14 @@ function buildDeps(): GatewayDependencies {
   };
 }
 
-function pair(deps: GatewayDependencies, provider = "telegram", chatId = "100"): void {
+function pair(deps: GatewayDependencies, provider = "telegram", chatId = "100"): string {
   // Register pair code with the daemon
   if (deps.daemon instanceof InMemoryDaemonClient) {
     deps.daemon.registerPairCode("test-code");
   }
   // Create the session directly
-  deps.sessions.createSession({ provider: provider as "telegram", chatId });
+  const session = deps.sessions.createSession({ provider: provider as "telegram", chatId });
+  return session.sessionToken;
 }
 
 describe("E2E: pair → install → start → status → stop flow", () => {
@@ -32,30 +33,31 @@ describe("E2E: pair → install → start → status → stop flow", () => {
     const pairRes = await safeHandleCommand("telegram 100 req-pair /pair my-code", deps);
     expect(pairRes.result).toBe("ok");
     expect(pairRes.sessionToken).toBeDefined();
+    const token = pairRes.sessionToken!;
 
     // 2. Install
-    const installRes = await safeHandleCommand("telegram 100 req-install /install openclaw", deps);
+    const installRes = await safeHandleCommand(`telegram 100 req-install ${token} /install openclaw`, deps);
     expect(installRes.result).toBe("ok");
     expect(installRes.message).toContain("install completed");
 
     // 3. Start
-    const startRes = await safeHandleCommand("telegram 100 req-start /start openclaw", deps);
+    const startRes = await safeHandleCommand(`telegram 100 req-start ${token} /start openclaw`, deps);
     expect(startRes.result).toBe("ok");
     expect(startRes.message).toContain("start completed");
 
     // 4. Status — should show running/healthy
-    const statusRes = await safeHandleCommand("telegram 100 req-status /status openclaw", deps);
+    const statusRes = await safeHandleCommand(`telegram 100 req-status ${token} /status openclaw`, deps);
     expect(statusRes.result).toBe("ok");
     expect(statusRes.message).toContain("running");
     expect(statusRes.message).toContain("healthy");
 
     // 5. Stop
-    const stopRes = await safeHandleCommand("telegram 100 req-stop /stop openclaw", deps);
+    const stopRes = await safeHandleCommand(`telegram 100 req-stop ${token} /stop openclaw`, deps);
     expect(stopRes.result).toBe("ok");
     expect(stopRes.message).toContain("stop completed");
 
     // 6. Status after stop — should show stopped
-    const statusAfterStop = await safeHandleCommand("telegram 100 req-status2 /status openclaw", deps);
+    const statusAfterStop = await safeHandleCommand(`telegram 100 req-status2 ${token} /status openclaw`, deps);
     expect(statusAfterStop.result).toBe("ok");
     expect(statusAfterStop.message).toContain("stopped");
   });
@@ -69,27 +71,27 @@ describe("E2E: pair → install → start → status → stop flow", () => {
 
   test("start fails before install", async () => {
     const deps = buildDeps();
-    pair(deps);
-    const res = await safeHandleCommand("telegram 100 req-1 /start openclaw", deps);
+    const token = pair(deps);
+    const res = await safeHandleCommand(`telegram 100 req-1 ${token} /start openclaw`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_NOT_INSTALLED");
   });
 
   test("double start fails", async () => {
     const deps = buildDeps();
-    pair(deps);
-    await safeHandleCommand("telegram 100 req-1 /install openclaw", deps);
-    await safeHandleCommand("telegram 100 req-2 /start openclaw", deps);
-    const res = await safeHandleCommand("telegram 100 req-3 /start openclaw", deps);
+    const token = pair(deps);
+    await safeHandleCommand(`telegram 100 req-1 ${token} /install openclaw`, deps);
+    await safeHandleCommand(`telegram 100 req-2 ${token} /start openclaw`, deps);
+    const res = await safeHandleCommand(`telegram 100 req-3 ${token} /start openclaw`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_ALREADY_RUNNING");
   });
 
   test("stop when already stopped fails", async () => {
     const deps = buildDeps();
-    pair(deps);
-    await safeHandleCommand("telegram 100 req-1 /install openclaw", deps);
-    const res = await safeHandleCommand("telegram 100 req-2 /stop openclaw", deps);
+    const token = pair(deps);
+    await safeHandleCommand(`telegram 100 req-1 ${token} /install openclaw`, deps);
+    const res = await safeHandleCommand(`telegram 100 req-2 ${token} /stop openclaw`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_ALREADY_STOPPED");
   });
@@ -98,10 +100,10 @@ describe("E2E: pair → install → start → status → stop flow", () => {
 describe("E2E: diagnose flow with download token", () => {
   test("diagnose generates artifact and download URL", async () => {
     const deps = buildDeps();
-    pair(deps);
-    await safeHandleCommand("telegram 100 req-1 /install openclaw", deps);
+    const token = pair(deps);
+    await safeHandleCommand(`telegram 100 req-1 ${token} /install openclaw`, deps);
 
-    const res = await safeHandleCommand("telegram 100 req-diag /diagnose openclaw", deps);
+    const res = await safeHandleCommand(`telegram 100 req-diag ${token} /diagnose openclaw`, deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("diagnose artifact prepared");
     expect(res.downloadUrl).toBeDefined();
@@ -110,13 +112,13 @@ describe("E2E: diagnose flow with download token", () => {
 
   test("diagnose-consent flow with remote diagnosis needed", async () => {
     const deps = buildDeps();
-    pair(deps);
+    const token = pair(deps);
 
     const daemon = deps.daemon as InMemoryDaemonClient;
     daemon.setDiagnoseArtifact("openclaw", "/tmp/openclaw-diag.zip");
     daemon.setRemoteDiagnosisState("openclaw", true);
 
-    const res = await safeHandleCommand("telegram 100 req-consent /diagnose-consent openclaw yes", deps);
+    const res = await safeHandleCommand(`telegram 100 req-consent ${token} /diagnose-consent openclaw yes`, deps);
     expect(res.result).toBe("ok");
     expect(res.handoffId).toBeDefined();
     expect(res.handoffStatus).toBe("pending");
@@ -125,21 +127,21 @@ describe("E2E: diagnose flow with download token", () => {
 
   test("diagnose-consent declined returns declined status", async () => {
     const deps = buildDeps();
-    pair(deps);
+    const token = pair(deps);
 
     const daemon = deps.daemon as InMemoryDaemonClient;
     daemon.setRemoteDiagnosisState("openclaw", true);
 
-    const res = await safeHandleCommand("telegram 100 req-consent /diagnose-consent openclaw no", deps);
+    const res = await safeHandleCommand(`telegram 100 req-consent ${token} /diagnose-consent openclaw no`, deps);
     expect(res.result).toBe("ok");
     expect(res.handoffStatus).toBe("declined");
   });
 
   test("diagnose-consent fails when not needed", async () => {
     const deps = buildDeps();
-    pair(deps);
+    const token = pair(deps);
 
-    const res = await safeHandleCommand("telegram 100 req-1 /diagnose-consent openclaw yes", deps);
+    const res = await safeHandleCommand(`telegram 100 req-1 ${token} /diagnose-consent openclaw yes`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_REMOTE_DIAG_NOT_NEEDED");
   });
@@ -148,8 +150,8 @@ describe("E2E: diagnose flow with download token", () => {
 describe("E2E: error propagation", () => {
   test("unknown agent returns E_AGENT_NOT_FOUND", async () => {
     const deps = buildDeps();
-    pair(deps);
-    const res = await safeHandleCommand("telegram 100 req-1 /install nonexistent", deps);
+    const token = pair(deps);
+    const res = await safeHandleCommand(`telegram 100 req-1 ${token} /install nonexistent`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_AGENT_NOT_FOUND");
   });
@@ -163,18 +165,19 @@ describe("E2E: error propagation", () => {
 
   test("unknown command name returns parse error", async () => {
     const deps = buildDeps();
-    const res = await safeHandleCommand("telegram 100 req-1 /unknown", deps);
+    const token = pair(deps);
+    const res = await safeHandleCommand(`telegram 100 req-1 ${token} /unknown`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_PARSE");
   });
 
   test("missing args return usage error", async () => {
     const deps = buildDeps();
-    pair(deps);
+    const token = pair(deps);
 
     const commands = ["/install", "/start", "/stop", "/logs", "/upgrade", "/diagnose"];
     for (const cmd of commands) {
-      const res = await safeHandleCommand(`telegram 100 req-1 ${cmd}`, deps);
+      const res = await safeHandleCommand(`telegram 100 req-1 ${token} ${cmd}`, deps);
       expect(res.result).toBe("error");
       expect(res.errorCode).toBe("E_USAGE");
     }
@@ -182,10 +185,10 @@ describe("E2E: error propagation", () => {
 
   test("error codes propagate from daemon to gateway response", async () => {
     const deps = buildDeps();
-    pair(deps);
+    const token = pair(deps);
 
     // Try to start without install → E_NOT_INSTALLED from daemon
-    const res = await safeHandleCommand("telegram 100 req-1 /start openclaw", deps);
+    const res = await safeHandleCommand(`telegram 100 req-1 ${token} /start openclaw`, deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_NOT_INSTALLED");
     expect(res.message).toContain("not installed");
@@ -195,22 +198,22 @@ describe("E2E: error propagation", () => {
 describe("E2E: logs and upgrade", () => {
   test("logs after lifecycle actions", async () => {
     const deps = buildDeps();
-    pair(deps);
-    await safeHandleCommand("telegram 100 r1 /install openclaw", deps);
-    await safeHandleCommand("telegram 100 r2 /start openclaw", deps);
-    await safeHandleCommand("telegram 100 r3 /stop openclaw", deps);
+    const token = pair(deps);
+    await safeHandleCommand(`telegram 100 r1 ${token} /install openclaw`, deps);
+    await safeHandleCommand(`telegram 100 r2 ${token} /start openclaw`, deps);
+    await safeHandleCommand(`telegram 100 r3 ${token} /stop openclaw`, deps);
 
-    const res = await safeHandleCommand("telegram 100 r4 /logs openclaw 200", deps);
+    const res = await safeHandleCommand(`telegram 100 r4 ${token} /logs openclaw 200`, deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("log lines");
   });
 
   test("upgrade bumps version", async () => {
     const deps = buildDeps();
-    pair(deps);
-    await safeHandleCommand("telegram 100 r1 /install openclaw", deps);
+    const token = pair(deps);
+    await safeHandleCommand(`telegram 100 r1 ${token} /install openclaw`, deps);
 
-    const res = await safeHandleCommand("telegram 100 r2 /upgrade openclaw", deps);
+    const res = await safeHandleCommand(`telegram 100 r2 ${token} /upgrade openclaw`, deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("0.1.0");
     expect(res.message).toContain("0.1.1");
@@ -219,8 +222,8 @@ describe("E2E: logs and upgrade", () => {
 
   test("agents list shows all agents", async () => {
     const deps = buildDeps();
-    pair(deps);
-    const res = await safeHandleCommand("telegram 100 r1 /agents", deps);
+    const token = pair(deps);
+    const res = await safeHandleCommand(`telegram 100 r1 ${token} /agents`, deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("1 agents");
   });
@@ -234,8 +237,9 @@ describe("E2E: multi-provider support", () => {
     }
     const res = await safeHandleCommand("discord guild-1 req-1 /pair dc-code", deps);
     expect(res.result).toBe("ok");
+    const token = res.sessionToken!;
 
-    const status = await safeHandleCommand("discord guild-1 req-2 /status", deps);
+    const status = await safeHandleCommand(`discord guild-1 req-2 ${token} /status`, deps);
     expect(status.result).toBe("ok");
   });
 
@@ -246,8 +250,9 @@ describe("E2E: multi-provider support", () => {
     }
     const res = await safeHandleCommand("feishu chat-1 req-1 /pair fs-code", deps);
     expect(res.result).toBe("ok");
+    const token = res.sessionToken!;
 
-    const status = await safeHandleCommand("feishu chat-1 req-2 /status", deps);
+    const status = await safeHandleCommand(`feishu chat-1 req-2 ${token} /status`, deps);
     expect(status.result).toBe("ok");
   });
 });

--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -211,18 +211,16 @@ describe("gateway runtime routes", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ input: "telegram 100 req-1 /pair pair-ok" }),
     }));
-    const pairPayload = await pairResponse.json() as { result: string; sessionToken?: string };
+    const pairPayload = await pairResponse.json() as { result: string; sessionToken: string };
     expect(pairPayload.result).toBe("ok");
-    expect(pairPayload.sessionToken).toBeDefined();
-
-    const sessionToken = pairPayload.sessionToken as string;
+    const sessionToken = pairPayload.sessionToken;
     const agentsResponse = await runtime.fetch(new Request("http://gateway.local/command", {
       method: "POST",
       headers: { 
         "content-type": "application/json",
         "authorization": `Bearer ${sessionToken}`,
       },
-      body: JSON.stringify({ input: "telegram 100 req-2 /agents" }),
+      body: JSON.stringify({ input: `telegram 100 req-2 ${sessionToken} /agents` }),
     }));
     const agentsPayload = await agentsResponse.json() as { result: string; message: string };
     expect(agentsPayload.result).toBe("ok");

--- a/gateway/src/session-token-validation.test.ts
+++ b/gateway/src/session-token-validation.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { handleCommand, parseInput, type GatewayDependencies } from "./index";
+import { InMemoryDaemonClient } from "./daemon/client";
+import { SessionStore } from "./session/store";
+import { DownloadTokenStore } from "./downloads/token_store";
+
+let deps: GatewayDependencies;
+
+function buildDeps(): GatewayDependencies {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+function pairChat(d: GatewayDependencies, provider: "telegram" | "discord" | "feishu" = "telegram", chatId = "100"): string {
+  if (d.daemon instanceof InMemoryDaemonClient) {
+    d.daemon.registerPairCode("pair-ok");
+  }
+  const session = d.sessions.createSession({ provider, chatId });
+  return session.sessionToken;
+}
+
+describe("session token validation", () => {
+  beforeEach(() => {
+    deps = buildDeps();
+  });
+
+  test("parseInput extracts session token when present", () => {
+    const cmd = parseInput("telegram 100 req-1 session-abc123 /agents");
+    expect(cmd.sessionToken).toBe("session-abc123");
+    expect(cmd.name).toBe("/agents");
+    expect(cmd.args).toEqual([]);
+  });
+
+  test("parseInput treats non-session token as command name for backward compat", () => {
+    const cmd = parseInput("telegram 100 req-1 /agents");
+    expect(cmd.sessionToken).toBeUndefined();
+    expect(cmd.name).toBe("/agents");
+  });
+
+  test("parseInput extracts session token with args", () => {
+    const cmd = parseInput("telegram 100 req-1 session-xyz /install openclaw");
+    expect(cmd.sessionToken).toBe("session-xyz");
+    expect(cmd.name).toBe("/install");
+    expect(cmd.args).toEqual(["openclaw"]);
+  });
+
+  test("commands without session token are rejected", async () => {
+    pairChat(deps);
+    const res = await handleCommand(parseInput("telegram 100 req-1 /agents"), deps);
+    
+    expect(res.result).toBe("error");
+    expect(res.errorCode).toBe("E_SESSION_TOKEN_MISSING");
+    expect(res.message).toContain("session token is required");
+  });
+
+  test("commands with wrong session token are rejected", async () => {
+    pairChat(deps);
+    const res = await handleCommand(
+      parseInput("telegram 100 req-1 session-wrong /agents"),
+      deps
+    );
+    
+    expect(res.result).toBe("error");
+    expect(res.errorCode).toBe("E_SESSION_TOKEN_INVALID");
+    expect(res.message).toContain("session token is invalid");
+  });
+
+  test("commands with correct session token succeed", async () => {
+    const sessionToken = pairChat(deps);
+    const res = await handleCommand(
+      parseInput(`telegram 100 req-1 ${sessionToken} /agents`),
+      deps
+    );
+    
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("listed");
+  });
+
+  test("/pair does not require session token", async () => {
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("my-code");
+    }
+    
+    const res = await handleCommand(parseInput("telegram 100 req-1 /pair my-code"), deps);
+    
+    expect(res.result).toBe("ok");
+    expect(res.sessionToken).toBeString();
+    expect(res.sessionToken).toMatch(/^session-/);
+  });
+
+  test("all command types require valid session token", async () => {
+    const sessionToken = pairChat(deps);
+    const commands = [
+      "/agents",
+      "/status",
+      "/install openclaw",
+      "/logs openclaw",
+      "/upgrade openclaw",
+    ];
+
+    let reqId = 1;
+    for (const cmdStr of commands) {
+      // Without token - should fail
+      const failRes = await handleCommand(
+        parseInput(`telegram 100 req-${reqId++} ${cmdStr}`),
+        deps
+      );
+      expect(failRes.result).toBe("error");
+      expect(failRes.errorCode).toBe("E_SESSION_TOKEN_MISSING");
+
+      // With correct token - should succeed (or fail with different error like E_NOT_INSTALLED)
+      const successRes = await handleCommand(
+        parseInput(`telegram 100 req-${reqId++} ${sessionToken} ${cmdStr}`),
+        deps
+      );
+      expect(successRes.errorCode).not.toBe("E_SESSION_TOKEN_MISSING");
+      expect(successRes.errorCode).not.toBe("E_SESSION_TOKEN_INVALID");
+    }
+  });
+
+  test("session token validation works across different providers", async () => {
+    const telegramToken = pairChat(deps, "telegram", "100");
+    const discordToken = pairChat(deps, "discord", "200");
+    
+    // Telegram chat using Discord token should fail
+    const res1 = await handleCommand(
+      parseInput(`telegram 100 req-1 ${discordToken} /agents`),
+      deps
+    );
+    expect(res1.result).toBe("error");
+    expect(res1.errorCode).toBe("E_SESSION_TOKEN_INVALID");
+    
+    // Discord chat using Telegram token should fail
+    const res2 = await handleCommand(
+      parseInput(`discord 200 req-2 ${telegramToken} /agents`),
+      deps
+    );
+    expect(res2.result).toBe("error");
+    expect(res2.errorCode).toBe("E_SESSION_TOKEN_INVALID");
+    
+    // Each with correct token should succeed
+    const res3 = await handleCommand(
+      parseInput(`telegram 100 req-3 ${telegramToken} /agents`),
+      deps
+    );
+    expect(res3.result).toBe("ok");
+    
+    const res4 = await handleCommand(
+      parseInput(`discord 200 req-4 ${discordToken} /agents`),
+      deps
+    );
+    expect(res4.result).toBe("ok");
+  });
+
+  test("session token from re-pairing is reused and validated", async () => {
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("code1");
+      deps.daemon.registerPairCode("code2");
+    }
+    
+    // First pairing
+    const res1 = await handleCommand(parseInput("telegram 100 req-1 /pair code1"), deps);
+    expect(res1.result).toBe("ok");
+    const token1 = res1.sessionToken!;
+    
+    // Second pairing (same provider+chatId)
+    const res2 = await handleCommand(parseInput("telegram 100 req-2 /pair code2"), deps);
+    expect(res2.result).toBe("ok");
+    const token2 = res2.sessionToken!;
+    
+    // Token should be reused
+    expect(token1).toBe(token2);
+    
+    // Old token should still work
+    const res3 = await handleCommand(
+      parseInput(`telegram 100 req-3 ${token1} /agents`),
+      deps
+    );
+    expect(res3.result).toBe("ok");
+  });
+});


### PR DESCRIPTION
Closes #728

## Summary
Fixes the security vulnerability where session tokens issued at pairing were never validated on subsequent commands.

## Changes
- **Added  field** to  contract
- **Updated ** to extract session token from command input (backward compatible)
- **Added session token validation** in  for all non- commands
- **Reject requests** with missing or invalid session tokens:
  -  - when token is not provided
  -  - when token doesn't match the stored session
- **Added comprehensive test coverage** for session token validation (10 new tests)
- **Updated all existing tests** to include session tokens in their commands (282 tests passing)

## Command Format
The session token is now required for all authenticated commands:
```
<provider> <chatId> <requestId> <sessionToken> <command> [...args]
```

Example:
```
telegram 100 req-1 session-abc123 /agents
```

For backward compatibility during parsing, if the 4th field doesn't start with `session-`, it's treated as the command name (legacy format).

## Testing
- ✅ All 282 tests passing
- ✅ Type checking passed
- ✅ Added dedicated session token validation test suite
- ✅ Updated all integration, e2e, and cross-provider tests