### PR TITLE
ci(security): enforce least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: CI only needs read access to repository contents.
+permissions:
+  contents: read
+
 jobs:
   daemon-tests:
     name: Daemon Tests


### PR DESCRIPTION
## Summary
- add explicit workflow-level `permissions` to CI
- scope `GITHUB_TOKEN` to read-only repository contents
- document least-privilege rationale inline in workflow

## Why
Closes #889 by making token scope explicit and auditable.

## Validation
- Workflow YAML parses
- Existing jobs only require checkout/read operations; no write scopes requested
