### PR TITLE
fix(config): warn when config file permissions are too permissive

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -87,10 +87,41 @@ func Load(path string) (Config, error) {
 		if err := json.Unmarshal(data, &cfg); err != nil {
 			return cfg, fmt.Errorf("config: parse %s: %w", path, err)
 		}
+
+		// Check file permissions if config was loaded from disk
+		if err := checkConfigPermissions(path, &cfg); err != nil {
+			return cfg, err
+		}
 	}
 
 	applyEnvOverrides(&cfg)
 	return cfg, nil
+}
+
+// checkConfigPermissions verifies that the config file has appropriate
+// permissions when it contains sensitive data like API tokens.
+// Returns an error if the file is world-readable (perms > 0600) and
+// contains an API token.
+func checkConfigPermissions(path string, cfg *Config) error {
+	// Only check permissions if an API token is present in the config file
+	if cfg.Server.APIToken == "" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("config: stat %s: %w", path, err)
+	}
+
+	perm := info.Mode().Perm()
+
+	// Check if permissions are too permissive (more than 0600)
+	// 0600 = owner read/write only, no group or world access
+	if perm > 0o600 {
+		return fmt.Errorf("config: %s contains api_token but has insecure permissions %04o (should be 0600 or stricter)", path, perm)
+	}
+
+	return nil
 }
 
 // CrashWindowDuration parses the CrashWindow string as a time.Duration.

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -118,3 +118,96 @@ func TestCrashDurations(t *testing.T) {
 		t.Errorf("expected 5m, got %v", c)
 	}
 }
+
+func TestConfigPermissionsSecure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data := `{"server":{"api_token":"secret123"}}`
+
+	// Write with secure permissions (0600)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error with secure permissions: %v", err)
+	}
+	if cfg.Server.APIToken != "secret123" {
+		t.Errorf("expected api_token secret123, got %s", cfg.Server.APIToken)
+	}
+}
+
+func TestConfigPermissionsInsecure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data := `{"server":{"api_token":"secret123"}}`
+
+	// Write with insecure permissions (0644 - world readable)
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for insecure permissions with api_token")
+	}
+	// Check that error message mentions permissions
+	errMsg := err.Error()
+	if !contains(errMsg, "insecure permissions") && !contains(errMsg, "0644") {
+		t.Errorf("expected error about insecure permissions, got: %v", err)
+	}
+}
+
+func TestConfigPermissionsNoToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data := `{"server":{"host":"0.0.0.0","port":8080}}`
+
+	// Write with world-readable permissions but no api_token
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error when no api_token present: %v", err)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", cfg.Server.Port)
+	}
+}
+
+func TestConfigPermissionsStricter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data := `{"server":{"api_token":"secret123"}}`
+
+	// Write with even stricter permissions (0400 - read-only)
+	if err := os.WriteFile(path, []byte(data), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error with stricter permissions: %v", err)
+	}
+	if cfg.Server.APIToken != "secret123" {
+		t.Errorf("expected api_token secret123, got %s", cfg.Server.APIToken)
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #867

## Summary
This PR adds security checks to validate config file permissions when the file contains an API token.

## Changes
- Added `checkConfigPermissions` function to validate file permissions after loading config
- Returns an error if a config file containing `api_token` has permissions more permissive than 0600
- Added comprehensive tests covering:
  - Secure permissions (0600) ✅
  - Insecure permissions (0644) ❌
  - No token with permissive permissions ✅
  - Stricter permissions (0400) ✅

## Security Impact
This prevents API tokens from being accidentally exposed via world-readable config files. Files containing sensitive credentials should only be readable by the owner (0600 or stricter).