### PR TITLE
feat(gateway): persist sessions to disk for restart resilience

### DIFF
--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -2,6 +2,7 @@ import { safeHandleCommand, type GatewayDependencies } from "./index";
 import { HttpDaemonClient } from "./daemon/http_client";
 import { DownloadTokenStore } from "./downloads/token_store";
 import { SessionStore } from "./session/store";
+import { join } from "node:path";
 
 export type GatewayRequestContext = {
   request: Request;
@@ -56,9 +57,13 @@ export const requestIdMiddleware: GatewayMiddleware = async (ctx, next) => {
 };
 
 export function createRuntimeDependencies(overrides: Partial<GatewayDependencies> = {}): GatewayDependencies {
+  // Determine session persistence path from environment or use a default
+  const dataDir = process.env.SESSION_DATA_DIR ?? process.env.ARTIFACT_ROOT ?? process.cwd();
+  const sessionPersistencePath = join(dataDir, "sessions.json");
+  
   return {
     daemon: overrides.daemon ?? new HttpDaemonClient(),
-    sessions: overrides.sessions ?? new SessionStore(),
+    sessions: overrides.sessions ?? new SessionStore(undefined, undefined, sessionPersistencePath).startPeriodicCleanup(),
     downloads: overrides.downloads ?? new DownloadTokenStore().startPeriodicCleanup(),
     rateLimiter: overrides.rateLimiter,
   };

--- a/gateway/src/session/store.test.ts
+++ b/gateway/src/session/store.test.ts
@@ -223,4 +223,112 @@ describe("SessionStore", () => {
       expect(store.sessionCount).toBe(1);
     });
   });
+
+  describe("persistence", () => {
+    const testDir = "/tmp/carrier-session-test";
+    
+    // Helper to generate unique path for each test
+    function getTestPath(name: string): string {
+      return `${testDir}/${name}-${Date.now()}-${Math.random()}.json`;
+    }
+
+    test("creates session and persists to disk", async () => {
+      const testPath = getTestPath("create-persist");
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      
+      store.createSession({ provider: "telegram", chatId: "persist-1" });
+      
+      // Wait for async save to complete
+      await store.flush();
+
+      // Verify file exists and contains the session
+      const file = Bun.file(testPath);
+      const content = await file.text();
+      const sessions = JSON.parse(content);
+
+      expect(Array.isArray(sessions)).toBe(true);
+      expect(sessions.length).toBe(1);
+      expect(sessions[0].provider).toBe("telegram");
+      expect(sessions[0].chatId).toBe("persist-1");
+    });
+
+    test("loads sessions from disk on initialization", async () => {
+      const testPath = getTestPath("load-persist");
+      // First store creates and saves session
+      const store1 = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      const session = store1.createSession({ provider: "discord", chatId: "persist-2" });
+      await store1.flush();
+
+      // Second store loads from disk
+      const store2 = new SessionStore(() => new Date("2026-01-01T00:01:00Z"), 30 * 24 * 60 * 60, testPath);
+      const loaded = store2.getSession("discord", "persist-2");
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.sessionToken).toBe(session.sessionToken);
+      expect(loaded!.createdAt).toBe(session.createdAt);
+    });
+
+    test("handles missing persistence file gracefully", () => {
+      const missingPath = "/tmp/carrier-session-test/nonexistent.json";
+      // Should not throw when file doesn't exist
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, missingPath);
+      expect(store.sessionCount).toBe(0);
+    });
+
+    test("handles corrupt persistence file gracefully", async () => {
+      const corruptPath = `${testDir}/corrupt.json`;
+      await Bun.write(corruptPath, "{ this is not valid json");
+      
+      // Should not throw, just start fresh
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, corruptPath);
+      expect(store.sessionCount).toBe(0);
+    });
+
+    test("persists multiple sessions", async () => {
+      const testPath = getTestPath("multi-persist");
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      
+      store.createSession({ provider: "telegram", chatId: "multi-1" });
+      store.createSession({ provider: "discord", chatId: "multi-2" });
+      store.createSession({ provider: "telegram", chatId: "multi-3" });
+      
+      await store.flush();
+
+      // Load in new store
+      const store2 = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      expect(store2.sessionCount).toBe(3);
+      expect(store2.getSession("telegram", "multi-1")).not.toBeNull();
+      expect(store2.getSession("discord", "multi-2")).not.toBeNull();
+      expect(store2.getSession("telegram", "multi-3")).not.toBeNull();
+    });
+
+    test("pairing persists to disk", async () => {
+      const testPath = getTestPath("pair-persist");
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      
+      store.registerPairCode("pair-persist", 300);
+      const session = store.pair({ provider: "telegram", chatId: "paired-1", code: "pair-persist" });
+      
+      await store.flush();
+
+      // Verify persistence
+      const store2 = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      const loaded = store2.getSession("telegram", "paired-1");
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.sessionToken).toBe(session!.sessionToken);
+    });
+
+    test("without persistence path, store works in-memory only", async () => {
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"));
+      
+      store.createSession({ provider: "telegram", chatId: "memory-only" });
+      
+      // flush should be a no-op
+      await store.flush();
+      
+      // Session exists in memory
+      expect(store.getSession("telegram", "memory-only")).not.toBeNull();
+    });
+  });
 });

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -3,6 +3,9 @@ import type {
   SessionRecord,
 } from "../contracts/session";
 import type { Provider } from "../contracts/commands";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rename } from "node:fs/promises";
+import { dirname } from "node:path";
 
 type PairingCodeRecord = {
   code: string;
@@ -17,11 +20,17 @@ export class SessionStore {
   private readonly pairCodes = new Map<string, PairingCodeRecord>();
   private readonly sessions = new Map<string, SessionRecord>();
   private cleanupIntervalId: Timer | null = null;
+  private savePromise: Promise<void> | null = null;
 
   constructor(
     private readonly now: () => Date = () => new Date(),
-    private readonly sessionTTLSeconds: number = 30 * 24 * 60 * 60 // 30 days default
-  ) {}
+    private readonly sessionTTLSeconds: number = 30 * 24 * 60 * 60, // 30 days default
+    private readonly persistencePath?: string
+  ) {
+    if (this.persistencePath) {
+      this.loadSessions();
+    }
+  }
 
   issuePairCode(ttlSeconds = 300): PairingCodeRecord {
     const code = `pair-${crypto.randomUUID()}`;
@@ -60,6 +69,7 @@ export class SessionStore {
       lastSeenAt: this.now().toISOString(),
     };
     this.sessions.set(sessionKey(request.provider, request.chatId), session);
+    this.scheduleSave();
     return session;
   }
 
@@ -75,6 +85,7 @@ export class SessionStore {
       lastSeenAt: this.now().toISOString(),
     };
     this.sessions.set(sessionKey(request.provider, request.chatId), session);
+    this.scheduleSave();
     return session;
   }
 
@@ -106,11 +117,18 @@ export class SessionStore {
     
     // Clean up stale sessions (not seen within TTL)
     const sessionCutoff = nowMs - this.sessionTTLSeconds * 1000;
+    let sessionsRemoved = 0;
     for (const [key, session] of this.sessions) {
       if (Date.parse(session.lastSeenAt) <= sessionCutoff) {
         this.sessions.delete(key);
         removed += 1;
+        sessionsRemoved += 1;
       }
+    }
+    
+    // If any sessions were removed, persist the updated state
+    if (sessionsRemoved > 0) {
+      this.scheduleSave();
     }
     
     return removed;
@@ -140,6 +158,71 @@ export class SessionStore {
     if (this.cleanupIntervalId !== null) {
       clearInterval(this.cleanupIntervalId);
       this.cleanupIntervalId = null;
+    }
+  }
+
+  /** Wait for any pending save operation to complete. */
+  async flush(): Promise<void> {
+    if (this.savePromise !== null) {
+      await this.savePromise;
+    }
+  }
+
+  private loadSessions(): void {
+    if (!this.persistencePath || !existsSync(this.persistencePath)) {
+      return;
+    }
+
+    try {
+      const data = readFileSync(this.persistencePath, "utf-8");
+      const parsed = JSON.parse(data);
+      
+      if (Array.isArray(parsed)) {
+        for (const session of parsed) {
+          this.sessions.set(sessionKey(session.provider, session.chatId), session);
+        }
+      }
+    } catch (error) {
+      // If the file is corrupt or invalid, start fresh
+      console.error("Failed to load sessions from disk:", error);
+    }
+  }
+
+  private scheduleSave(): void {
+    if (!this.persistencePath) {
+      return;
+    }
+
+    // Debounce saves to avoid excessive I/O
+    if (this.savePromise !== null) {
+      return;
+    }
+
+    this.savePromise = this.saveSessions().finally(() => {
+      this.savePromise = null;
+    });
+  }
+
+  private async saveSessions(): Promise<void> {
+    if (!this.persistencePath) {
+      return;
+    }
+
+    try {
+      // Ensure the directory exists
+      const dir = dirname(this.persistencePath);
+      await mkdir(dir, { recursive: true });
+
+      // Convert sessions map to array
+      const sessions = Array.from(this.sessions.values());
+      const json = JSON.stringify(sessions, null, 2);
+
+      // Atomic write: write to temp file, then rename
+      const tempPath = `${this.persistencePath}.tmp`;
+      await Bun.write(tempPath, json);
+      await rename(tempPath, this.persistencePath);
+    } catch (error) {
+      console.error("Failed to save sessions to disk:", error);
     }
   }
 


### PR DESCRIPTION
Closes #866

## Changes

This PR adds file-based persistence to the gateway's SessionStore, resolving the issue where restarting the gateway would lose all paired device sessions.

### Implementation Details

1. **Persistent Storage**: Sessions are now saved to a JSON file () using atomic writes (write to temp file, then rename)
2. **Auto-load on Startup**: Sessions are automatically loaded from disk when the SessionStore is initialized
3. **Configuration**: Storage location can be configured via  or  environment variables, defaulting to the current working directory
4. **Atomic Writes**: Uses write-to-temp-then-rename pattern to prevent corruption
5. **Cleanup Persistence**: When cleanup removes stale sessions, the updated state is persisted to disk
6. **Graceful Error Handling**: Corrupted or missing files are handled gracefully without crashing

### Testing

- Added 7 new tests covering:
  - Session creation and persistence
  - Loading sessions on initialization  
  - Handling missing/corrupt files
  - Multi-session persistence
  - Pairing persistence
  - In-memory mode (when no path provided)
- All 300 existing tests still pass
- TypeScript checks pass

### Backward Compatibility

- The SessionStore can still be used without persistence by omitting the  parameter
- Default behavior in production now enables persistence using standard data directories