### PR TITLE
fix(daemon/api): handle /api/v1/status and /api/v1/logs agent IDs correctly

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -228,7 +228,7 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool) *http.ServeMux {
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		raw := strings.TrimPrefix(r.URL.Path, "/api/status/")
+		raw := trimPathByPrefixes(r.URL.Path, "/api/status/", "/api/v1/status/")
 		agentID, err := parsePathAgentID(raw)
 		if err != nil {
 			writeJSONError(w, http.StatusBadRequest, err.Error())
@@ -247,7 +247,7 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool) *http.ServeMux {
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		raw := strings.TrimPrefix(r.URL.Path, "/api/logs/")
+		raw := trimPathByPrefixes(r.URL.Path, "/api/logs/", "/api/v1/logs/")
 		agentID, err := parsePathAgentID(raw)
 		if err != nil {
 			writeJSONError(w, http.StatusBadRequest, err.Error())
@@ -334,6 +334,15 @@ func validateAgentID(id string) error {
 		return fmt.Errorf("agent ID contains invalid characters")
 	}
 	return nil
+}
+
+func trimPathByPrefixes(path string, prefixes ...string) string {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(path, prefix) {
+			return strings.TrimPrefix(path, prefix)
+		}
+	}
+	return path
 }
 
 // parsePathAgentID extracts, URL-decodes, and validates an agent ID from a URL path segment.

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -209,6 +209,46 @@ func TestAPIListAgentsV1(t *testing.T) {
 	}
 }
 
+func TestAPIStatusAndLogsV1Aliases(t *testing.T) {
+	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
+		t.Fatal(err)
+	}
+	mux := buildTestMux(svc, true)
+
+	statusRec := httptest.NewRecorder()
+	mux.ServeHTTP(statusRec, httptest.NewRequest("GET", "/api/v1/status/openclaw", nil))
+	if statusRec.Code != http.StatusOK {
+		t.Fatalf("v1 status: expected 200, got %d: %s", statusRec.Code, statusRec.Body.String())
+	}
+
+	logsRec := httptest.NewRecorder()
+	mux.ServeHTTP(logsRec, httptest.NewRequest("GET", "/api/v1/logs/openclaw", nil))
+	if logsRec.Code != http.StatusOK {
+		t.Fatalf("v1 logs: expected 200, got %d: %s", logsRec.Code, logsRec.Body.String())
+	}
+}
+
+func TestAPIStatusAndLogsV1AliasesInvalidAgentID(t *testing.T) {
+	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
+		t.Fatal(err)
+	}
+	mux := buildTestMux(svc, true)
+
+	statusRec := httptest.NewRecorder()
+	mux.ServeHTTP(statusRec, httptest.NewRequest("GET", "/api/v1/status/bad/id", nil))
+	if statusRec.Code != http.StatusBadRequest {
+		t.Fatalf("v1 status invalid id: expected 400, got %d", statusRec.Code)
+	}
+
+	logsRec := httptest.NewRecorder()
+	mux.ServeHTTP(logsRec, httptest.NewRequest("GET", "/api/v1/logs/bad/id", nil))
+	if logsRec.Code != http.StatusBadRequest {
+		t.Fatalf("v1 logs invalid id: expected 400, got %d", logsRec.Code)
+	}
+}
+
 func TestAPIInstallAndStart(t *testing.T) {
 	svc := lifecycle.NewService(
 		baseagent.NoopTriager{},


### PR DESCRIPTION
## Summary
- fix dynamic path normalization for versioned aliases on status/logs endpoints
- add a shared path-prefix helper used by both `/api/*` and `/api/v1/*` dynamic handlers
- add regression tests covering v1 status/logs for valid and invalid agent IDs

## Validation
- cd daemon && go test ./cmd/agentd -run 'TestAPI(Status|Logs|StatusAndLogs).*V1|TestAPIStatusNotFound'
- cd daemon && go test ./...

Closes #909
