### PR TITLE
refactor(api): simplify parseAgentActionPath prefix slicing

### DIFF
--- a/daemon/internal/api/server.go
+++ b/daemon/internal/api/server.go
@@ -370,7 +370,7 @@ func parseAgentActionPath(path string) (agentID string, action string, ok bool) 
 	if !strings.HasPrefix(path, prefix) {
 		return "", "", false
 	}
-	rest := strings.TrimPrefix(path, prefix)
+	rest := path[len(prefix):]
 	if strings.Contains(rest, "//") {
 		return "", "", false
 	}


### PR DESCRIPTION
## Summary
- simplify `parseAgentActionPath` by slicing `path[len(prefix):]` after `HasPrefix` guard
- preserve existing validation logic and behavior

## Testing
- `cd daemon && go test ./internal/api -count=1`

Closes #914
