### PR TITLE
fix(ci): make Kanban sync fail-open when CARRIER_PROJECT_ID is missing

### DIFF
--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -22,7 +22,7 @@ jobs:
           script: |
             const projectId = process.env.CARRIER_PROJECT_ID;
             if (!projectId) {
-              core.setFailed('CARRIER_PROJECT_ID is required. Set it in repository/environment variables.');
+              core.warning('CARRIER_PROJECT_ID is not set; skipping Kanban sync for this run.');
               return;
             }
             const statusFieldNames = ['Status', '状态'];


### PR DESCRIPTION
## Summary
Fix Kanban sync CI false failures caused by missing `CARRIER_PROJECT_ID`.

## Change
- In `.github/workflows/carrier-kanban-automation.yml`, changed missing project-id behavior from:
  - `core.setFailed(...)`
  to
  - `core.warning(...)` + early return

## Why
`sync` was failing on unrelated PRs due to workflow configuration state, even when all core code checks were green. This makes the Kanban sync job fail-open for missing project configuration and prevents unrelated PRs from being blocked.