### PR TITLE
fix(ci): complete Kanban project-id resolution and vars wiring

### DIFF
--- a/.github/scripts/kanban-project-id.js
+++ b/.github/scripts/kanban-project-id.js
@@ -1,0 +1,74 @@
+const sanitizeProjectIdValue = (value) => String(value || '').trim().replace(/^["']|["']$/g, '');
+
+const USER_OR_ORG_PROJECT_URL = /^https?:\/\/github\.com\/(users|orgs)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i;
+const REPO_PROJECT_URL = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i;
+
+async function resolveProjectId(candidate, options = {}) {
+  const raw = sanitizeProjectIdValue(candidate);
+  const { graphql, log = () => {} } = options;
+
+  if (!raw) return '';
+
+  if (/^PVT_[A-Za-z0-9_]+$/.test(raw) || /^PD_[A-Za-z0-9_]+$/.test(raw)) {
+    return raw;
+  }
+
+  if (typeof graphql !== 'function') {
+    return raw;
+  }
+
+  const userOrOrg = raw.match(USER_OR_ORG_PROJECT_URL);
+  if (userOrOrg) {
+    const [, scope, login, number] = userOrOrg;
+    const num = Number.parseInt(number, 10);
+    if (!Number.isFinite(num)) return raw;
+    try {
+      const query = scope === 'users'
+        ? 'query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { id } } }'
+        : 'query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { id } } }';
+      const response = await graphql(query, { login, number: num });
+      const node = scope === 'users' ? response?.user?.projectV2 : response?.organization?.projectV2;
+      if (node?.id) return node.id;
+    } catch (error) {
+      log(`Could not resolve project URL "${raw}": ${error?.message || error}`);
+    }
+    return '';
+  }
+
+  const repoProject = raw.match(REPO_PROJECT_URL);
+  if (repoProject) {
+    const [, owner, repo, number] = repoProject;
+    const num = Number.parseInt(number, 10);
+    if (!Number.isFinite(num)) return raw;
+    try {
+      const response = await graphql(
+        `query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            projectV2(number: $number) { id }
+          }
+        }`,
+        { owner, repo, number: num }
+      );
+      if (response?.repository?.projectV2?.id) return response.repository.projectV2.id;
+    } catch (error) {
+      log(`Could not resolve repo project URL "${raw}": ${error?.message || error}`);
+    }
+    return '';
+  }
+
+  return raw;
+}
+
+async function resolveProjectIdFromCandidates(candidates, options = {}) {
+  for (const c of candidates) {
+    const resolved = await resolveProjectId(c, options);
+    if (resolved) return resolved;
+  }
+  return '';
+}
+
+module.exports = {
+  sanitizeProjectIdValue,
+  resolveProjectId,
+  resolveProjectIdFromCandidates,
+};

--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -16,13 +16,46 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Sync issue/pr to Projects Kanban
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CARRIER_PROJECT_ID: ${{ vars.CARRIER_PROJECT_ID }}
+          CARRIER_CANONICAL_PROJECT_ID: ${{ vars.CARRIER_CANONICAL_PROJECT_ID }}
         with:
+          github-token: ${{ secrets.CARRIER_PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            const projectId = process.env.CARRIER_PROJECT_ID;
+            const fs = require('fs');
+            const { resolveProjectIdFromCandidates } = require('./.github/scripts/kanban-project-id');
+
+            const configPath = '.github/kanban-config.json';
+            let configProjectId = '';
+            if (fs.existsSync(configPath)) {
+              try {
+                const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+                configProjectId = config.projectId || '';
+              } catch (error) {
+                core.info(`Cannot parse ${configPath}: ${error?.message || error}`);
+              }
+            }
+
+            const resolveProjectCandidates = [
+              process.env.CARRIER_PROJECT_ID,
+              process.env.CARRIER_CANONICAL_PROJECT_ID,
+              configProjectId,
+            ];
+            const projectId = await resolveProjectIdFromCandidates(resolveProjectCandidates, {
+              graphql: github.graphql,
+              log: (message) => core.info(message),
+            });
+
             if (!projectId) {
-              core.warning('CARRIER_PROJECT_ID is not set; skipping Kanban sync for this run.');
+              core.warning('No project id resolved (CARRIER_PROJECT_ID / CARRIER_CANONICAL_PROJECT_ID / .github/kanban-config.json). Skipping Kanban sync for this run.');
               return;
             }
             const statusFieldNames = ['Status', '状态'];

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -30,9 +30,14 @@ jobs:
 
       - name: Publish Kanban field/view status to Discussion
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CARRIER_PROJECT_ID: ${{ vars.CARRIER_PROJECT_ID }}
+          CARRIER_CANONICAL_PROJECT_ID: ${{ vars.CARRIER_CANONICAL_PROJECT_ID }}
         with:
+          github-token: ${{ secrets.CARRIER_PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            const { resolveProjectIdFromCandidates } = require('./.github/scripts/kanban-project-id');
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -64,9 +69,18 @@ jobs:
             }
 
             const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-            const projectId = process.env.CARRIER_PROJECT_ID || (context.payload.inputs && context.payload.inputs.project_id) || config.projectId;
+            const resolveProjectCandidates = [
+              process.env.CARRIER_PROJECT_ID,
+              process.env.CARRIER_CANONICAL_PROJECT_ID,
+              (context.payload.inputs && context.payload.inputs.project_id) || '',
+              config.projectId || '',
+            ];
+            const projectId = await resolveProjectIdFromCandidates(resolveProjectCandidates, {
+              graphql: ghClient.graphql,
+              log: (message) => core.info(message),
+            });
             if (!projectId) {
-              core.setFailed('Missing projectId. Set CARRIER_PROJECT_ID secret or pass workflow input project_id.');
+              core.setFailed('Missing projectId. Set CARRIER_PROJECT_ID/CARRIER_CANONICAL_PROJECT_ID, pass workflow input project_id, or configure .github/kanban-config.json');
               return;
             }
 


### PR DESCRIPTION
## Summary
Complete fix for Kanban sync project-id resolution regressions.

## What was wrong
The workflow only read `process.env.CARRIER_PROJECT_ID`, but repository `vars.*` are not automatically injected into `process.env` unless mapped via `env:`. That made `sync` fail even when project id existed in repo variables.

## Changes
1. Added explicit env mapping in both Kanban workflows:
- `CARRIER_PROJECT_ID: ${{ vars.CARRIER_PROJECT_ID }}`
- `CARRIER_CANONICAL_PROJECT_ID: ${{ vars.CARRIER_CANONICAL_PROJECT_ID }}`

2. Added shared resolver helper:
- `.github/scripts/kanban-project-id.js`
- Supports node IDs and project URLs (`users/orgs/.../projects/<n>` and `owner/repo/projects/<n>`) via GraphQL resolution.

3. Unified candidate precedence in workflows:
- `CARRIER_PROJECT_ID`
- `CARRIER_CANONICAL_PROJECT_ID`
- workflow input (`project_id`, ops workflow)
- `.github/kanban-config.json` `projectId`

4. Kept sync fail-open behavior in automation workflow when unresolved project id (warn + skip) to avoid unrelated PR blockage.

## Result
Kanban sync now resolves project id consistently, and `sync` no longer false-fails due to variable wiring mismatch.