### PR TITLE
feat(lifecycle): implement triage rule engine for policy-bounded repair decisions

### DIFF
--- a/daemon/internal/lifecycle/triage_rules.go
+++ b/daemon/internal/lifecycle/triage_rules.go
@@ -1,0 +1,340 @@
+package lifecycle
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RepairAction represents the repair decision made by the triage engine.
+type RepairAction string
+
+const (
+	RepairActionRestart  RepairAction = "restart"  // Restart the service
+	RepairActionRebind   RepairAction = "rebind"   // Change port/address binding
+	RepairActionRollback RepairAction = "rollback" // Rollback to previous version
+	RepairActionEscalate RepairAction = "escalate" // Needs human intervention
+	RepairActionNoOp     RepairAction = "noop"     // Do nothing
+)
+
+// CrashEvidence contains information about a service crash.
+type CrashEvidence struct {
+	AgentID       string
+	ExitCode      int
+	LogLines      []string // Recent log output
+	CrashTime     time.Time
+	CrashCount    int       // Number of crashes in recent window
+	LastStartTime time.Time // When the service was last started
+}
+
+// RepairDecision is the output of the triage engine.
+type RepairDecision struct {
+	Action          RepairAction
+	Reason          string
+	SuggestedParams map[string]string // e.g., {"port": "8081"}
+}
+
+// TriageRule defines a single triage rule.
+type TriageRule struct {
+	Name     string
+	Priority int                                                   // Lower number = higher priority
+	Evaluate func(evidence *CrashEvidence) (*RepairDecision, bool) // Returns (decision, matched)
+}
+
+// PolicyBounds defines limits on repair attempts.
+type PolicyBounds struct {
+	MaxRestartAttempts  int
+	MaxRebindAttempts   int
+	MaxRollbackAttempts int
+	RepairCooldownSecs  int // Minimum seconds between repair attempts of same type
+}
+
+// DefaultPolicyBounds returns sensible default policy bounds.
+func DefaultPolicyBounds() PolicyBounds {
+	return PolicyBounds{
+		MaxRestartAttempts:  3,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  60,
+	}
+}
+
+// repairAttempt tracks a single repair attempt.
+type repairAttempt struct {
+	Action    RepairAction
+	Timestamp time.Time
+}
+
+// TriageEngine evaluates crash evidence and decides on repair actions.
+type TriageEngine struct {
+	mu           sync.RWMutex
+	rules        []TriageRule
+	policyBounds PolicyBounds
+	// Track repair attempts per agent
+	attempts map[string][]repairAttempt
+}
+
+// NewTriageEngine creates a new triage engine with default rules and policy bounds.
+func NewTriageEngine(policyBounds PolicyBounds) *TriageEngine {
+	engine := &TriageEngine{
+		rules:        []TriageRule{},
+		policyBounds: policyBounds,
+		attempts:     make(map[string][]repairAttempt),
+	}
+
+	// Add default rules (in priority order)
+	engine.AddRule(ruleOOMKilled())
+	engine.AddRule(rulePortConflict())
+	engine.AddRule(ruleMissingDependency())
+	engine.AddRule(ruleGenericCrash())
+
+	return engine
+}
+
+// AddRule adds a triage rule to the engine.
+// Rules are evaluated in priority order (lower number first).
+func (te *TriageEngine) AddRule(rule TriageRule) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+
+	// Insert in priority order
+	inserted := false
+	for i, existingRule := range te.rules {
+		if rule.Priority < existingRule.Priority {
+			// Insert before this rule
+			te.rules = append(te.rules[:i], append([]TriageRule{rule}, te.rules[i:]...)...)
+			inserted = true
+			break
+		}
+	}
+
+	if !inserted {
+		te.rules = append(te.rules, rule)
+	}
+}
+
+// Decide evaluates the crash evidence and returns a repair decision.
+// First matching rule wins (based on priority order).
+func (te *TriageEngine) Decide(evidence *CrashEvidence) RepairDecision {
+	te.mu.RLock()
+	rules := te.rules
+	te.mu.RUnlock()
+
+	// Evaluate rules in priority order
+	for _, rule := range rules {
+		decision, matched := rule.Evaluate(evidence)
+		if matched && decision != nil {
+			// Check policy bounds before returning decision
+			if !te.isActionAllowed(evidence.AgentID, decision.Action) {
+				// Exceeded policy bounds - escalate instead
+				return RepairDecision{
+					Action: RepairActionEscalate,
+					Reason: fmt.Sprintf("policy bounds exceeded for action %s (matched rule: %s)", decision.Action, rule.Name),
+				}
+			}
+
+			// Record the attempt
+			te.recordAttempt(evidence.AgentID, decision.Action)
+
+			return *decision
+		}
+	}
+
+	// No rule matched - default to no-op
+	return RepairDecision{
+		Action: RepairActionNoOp,
+		Reason: "no triage rule matched",
+	}
+}
+
+// isActionAllowed checks if the repair action is allowed under policy bounds.
+func (te *TriageEngine) isActionAllowed(agentID string, action RepairAction) bool {
+	te.mu.RLock()
+	defer te.mu.RUnlock()
+
+	attempts, exists := te.attempts[agentID]
+	if !exists {
+		return true // No previous attempts, allow
+	}
+
+	now := time.Now()
+	cooldown := time.Duration(te.policyBounds.RepairCooldownSecs) * time.Second
+
+	// Count recent attempts of this action type
+	recentAttempts := 0
+	for _, attempt := range attempts {
+		if attempt.Action == action && now.Sub(attempt.Timestamp) < 24*time.Hour {
+			recentAttempts++
+
+			// Check cooldown
+			if now.Sub(attempt.Timestamp) < cooldown {
+				return false // Still in cooldown period
+			}
+		}
+	}
+
+	// Check max attempts
+	var maxAttempts int
+	switch action {
+	case RepairActionRestart:
+		maxAttempts = te.policyBounds.MaxRestartAttempts
+	case RepairActionRebind:
+		maxAttempts = te.policyBounds.MaxRebindAttempts
+	case RepairActionRollback:
+		maxAttempts = te.policyBounds.MaxRollbackAttempts
+	default:
+		return true // No limits on escalate or noop
+	}
+
+	return recentAttempts < maxAttempts
+}
+
+// recordAttempt records a repair attempt for policy tracking.
+func (te *TriageEngine) recordAttempt(agentID string, action RepairAction) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+
+	te.attempts[agentID] = append(te.attempts[agentID], repairAttempt{
+		Action:    action,
+		Timestamp: time.Now(),
+	})
+}
+
+// ResetAttempts clears the repair attempt history for an agent.
+// Useful when an agent has been manually fixed or upgraded.
+func (te *TriageEngine) ResetAttempts(agentID string) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+
+	delete(te.attempts, agentID)
+}
+
+// GetAttemptHistory returns the repair attempt history for an agent.
+func (te *TriageEngine) GetAttemptHistory(agentID string) []repairAttempt {
+	te.mu.RLock()
+	defer te.mu.RUnlock()
+
+	attempts, exists := te.attempts[agentID]
+	if !exists {
+		return []repairAttempt{}
+	}
+
+	// Return a copy to prevent mutation
+	result := make([]repairAttempt, len(attempts))
+	copy(result, attempts)
+	return result
+}
+
+// --- Default Triage Rules ---
+
+// ruleOOMKilled detects OOM (Out of Memory) kills.
+// Exit code 137 = SIGKILL (128 + 9), often used by OOM killer.
+func ruleOOMKilled() TriageRule {
+	return TriageRule{
+		Name:     "oom_killed",
+		Priority: 10,
+		Evaluate: func(evidence *CrashEvidence) (*RepairDecision, bool) {
+			if evidence.ExitCode == 137 {
+				// Exit 137 is SIGKILL (128+9), often from OOM killer
+				return &RepairDecision{
+					Action: RepairActionEscalate,
+					Reason: "process killed by OOM (exit 137), needs resource adjustment",
+				}, true
+			}
+			return nil, false
+		},
+	}
+}
+
+// rulePortConflict detects port/address binding conflicts.
+func rulePortConflict() TriageRule {
+	return TriageRule{
+		Name:     "port_conflict",
+		Priority: 20,
+		Evaluate: func(evidence *CrashEvidence) (*RepairDecision, bool) {
+			if evidence.ExitCode != 1 {
+				return nil, false
+			}
+
+			// Check logs for port conflict indicators
+			for _, line := range evidence.LogLines {
+				lowerLine := strings.ToLower(line)
+				if strings.Contains(lowerLine, "address already in use") ||
+					strings.Contains(lowerLine, "bind: address already in use") ||
+					strings.Contains(lowerLine, "port already in use") {
+					return &RepairDecision{
+						Action: RepairActionRebind,
+						Reason: "detected port conflict in logs",
+						SuggestedParams: map[string]string{
+							"strategy": "increment", // Suggest incrementing port number
+						},
+					}, true
+				}
+			}
+
+			return nil, false
+		},
+	}
+}
+
+// ruleMissingDependency detects missing dependencies or broken installations.
+func ruleMissingDependency() TriageRule {
+	return TriageRule{
+		Name:     "missing_dependency",
+		Priority: 30,
+		Evaluate: func(evidence *CrashEvidence) (*RepairDecision, bool) {
+			if evidence.ExitCode != 1 && evidence.ExitCode != 127 {
+				return nil, false
+			}
+
+			// Check logs for dependency errors
+			for _, line := range evidence.LogLines {
+				lowerLine := strings.ToLower(line)
+				if strings.Contains(lowerLine, "no such file") ||
+					strings.Contains(lowerLine, "cannot find") ||
+					strings.Contains(lowerLine, "not found") ||
+					strings.Contains(lowerLine, "missing") ||
+					strings.Contains(lowerLine, "failed to load") {
+					return &RepairDecision{
+						Action: RepairActionRollback,
+						Reason: "detected missing dependency or broken installation",
+					}, true
+				}
+			}
+
+			return nil, false
+		},
+	}
+}
+
+// ruleGenericCrash handles generic crashes with backoff logic.
+func ruleGenericCrash() TriageRule {
+	return TriageRule{
+		Name:     "generic_crash",
+		Priority: 100, // Lowest priority - catch-all
+		Evaluate: func(evidence *CrashEvidence) (*RepairDecision, bool) {
+			// Generic crash - restart with exponential backoff
+			// Check crash frequency
+			uptime := evidence.CrashTime.Sub(evidence.LastStartTime)
+
+			if uptime < 10*time.Second {
+				// Crashed very quickly - likely a persistent issue
+				if evidence.CrashCount >= 3 {
+					return &RepairDecision{
+						Action: RepairActionEscalate,
+						Reason: "crash loop detected (3+ crashes with <10s uptime)",
+					}, true
+				}
+			}
+
+			return &RepairDecision{
+				Action: RepairActionRestart,
+				Reason: "generic crash, attempting restart",
+				SuggestedParams: map[string]string{
+					"backoff": "exponential", // Suggest exponential backoff
+				},
+			}, true
+		},
+	}
+}

--- a/daemon/internal/lifecycle/triage_rules_test.go
+++ b/daemon/internal/lifecycle/triage_rules_test.go
@@ -1,0 +1,414 @@
+package lifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTriageEngine_OOMKilled(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      137,
+		LogLines:      []string{"fatal error: out of memory"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionEscalate {
+		t.Errorf("Expected escalate for OOM, got %s", decision.Action)
+	}
+
+	if decision.Reason == "" {
+		t.Error("Expected reason to be set")
+	}
+}
+
+func TestTriageEngine_PortConflict(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"listen tcp :8080: bind: address already in use"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionRebind {
+		t.Errorf("Expected rebind for port conflict, got %s", decision.Action)
+	}
+
+	if decision.SuggestedParams["strategy"] != "increment" {
+		t.Error("Expected strategy=increment in suggested params")
+	}
+}
+
+func TestTriageEngine_MissingDependency(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      127,
+		LogLines:      []string{"error: cannot find required library libfoo.so"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-30 * time.Second),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionRollback {
+		t.Errorf("Expected rollback for missing dependency, got %s", decision.Action)
+	}
+}
+
+func TestTriageEngine_GenericCrash(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"unexpected error occurred"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-2 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionRestart {
+		t.Errorf("Expected restart for generic crash, got %s", decision.Action)
+	}
+
+	if decision.SuggestedParams["backoff"] != "exponential" {
+		t.Error("Expected backoff=exponential in suggested params")
+	}
+}
+
+func TestTriageEngine_CrashLoop(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	// Simulate a crash loop (3+ crashes with short uptime)
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"error: something bad happened"},
+		CrashTime:     time.Now(),
+		CrashCount:    3,
+		LastStartTime: time.Now().Add(-5 * time.Second), // Very short uptime
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionEscalate {
+		t.Errorf("Expected escalate for crash loop, got %s", decision.Action)
+	}
+}
+
+func TestTriageEngine_RulePriority(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	// Exit code 1 with both port conflict and missing dependency indicators
+	// Port conflict rule (priority 20) should win over missing dependency (priority 30)
+	evidence := &CrashEvidence{
+		AgentID:  "test-agent",
+		ExitCode: 1,
+		LogLines: []string{
+			"error: cannot find library",
+			"bind: address already in use",
+		},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionRebind {
+		t.Errorf("Expected rebind (higher priority rule), got %s", decision.Action)
+	}
+}
+
+func TestTriageEngine_PolicyBounds_MaxRestarts(t *testing.T) {
+	bounds := PolicyBounds{
+		MaxRestartAttempts:  2,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  1, // Short cooldown for testing
+	}
+	engine := NewTriageEngine(bounds)
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"generic error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	// First two attempts should succeed
+	decision1 := engine.Decide(evidence)
+	if decision1.Action != RepairActionRestart {
+		t.Errorf("First attempt: expected restart, got %s", decision1.Action)
+	}
+
+	time.Sleep(1100 * time.Millisecond) // Wait for cooldown
+
+	decision2 := engine.Decide(evidence)
+	if decision2.Action != RepairActionRestart {
+		t.Errorf("Second attempt: expected restart, got %s", decision2.Action)
+	}
+
+	time.Sleep(1100 * time.Millisecond) // Wait for cooldown
+
+	// Third attempt should escalate (exceeded max)
+	decision3 := engine.Decide(evidence)
+	if decision3.Action != RepairActionEscalate {
+		t.Errorf("Third attempt: expected escalate, got %s", decision3.Action)
+	}
+}
+
+func TestTriageEngine_PolicyBounds_Cooldown(t *testing.T) {
+	bounds := PolicyBounds{
+		MaxRestartAttempts:  5,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  2, // 2 second cooldown
+	}
+	engine := NewTriageEngine(bounds)
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"generic error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	// First attempt should succeed
+	decision1 := engine.Decide(evidence)
+	if decision1.Action != RepairActionRestart {
+		t.Errorf("First attempt: expected restart, got %s", decision1.Action)
+	}
+
+	// Immediate second attempt should be blocked by cooldown
+	decision2 := engine.Decide(evidence)
+	if decision2.Action != RepairActionEscalate {
+		t.Errorf("Immediate retry: expected escalate (cooldown), got %s", decision2.Action)
+	}
+
+	// Wait for cooldown to expire
+	time.Sleep(2100 * time.Millisecond)
+
+	// Now it should work again
+	decision3 := engine.Decide(evidence)
+	if decision3.Action != RepairActionRestart {
+		t.Errorf("After cooldown: expected restart, got %s", decision3.Action)
+	}
+}
+
+func TestTriageEngine_ResetAttempts(t *testing.T) {
+	bounds := PolicyBounds{
+		MaxRestartAttempts:  1,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  1,
+	}
+	engine := NewTriageEngine(bounds)
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"generic error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	// First attempt
+	decision1 := engine.Decide(evidence)
+	if decision1.Action != RepairActionRestart {
+		t.Errorf("First attempt: expected restart, got %s", decision1.Action)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+
+	// Second attempt should escalate (max=1)
+	decision2 := engine.Decide(evidence)
+	if decision2.Action != RepairActionEscalate {
+		t.Errorf("Second attempt: expected escalate, got %s", decision2.Action)
+	}
+
+	// Reset attempts
+	engine.ResetAttempts("test-agent")
+
+	// Should work again now
+	decision3 := engine.Decide(evidence)
+	if decision3.Action != RepairActionRestart {
+		t.Errorf("After reset: expected restart, got %s", decision3.Action)
+	}
+}
+
+func TestTriageEngine_GetAttemptHistory(t *testing.T) {
+	bounds := PolicyBounds{
+		MaxRestartAttempts:  5,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  1, // 1 second cooldown
+	}
+	engine := NewTriageEngine(bounds)
+
+	// Initially empty
+	history := engine.GetAttemptHistory("test-agent")
+	if len(history) != 0 {
+		t.Errorf("Expected empty history, got %d attempts", len(history))
+	}
+
+	// Make some decisions
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      1,
+		LogLines:      []string{"generic error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	engine.Decide(evidence)
+	time.Sleep(1100 * time.Millisecond) // Wait for cooldown
+	engine.Decide(evidence)
+
+	// Check history
+	history = engine.GetAttemptHistory("test-agent")
+	if len(history) != 2 {
+		t.Errorf("Expected 2 attempts in history, got %d", len(history))
+	}
+
+	for _, attempt := range history {
+		if attempt.Action != RepairActionRestart {
+			t.Errorf("Expected restart in history, got %s", attempt.Action)
+		}
+	}
+}
+
+func TestTriageEngine_AddCustomRule(t *testing.T) {
+	engine := NewTriageEngine(DefaultPolicyBounds())
+
+	// Add a custom high-priority rule
+	customRule := TriageRule{
+		Name:     "custom_test_rule",
+		Priority: 5, // Higher priority than OOM rule (10)
+		Evaluate: func(evidence *CrashEvidence) (*RepairDecision, bool) {
+			if evidence.ExitCode == 42 {
+				return &RepairDecision{
+					Action: RepairActionNoOp,
+					Reason: "custom rule matched",
+				}, true
+			}
+			return nil, false
+		},
+	}
+
+	engine.AddRule(customRule)
+
+	// Test that custom rule fires
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      42,
+		LogLines:      []string{},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionNoOp {
+		t.Errorf("Expected noop from custom rule, got %s", decision.Action)
+	}
+
+	if decision.Reason != "custom rule matched" {
+		t.Errorf("Expected custom reason, got %s", decision.Reason)
+	}
+}
+
+func TestTriageEngine_NoMatchingRule(t *testing.T) {
+	// Create engine with no default rules
+	engine := &TriageEngine{
+		rules:        []TriageRule{},
+		policyBounds: DefaultPolicyBounds(),
+		attempts:     make(map[string][]repairAttempt),
+	}
+
+	evidence := &CrashEvidence{
+		AgentID:       "test-agent",
+		ExitCode:      99,
+		LogLines:      []string{},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	decision := engine.Decide(evidence)
+
+	if decision.Action != RepairActionNoOp {
+		t.Errorf("Expected noop when no rules match, got %s", decision.Action)
+	}
+}
+
+func TestTriageEngine_MultipleAgents(t *testing.T) {
+	bounds := PolicyBounds{
+		MaxRestartAttempts:  1,
+		MaxRebindAttempts:   2,
+		MaxRollbackAttempts: 1,
+		RepairCooldownSecs:  1,
+	}
+	engine := NewTriageEngine(bounds)
+
+	evidence1 := &CrashEvidence{
+		AgentID:       "agent-1",
+		ExitCode:      1,
+		LogLines:      []string{"error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	evidence2 := &CrashEvidence{
+		AgentID:       "agent-2",
+		ExitCode:      1,
+		LogLines:      []string{"error"},
+		CrashTime:     time.Now(),
+		CrashCount:    1,
+		LastStartTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	// Both agents should be able to restart once
+	decision1 := engine.Decide(evidence1)
+	if decision1.Action != RepairActionRestart {
+		t.Errorf("Agent 1: expected restart, got %s", decision1.Action)
+	}
+
+	decision2 := engine.Decide(evidence2)
+	if decision2.Action != RepairActionRestart {
+		t.Errorf("Agent 2: expected restart, got %s", decision2.Action)
+	}
+
+	// Verify attempts are tracked separately
+	history1 := engine.GetAttemptHistory("agent-1")
+	history2 := engine.GetAttemptHistory("agent-2")
+
+	if len(history1) != 1 || len(history2) != 1 {
+		t.Errorf("Expected 1 attempt per agent, got %d and %d", len(history1), len(history2))
+	}
+}


### PR DESCRIPTION
Closes #846

## Summary

Implements FR-D-013 triage rule engine with policy-bounded repair decisions for the lifecycle manager.

## Changes

- **Triage Engine**: Priority-based rule evaluation system that analyzes crash evidence and decides repair actions
- **Default Rules**:
  - Exit code 137 (OOM killed) → escalate (needs resource adjustment)
  - Exit code 1 + "address in use" in logs → rebind (change port)
  - Exit code 1/127 + missing dependency patterns → rollback (to previous version)
  - Generic crashes → restart with exponential backoff
- **Policy Bounds**:
  - Maximum repair attempts per action type (restart, rebind, rollback)
  - Cooldown periods between repair attempts
  - Automatic escalation when bounds exceeded
- **Crash Loop Detection**: Escalates when multiple crashes occur with short uptime
- **Comprehensive Tests**: 13 test cases covering rule logic, priority ordering, policy enforcement, and multi-agent scenarios

## Testing

All tests pass:
```
PASS
ok  	carrier/daemon/internal/lifecycle	6.509s
```