### PR TITLE
test(daemon): add auth middleware + agent action path boundary tests

### DIFF
--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -446,3 +446,38 @@ func TestPairingMethodNotAllowed(t *testing.T) {
 		t.Fatalf("GET /api/pairing/verify-consume: expected 405, got %d", rec.Code)
 	}
 }
+
+func TestBearerAuthMiddlewareBoundaryCases(t *testing.T) {
+	token := "secret-token"
+	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := bearerAuthMiddleware(token, base)
+
+	tests := []struct {
+		name   string
+		path   string
+		auth   string
+		want   int
+	}{
+		{name: "api missing auth", path: "/api/v1/agents", auth: "", want: http.StatusUnauthorized},
+		{name: "api wrong scheme", path: "/api/v1/agents", auth: "Token secret-token", want: http.StatusUnauthorized},
+		{name: "api near miss token", path: "/api/v1/agents", auth: "Bearer secret-token ", want: http.StatusUnauthorized},
+		{name: "api correct token", path: "/api/v1/agents", auth: "Bearer secret-token", want: http.StatusOK},
+		{name: "healthz exempt", path: "/healthz", auth: "", want: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.auth != "" {
+				req.Header.Set("Authorization", tt.auth)
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			if rr.Code != tt.want {
+				t.Fatalf("status=%d, want=%d; body=%s", rr.Code, tt.want, rr.Body.String())
+			}
+		})
+	}
+}

--- a/daemon/internal/api/server_test.go
+++ b/daemon/internal/api/server_test.go
@@ -365,4 +365,37 @@ func TestIssuePairCodeRejectsTrailingGarbage(t *testing.T) {
 	}
 }
 
+
+func TestParseAgentActionPathBoundaryCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantID    string
+		wantAction string
+		wantOK    bool
+	}{
+		{name: "valid simple", path: "/api/v1/agents/openclaw/start", wantID: "openclaw", wantAction: "start", wantOK: true},
+		{name: "valid encoded id", path: "/api/v1/agents/openclaw%2Dbeta/status", wantID: "openclaw-beta", wantAction: "status", wantOK: true},
+		{name: "reject encoded space", path: "/api/v1/agents/openclaw%20beta/start", wantOK: false},
+		{name: "reject dotdot", path: "/api/v1/agents/open..claw/start", wantOK: false},
+		{name: "reject missing action", path: "/api/v1/agents/openclaw/", wantOK: false},
+		{name: "reject extra segment", path: "/api/v1/agents/openclaw/start/now", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotAction, gotOK := parseAgentActionPath(tt.path)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (id=%q action=%q)", gotOK, tt.wantOK, gotID, gotAction)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotID != tt.wantID || gotAction != tt.wantAction {
+				t.Fatalf("parseAgentActionPath(%q) = (%q, %q), want (%q, %q)", tt.path, gotID, gotAction, tt.wantID, tt.wantAction)
+			}
+		})
+	}
+}
+
 var _ runtimecheck.Checker = (*fakeChecker)(nil)


### PR DESCRIPTION
## Summary
- add focused boundary tests for `bearerAuthMiddleware` covering missing/invalid/near-miss/correct bearer tokens and exempt non-API route behavior
- add focused boundary tests for `parseAgentActionPath` covering valid encoded IDs and invalid edge cases (encoded spaces, dotdot, missing action, extra segments)

## Testing
- `cd daemon && go test ./internal/api ./cmd/agentd`

Closes #924
