### PR TITLE
fix(gateway): allow ARTIFACT_ROOT under /root subdirectories

### DIFF
--- a/gateway/src/artifact_root.test.ts
+++ b/gateway/src/artifact_root.test.ts
@@ -211,6 +211,27 @@ describe("ARTIFACT_ROOT security", () => {
     }).toThrow();
   });
 
+  test("allows ARTIFACT_ROOT under /root subdirectory", async () => {
+    // Scoped subdirectories of /root are legitimate in dev/CI environments.
+    // We test that the runtime doesn't throw during construction (validation
+    // passes), even though the directory may not exist on this host.
+    process.env.ARTIFACT_ROOT = "/root/project/artifacts";
+
+    const deps = makeDeps();
+    // Issue a token for a hypothetical file under /root/project/artifacts.
+    const testFile = "/root/project/artifacts/data.txt";
+    const token = deps.downloads.issue(testFile, 300, false);
+    const runtime = createGatewayRuntime({ deps });
+
+    // The request should NOT throw a security error. It will return 404
+    // because the file doesn't actually exist, which proves validation passed.
+    const response = await runtime.fetch(
+      new Request(`http://gateway.local${deps.downloads.toDownloadURL(token)}`)
+    );
+
+    expect(response.status).toBe(404);
+  });
+
   test("resolves relative ARTIFACT_ROOT to absolute path", async () => {
     process.env.ARTIFACT_ROOT = "./test-artifacts";
     

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -245,7 +245,7 @@ function buildContentDisposition(filename: string): string {
 /**
  * Validates and resolves the artifact root directory to prevent security issues.
  * - Ensures the path is absolute
- * - Blocks dangerous paths like `/`, `/etc`, `/usr`, `/var`, `/root`
+ * - Blocks dangerous paths like `/`, `/etc`, `/usr`, `/var`; `/root` exact only (subpaths allowed)
  * - Returns the resolved absolute path
  */
 function validateAndResolveArtifactRoot(rootPath: string): string {
@@ -260,9 +260,19 @@ function validateAndResolveArtifactRoot(rootPath: string): string {
   }
   
   // Block critical system directories
-  const dangerousPaths = ["/etc", "/usr", "/var", "/root", "/bin", "/sbin", "/boot", "/sys", "/proc"];
-  for (const dangerous of dangerousPaths) {
+  // Block critical system directories (exact match + subdirectories).
+  // /root is only blocked as exact match — scoped subdirectories like
+  // /root/project/artifacts are legitimate in dev/CI environments.
+  const blockedExactAndBelow = ["/etc", "/usr", "/var", "/bin", "/sbin", "/boot", "/sys", "/proc"];
+  const blockedExactOnly = ["/root"];
+
+  for (const dangerous of blockedExactAndBelow) {
     if (resolved === dangerous || resolved.startsWith(dangerous + sep)) {
+      throw new Error(`[security] ARTIFACT_ROOT cannot be in system directory: ${resolved}`);
+    }
+  }
+  for (const dangerous of blockedExactOnly) {
+    if (resolved === dangerous) {
       throw new Error(`[security] ARTIFACT_ROOT cannot be in system directory: ${resolved}`);
     }
   }


### PR DESCRIPTION
## Summary
Block exact `/root` but permit scoped subdirectories like `/root/project/artifacts` which are legitimate in dev/CI environments.

## Changes
- **`gateway/src/server.ts`**: Split dangerous-path list into `blockedExactAndBelow` (system dirs) and `blockedExactOnly` (`/root`)
- **`gateway/src/artifact_root.test.ts`**: Add test verifying `/root/project/artifacts` is accepted as ARTIFACT_ROOT

## Scope
Gateway artifact-root validation only. No daemon changes.

## Acceptance Criteria
- [x] Default artifact root under cwd works even if cwd is under `/root/...`
- [x] Relative ARTIFACT_ROOT resolves and is accepted
- [x] Exact dangerous roots (`/`, `/etc`, `/usr`, `/var`, `/root`, etc.) still rejected
- [x] Traversal/symlink escape protections unchanged
- [x] All artifact_root tests pass (12/12)

Fixes #938