### PR TITLE
ci(security): pin remaining actions/checkout ref in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run OpenClaw installer test
         run: bash daemon/internal/catalog/openclaw-installer_test.sh


### PR DESCRIPTION
## Summary
- pin the remaining mutable `actions/checkout@v4` usage in `.github/workflows/ci.yml` to immutable SHA `34e114876b0b11c390a56381ad16ebd13914f8d5`

## Scope
- CI workflow hardening only

## Testing
- not run (workflow-reference-only change)

Closes #951
