### PR TITLE
fix(gateway/session): persist lastSeenAt updates on touch

### DIFF
--- a/gateway/src/session/store.test.ts
+++ b/gateway/src/session/store.test.ts
@@ -319,6 +319,28 @@ describe("SessionStore", () => {
       expect(loaded!.sessionToken).toBe(session!.sessionToken);
     });
 
+    test("touch persists updated lastSeenAt across reload", async () => {
+      const testPath = getTestPath("touch-persist");
+      let time = new Date("2026-01-01T00:00:00Z");
+      const store = new SessionStore(() => time, 30 * 24 * 60 * 60, testPath);
+
+      store.createSession({ provider: "telegram", chatId: "touch-1" });
+      await store.flush();
+      const before = store.getSession("telegram", "touch-1");
+
+      time = new Date("2026-01-01T00:05:00Z");
+      store.touch("telegram", "touch-1");
+      await store.flush();
+
+      const reloaded = new SessionStore(() => time, 30 * 24 * 60 * 60, testPath);
+      const after = reloaded.getSession("telegram", "touch-1");
+
+      expect(before).not.toBeNull();
+      expect(after).not.toBeNull();
+      expect(after!.lastSeenAt).toBe(time.toISOString());
+      expect(after!.lastSeenAt).not.toBe(before!.lastSeenAt);
+    });
+
     test("without persistence path, store works in-memory only", async () => {
       const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"));
       

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -99,7 +99,14 @@ export class SessionStore {
     if (!session) {
       return;
     }
-    this.sessions.set(key, { ...session, lastSeenAt: this.now().toISOString() });
+
+    const lastSeenAt = this.now().toISOString();
+    if (session.lastSeenAt === lastSeenAt) {
+      return;
+    }
+
+    this.sessions.set(key, { ...session, lastSeenAt });
+    this.scheduleSave();
   }
 
   /** Remove expired pairing codes and stale sessions from the internal map. */


### PR DESCRIPTION
## Summary
- call `scheduleSave()` in `SessionStore.touch()` when `lastSeenAt` actually changes
- keep no-op behavior for unknown sessions unchanged
- add persistence regression test proving touched `lastSeenAt` survives reload

## Testing
- `cd gateway && bun test src/session/store.test.ts`

Closes #953
