### PR TITLE
refactor(gateway): simplify touch lastSeenAt guard

### DIFF
--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -101,12 +101,10 @@ export class SessionStore {
     }
 
     const lastSeenAt = this.now().toISOString();
-    if (session.lastSeenAt === lastSeenAt) {
-      return;
+    if (session.lastSeenAt !== lastSeenAt) {
+      this.sessions.set(key, { ...session, lastSeenAt });
+      this.scheduleSave();
     }
-
-    this.sessions.set(key, { ...session, lastSeenAt });
-    this.scheduleSave();
   }
 
   /** Remove expired pairing codes and stale sessions from the internal map. */


### PR DESCRIPTION
## Summary
- simplify `SessionStore.touch` guard by switching to a positive inequality branch
- keep behavior unchanged (only persist when `lastSeenAt` actually changes)

## Testing
- `cd gateway && bun test src/session/store.test.ts`

Closes #955
