### PR TITLE
fix: align daemon JSON fields with gateway types and support dev-mode install

### DIFF
--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -57,7 +57,18 @@ func getInstallCommand() string {
 set -e
 CHECKSUM="%s"
 if [ -z "$CHECKSUM" ]; then
+  if [ "${CARRIER_DEV_MODE:-0}" = "1" ]; then
+    echo "WARNING: Dev mode enabled - skipping checksum validation" >&2
+    echo "Creating placeholder installation for development..." >&2
+    mkdir -p "$HOME/.local/bin"
+    echo "#!/bin/sh" > "$HOME/.local/bin/openclaw"
+    echo "echo \"OpenClaw dev placeholder - version %s\"" >> "$HOME/.local/bin/openclaw"
+    chmod +x "$HOME/.local/bin/openclaw"
+    echo "Dev placeholder created at $HOME/.local/bin/openclaw" >&2
+    exit 0
+  fi
   echo "FATAL: no pinned checksum for this platform — binary was not built with release ldflags" >&2
+  echo "Set CARRIER_DEV_MODE=1 to bypass checksum validation for development" >&2
   exit 1
 fi
 SCRIPT="$(mktemp /tmp/openclaw-installer.XXXXXX.sh)"
@@ -67,7 +78,7 @@ cat > "$SCRIPT" << '\''INSTALLER_EOF'\''
 INSTALLER_EOF
 chmod 700 "$SCRIPT"
 "$SCRIPT" "%s" "$CHECKSUM"
-'`, checksum, openclawInstallerScript, openclawVersion)
+'`, checksum, openclawVersion, openclawInstallerScript, openclawVersion)
 }
 
 func OpenClawManifest() manifest.Manifest {

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -262,6 +262,7 @@ func (s *Service) RegisterManifest(m manifest.Manifest) error {
 	s.manifests[m.ID] = m
 	s.states[m.ID] = AgentState{
 		ID:        m.ID,
+		Name:      m.Name,
 		Version:   m.Version,
 		Install:   InstallStateNotInstalled,
 		Runtime:   RuntimeStateStopped,

--- a/daemon/internal/lifecycle/types.go
+++ b/daemon/internal/lifecycle/types.go
@@ -30,16 +30,17 @@ const (
 )
 
 type AgentState struct {
-	ID                   string
-	Version              string
-	Install              InstallState
-	Runtime              RuntimeState
-	Health               HealthState
-	LastError            string
-	LastTriageSummary    string
-	NeedsRemoteDiagnosis bool
-	LastDiagnoseFile     string
-	UpdatedAt            time.Time
+	ID                   string       `json:"id"`
+	Name                 string       `json:"name"`
+	Version              string       `json:"version"`
+	Install              InstallState `json:"installState"`
+	Runtime              RuntimeState `json:"runtimeState"`
+	Health               HealthState  `json:"health"`
+	LastError            string       `json:"lastError,omitempty"`
+	LastTriageSummary    string       `json:"lastTriageSummary,omitempty"`
+	NeedsRemoteDiagnosis bool         `json:"needsRemoteDiagnosis"`
+	LastDiagnoseFile     string       `json:"lastDiagnoseFile,omitempty"`
+	UpdatedAt            time.Time    `json:"updatedAt"`
 }
 
 type UpgradeResult struct {

--- a/gateway/src/command-routing.test.ts
+++ b/gateway/src/command-routing.test.ts
@@ -106,7 +106,7 @@ describe("command routing: /install", () => {
     // Verify agent state was updated
     const statuses = await deps.daemon.getStatus("openclaw", { requestId: "verify", actor: "test" });
     expect(statuses).toHaveLength(1);
-    expect(statuses[0].installed).toBe(true);
+    expect(statuses[0].installState).toBe("installed");
   });
 });
 

--- a/gateway/src/daemon/client.ts
+++ b/gateway/src/daemon/client.ts
@@ -9,7 +9,7 @@ export type DaemonAgentState = {
   id: string;
   name: string;
   version: string;
-  installed: boolean;
+  installState: "not_installed" | "installed" | "broken";
   runtimeState: "running" | "stopped";
   health: "healthy" | "unhealthy" | "unknown";
   needsRemoteDiagnosis: boolean;
@@ -85,7 +85,7 @@ type InMemoryAgentState = {
   id: string;
   name: string;
   version: string;
-  installed: boolean;
+  installState: "not_installed" | "installed" | "broken";
   runtimeState: "running" | "stopped";
   health: "healthy" | "unhealthy" | "unknown";
   needsRemoteDiagnosis: boolean;
@@ -119,7 +119,7 @@ export class InMemoryDaemonClient implements DaemonClient {
       id: "openclaw",
       name: "OpenClaw",
       version: "0.1.0",
-      installed: false,
+      installState: "not_installed",
       runtimeState: "stopped",
       health: "unknown",
       needsRemoteDiagnosis: false,
@@ -158,7 +158,7 @@ export class InMemoryDaemonClient implements DaemonClient {
     const state = this.requireAgent(agentId);
     this.upsertAgent({
       ...state,
-      installed: true,
+      installState: "installed",
       runtimeState: "stopped",
       health: "unknown",
       lastError: undefined,
@@ -170,7 +170,7 @@ export class InMemoryDaemonClient implements DaemonClient {
 
   async startAgent(agentId: string, ctx: RequestContext): Promise<void> {
     const state = this.requireAgent(agentId);
-    if (!state.installed) {
+    if (state.installState !== "installed") {
       throw new DaemonClientError("E_NOT_INSTALLED", "agent is not installed");
     }
     if (state.runtimeState === "running") {
@@ -342,7 +342,7 @@ export class InMemoryDaemonClient implements DaemonClient {
       id: state.id,
       name: state.name,
       version: state.version,
-      installed: state.installed,
+      installState: state.installState,
       runtimeState: state.runtimeState,
       health: state.health,
       needsRemoteDiagnosis: state.needsRemoteDiagnosis,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -160,7 +160,7 @@ export async function handleCommand(
     switch (cmd.name) {
       case "/agents": {
         const agents = await deps.daemon.listAgents(ctx);
-        const installed = agents.filter((agent) => agent.installed).length;
+        const installed = agents.filter((agent) => agent.installState === "installed").length;
         return {
           requestId: cmd.requestId,
           result: "ok",


### PR DESCRIPTION
Fixes /status displaying undefined (field name mismatch) and /install failing in non-release builds.

**Changes:**

1. **Fixed /status field name mismatch** (Issue 1)
   - Added JSON tags to `AgentState` struct in `daemon/internal/lifecycle/types.go` for camelCase output
   - Added `Name` field to `AgentState` and populated it from manifest
   - Changed gateway `DaemonAgentState.installed` (boolean) to `installState` (string enum: "not_installed" | "installed" | "broken")
   - Updated all references in gateway tests and code to use `installState`

2. **Added dev-mode install support** (Issue 2)
   - Modified `daemon/internal/catalog/manifests.go` to check for `CARRIER_DEV_MODE=1` environment variable
   - When checksum is empty and dev mode is enabled, creates a placeholder binary instead of failing
   - Preserves security by failing-closed in production (no dev mode)

**Testing:**
- ✅ Daemon builds and runs
- ✅ Gateway type checks pass
- ✅ Gateway tests pass (320/323, 3 failures are port conflicts unrelated to changes)
- ✅ Manual verification:
  - `/api/v1/agents/openclaw/status` returns correct camelCase JSON with all fields
  - Install succeeds in dev mode with `CARRIER_DEV_MODE=1`
  - Placeholder binary created at `~/.local/bin/openclaw`