### PR TITLE
fix(start): correct --systemd --user target and activation flow

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,8 +5,8 @@
 # Usage:
 #   ./start.sh                    # Start daemon in foreground
 #   ./start.sh --daemon           # Start daemon in background
-#   ./start.sh --systemd          # Create and enable systemd service
-#   ./start.sh --systemd --user   # Create user-level systemd service
+#   ./start.sh --systemd          # Create, enable, and start systemd service
+#   ./start.sh --systemd --user   # Create, enable, and start user-level systemd service
 #
 # Environment Variables:
 #   OPENCLAW_PORT       - HTTP port (default: 9090)
@@ -91,9 +91,11 @@ if [ "$MODE" = "systemd" ]; then
     if [ "$SYSTEMD_USER" = "--user" ]; then
         SERVICE_DIR="$HOME/.config/systemd/user"
         SYSTEMCTL_CMD="systemctl --user"
+        WANTED_BY_TARGET="default.target"
     else
         SERVICE_DIR="/etc/systemd/system"
         SYSTEMCTL_CMD="systemctl"
+        WANTED_BY_TARGET="multi-user.target"
         # Check for sudo if system-level
         if [ ! -w "$SERVICE_DIR" ] && [ -z "${DRY_RUN:-}" ]; then
             if ! command -v sudo >/dev/null 2>&1; then
@@ -148,7 +150,7 @@ Environment=OPENCLAW_LOG_LEVEL=${LOG_LEVEL}
 Environment=OPENCLAW_DATA_DIR=${DATA_DIR}
 
 [Install]
-WantedBy=multi-user.target"
+WantedBy=${WANTED_BY_TARGET}"
 
     if [ "${DRY_RUN:-}" ]; then
         echo "[DRY_RUN] Would write to: $SERVICE_FILE"
@@ -167,14 +169,12 @@ WantedBy=multi-user.target"
             printf "%s\n" "$SERVICE_CONTENT" | sudo tee "$SERVICE_FILE" > /dev/null
         fi
 
-        # Reload systemd
+        # Reload and activate service
         $SYSTEMCTL_CMD daemon-reload
+        $SYSTEMCTL_CMD enable openclaw-gateway.service
+        $SYSTEMCTL_CMD start openclaw-gateway.service
 
-        echo "Service created: openclaw-gateway.service"
-        echo ""
-        echo "To enable and start:"
-        echo "  ${SYSTEMCTL_CMD} enable openclaw-gateway.service"
-        echo "  ${SYSTEMCTL_CMD} start openclaw-gateway.service"
+        echo "Service created and started: openclaw-gateway.service"
         echo ""
         echo "To check status:"
         echo "  ${SYSTEMCTL_CMD} status openclaw-gateway.service"

--- a/scripts/start_systemd_test.sh
+++ b/scripts/start_systemd_test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+START_SCRIPT="$SCRIPT_DIR/start.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_BIN_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_BIN_DIR"' EXIT
+
+cat > "$TMP_BIN_DIR/openclaw" <<'EOF'
+#!/bin/sh
+echo "mock openclaw $*"
+EOF
+chmod +x "$TMP_BIN_DIR/openclaw"
+
+run_start() {
+  PATH="$TMP_BIN_DIR:$PATH" DRY_RUN=1 "$START_SCRIPT" "$@"
+}
+
+echo "Testing scripts/start.sh systemd unit targets..."
+
+OUT_USER="$(run_start --systemd --user 2>&1 || true)"
+if echo "$OUT_USER" | grep -q 'WantedBy=default.target'; then
+  pass "--systemd --user emits WantedBy=default.target"
+else
+  fail "--systemd --user did not emit WantedBy=default.target"
+fi
+
+if echo "$OUT_USER" | grep -q '\[DRY_RUN\] systemctl --user enable openclaw-gateway.service' && \
+   echo "$OUT_USER" | grep -q '\[DRY_RUN\] systemctl --user start openclaw-gateway.service'; then
+  pass "--systemd --user dry-run shows enable/start sequence"
+else
+  fail "--systemd --user dry-run missing enable/start sequence"
+fi
+
+OUT_SYSTEM="$(run_start --systemd 2>&1 || true)"
+if echo "$OUT_SYSTEM" | grep -q 'WantedBy=multi-user.target'; then
+  pass "--systemd emits WantedBy=multi-user.target"
+else
+  fail "--systemd did not emit WantedBy=multi-user.target"
+fi
+
+if echo "$OUT_SYSTEM" | grep -q '\[DRY_RUN\] systemctl enable openclaw-gateway.service' && \
+   echo "$OUT_SYSTEM" | grep -q '\[DRY_RUN\] systemctl start openclaw-gateway.service'; then
+  pass "--systemd dry-run shows enable/start sequence"
+else
+  fail "--systemd dry-run missing enable/start sequence"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- fix `scripts/start.sh` to emit `WantedBy=default.target` when `--systemd --user` is used
- keep `WantedBy=multi-user.target` for system-level services
- align non-dry-run behavior with help text by actually running `enable` + `start` after `daemon-reload`
- add `scripts/start_systemd_test.sh` to assert generated target and dry-run command sequence for system/user modes

## Validation
- `scripts/start_systemd_test.sh`

Closes #962
