### PR TITLE
fix(start): log selected systemd target and wire correct user WantedBy

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -91,9 +91,11 @@ if [ "$MODE" = "systemd" ]; then
     if [ "$SYSTEMD_USER" = "--user" ]; then
         SERVICE_DIR="$HOME/.config/systemd/user"
         SYSTEMCTL_CMD="systemctl --user"
+        WANTED_BY_TARGET="default.target"
     else
         SERVICE_DIR="/etc/systemd/system"
         SYSTEMCTL_CMD="systemctl"
+        WANTED_BY_TARGET="multi-user.target"
         # Check for sudo if system-level
         if [ ! -w "$SERVICE_DIR" ] && [ -z "${DRY_RUN:-}" ]; then
             if ! command -v sudo >/dev/null 2>&1; then
@@ -112,6 +114,7 @@ if [ "$MODE" = "systemd" ]; then
     fi
 
     echo "Creating systemd service: $SERVICE_FILE"
+    echo "Using systemd install target: $WANTED_BY_TARGET"
 
     # Generate service unit
     SERVICE_CONTENT="[Unit]
@@ -148,7 +151,7 @@ Environment=OPENCLAW_LOG_LEVEL=${LOG_LEVEL}
 Environment=OPENCLAW_DATA_DIR=${DATA_DIR}
 
 [Install]
-WantedBy=multi-user.target"
+WantedBy=${WANTED_BY_TARGET}"
 
     if [ "${DRY_RUN:-}" ]; then
         echo "[DRY_RUN] Would write to: $SERVICE_FILE"


### PR DESCRIPTION
## Summary
- log the selected systemd install target during `--systemd` setup for easier debugging
- compute `WantedBy` dynamically by mode:
  - system service → `multi-user.target`
  - user service (`--systemd --user`) → `default.target`
- preserve existing behavior for foreground/daemon modes

## Validation
- `sh -n scripts/start.sh`
- `DRY_RUN=1 sh scripts/start.sh --systemd`
- `DRY_RUN=1 sh scripts/start.sh --systemd --user`

Closes #964
