### PR TITLE
test(ci): include scripts/start_systemd_test.sh in canonical test entrypoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ GitHub Actions is the source of truth for test status.
 To reduce CI churn, we enforce pre-push tests locally:
 - Enable the repo hook path once per clone:
   - `git config core.hooksPath .githooks`
-- The pre-push hook runs `./scripts/run-all-tests.sh`, which includes daemon tests, gateway tests/checks, and end-to-end hook.
+- The pre-push hook runs `./scripts/run-all-tests.sh`, which includes daemon tests, gateway tests/checks, `scripts/start_systemd_test.sh`, and end-to-end hook.
 
 Current CI checks:
 - Daemon Go tests

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: test test-daemon test-gateway test-openclaw-installer lint build clean hooks help
+.PHONY: test test-daemon test-gateway test-openclaw-installer test-start-systemd lint build clean hooks help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
 
-test: test-daemon test-gateway test-openclaw-installer ## Run all tests
+test: test-daemon test-gateway test-openclaw-installer test-start-systemd ## Run all tests
 
 test-daemon: ## Run daemon Go tests
 	cd daemon && go test ./...
@@ -14,6 +14,9 @@ test-gateway: ## Run gateway TypeScript type check and tests
 
 test-openclaw-installer: ## Run OpenClaw installer checksum regression test
 	cd daemon/internal/catalog && bash ./openclaw-installer_test.sh
+
+test-start-systemd: ## Run start.sh systemd target regression test
+	bash scripts/start_systemd_test.sh
 
 lint: ## Run linters (go vet + tsc)
 	cd daemon && go vet ./...

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -17,5 +17,8 @@ printf '\n=== Gateway checks and tests ===\n'
   bun test
 )
 
+printf '\n=== Start script systemd regression test ===\n'
+"$repo_root/scripts/start_systemd_test.sh"
+
 printf '\n=== End-to-end tests ===\n'
 "$repo_root/scripts/run-e2e-tests.sh"


### PR DESCRIPTION
## Summary
- include `scripts/start_systemd_test.sh` in canonical local test entrypoints
- add `test-start-systemd` target to `Makefile` and include it in `make test`
- run `start_systemd_test.sh` from `scripts/run-all-tests.sh` before e2e
- update `CONTRIBUTING.md` to reflect the expanded pre-push test scope

## Validation
- `bash scripts/start_systemd_test.sh`

Closes #968
