### PR TITLE
fix(catalog): dev placeholder as long-running process + absolute path

### DIFF
--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -4,6 +4,8 @@ import (
 	"carrier/daemon/internal/manifest"
 	_ "embed"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -61,8 +63,7 @@ if [ -z "$CHECKSUM" ]; then
     echo "WARNING: Dev mode enabled - skipping checksum validation" >&2
     echo "Creating placeholder installation for development..." >&2
     mkdir -p "$HOME/.local/bin"
-    echo "#!/bin/sh" > "$HOME/.local/bin/openclaw"
-    echo "echo \"OpenClaw dev placeholder - version %s\"" >> "$HOME/.local/bin/openclaw"
+    echo "IyEvYmluL3NoCmlmIFsgIiQxIiA9ICJnYXRld2F5IiBdICYmIFsgIiQyIiA9ICJzdGFydCIgXTsgdGhlbgogIGVjaG8gIk9wZW5DbGF3IGRldiBwbGFjZWhvbGRlciBydW5uaW5nIChwaWQgJCQpIgogIHRyYXAgImV4aXQgMCIgVEVSTSBJTlQKICB3aGlsZSB0cnVlOyBkbyBzbGVlcCAxOyBkb25lCmVsaWYgWyAiJDEiID0gImdhdGV3YXkiIF0gJiYgWyAiJDIiID0gInN0b3AiIF07IHRoZW4KICBlY2hvICJPcGVuQ2xhdyBkZXYgc3RvcCIKZWxzZQogIGVjaG8gIk9wZW5DbGF3IGRldiBwbGFjZWhvbGRlciIKZmkK" | base64 -d > "$HOME/.local/bin/openclaw"
     chmod +x "$HOME/.local/bin/openclaw"
     echo "Dev placeholder created at $HOME/.local/bin/openclaw" >&2
     exit 0
@@ -78,11 +79,34 @@ cat > "$SCRIPT" << '\''INSTALLER_EOF'\''
 INSTALLER_EOF
 chmod 700 "$SCRIPT"
 "$SCRIPT" "%s" "$CHECKSUM"
-'`, checksum, openclawVersion, openclawInstallerScript, openclawVersion)
+'`, checksum, openclawInstallerScript, openclawVersion)
+}
+
+func getNetworkSpec() manifest.NetworkSpec {
+	spec := manifest.NetworkSpec{
+		Healthcheck: manifest.HealthcheckSpec{
+			Type: "http",
+			URL:  defaultDaemonHealthURL,
+		},
+	}
+	// Skip port declarations in dev mode to avoid port conflict with the daemon itself
+	if os.Getenv("CARRIER_DEV_MODE") != "1" {
+		spec.Ports = []manifest.PortSpec{{Name: "http", Port: defaultDaemonPort}}
+	}
+	return spec
+}
+
+func openclawBinPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".local", "bin", "openclaw")
 }
 
 func OpenClawManifest() manifest.Manifest {
 	installCmd := getInstallCommand()
+	bin := openclawBinPath()
 
 	return manifest.Manifest{
 		ID:           "openclaw",
@@ -94,16 +118,10 @@ func OpenClawManifest() manifest.Manifest {
 			Type:    manifest.RuntimeTypeLocalBinary,
 			Install: manifest.CommandSpec{Command: installCmd},
 			Upgrade: manifest.CommandSpec{Command: installCmd},
-			Start:   manifest.CommandSpec{Command: "openclaw gateway start"},
-			Stop:    manifest.CommandSpec{Command: "openclaw gateway stop"},
+			Start:   manifest.CommandSpec{Command: bin + " gateway start"},
+			Stop:    manifest.CommandSpec{Command: bin + " gateway stop"},
 		},
-		Network: manifest.NetworkSpec{
-			Ports: []manifest.PortSpec{{Name: "http", Port: defaultDaemonPort}},
-			Healthcheck: manifest.HealthcheckSpec{
-				Type: "http",
-				URL:  defaultDaemonHealthURL,
-			},
-		},
+		Network: getNetworkSpec(),
 		Env: manifest.EnvSpec{
 			Required: []manifest.EnvVar{{Name: "OPENAI_API_KEY", Secret: true, Description: "OpenAI API key for LLM access"}},
 			Optional: []manifest.EnvVar{{Name: "LOG_LEVEL", Default: "info", Description: "Logging verbosity level"}},


### PR DESCRIPTION
## Problem

Three issues prevented the full E2E start→status→stop loop from working in dev mode (`CARRIER_DEV_MODE=1`):

1. **Placeholder exits immediately** — the dev placeholder was just `echo "OpenClaw dev placeholder"` which exits instantly → `monitorProcess` marks agent as `crashing`
2. **Port 9090 conflict** — daemon listens on :9090 and the manifest also declares port 9090 → pre-flight check fails with "port already in use"
3. **PATH shadowing** — `openclaw` in `~/.local/bin/` was shadowed by the real `openclaw` binary earlier in PATH → wrong binary executed

## Fix

1. **Long-running placeholder** — base64-encoded shell script that handles `gateway start` (trap + sleep loop), `gateway stop`, and default version echo
2. **Skip port check in dev mode** — `getNetworkSpec()` omits port declarations when `CARRIER_DEV_MODE=1`
3. **Absolute path** — `openclawBinPath()` resolves `~/.local/bin/openclaw` via `os.UserHomeDir()` at manifest build time

## Verified

11/11 E2E gateway commands pass:

| Step | Command | Result |
|------|---------|--------|
| 1 | /pair | ✅ paired |
| 2 | /agents | ✅ listed 1 agent |
| 3 | /install | ✅ completed |
| 4 | /status | ✅ stopped/unknown |
| 5 | /start | ✅ completed |
| 6 | /status | ✅ **running/healthy** |
| 7 | /logs | ✅ 3 log lines |
| 8 | /stop | ✅ completed |
| 9 | /status | ✅ stopped/unknown |
| 10 | /diagnose | ✅ artifact prepared |
| 11 | auth test | ✅ rejected without token |
