### PR TITLE
test(scripts): make check-tools test hermetic

### DIFF
--- a/scripts/test-check-tools.sh
+++ b/scripts/test-check-tools.sh
@@ -9,17 +9,36 @@ fail=0
 
 echo "Testing check-tools.sh..."
 
-# Test 1: With full PATH, should succeed
-if bash "$CHECK_SCRIPT" >/dev/null 2>&1; then
-  echo "  PASS: exits 0 with all tools present"
+TMP_BIN="$(mktemp -d)"
+trap 'rm -rf "$TMP_BIN"' EXIT
+
+make_stub() {
+  local tool="$1"
+  cat >"$TMP_BIN/$tool" <<'STUB'
+#!/usr/bin/env bash
+echo "stub 0.0.0"
+STUB
+  chmod +x "$TMP_BIN/$tool"
+}
+
+# Hermetic stubs for required tools used by check-tools.sh.
+make_stub "gh"
+make_stub "jq"
+make_stub "go"
+make_stub "bun"
+ln -sf "$(command -v bash)" "$TMP_BIN/bash"
+
+# Test 1: Hermetic success path with stubbed required tools.
+if PATH="$TMP_BIN:/usr/bin:/bin" /bin/bash "$CHECK_SCRIPT" >/dev/null 2>&1; then
+  echo "  PASS: exits 0 with stubbed required tools"
   pass=$((pass + 1))
 else
-  echo "  FAIL: expected exit 0 with all tools present"
+  echo "  FAIL: expected exit 0 with stubbed required tools"
   fail=$((fail + 1))
 fi
 
-# Test 2: With empty PATH, should fail (missing required tools)
-if PATH="/nonexistent" bash "$CHECK_SCRIPT" >/dev/null 2>&1; then
+# Test 2: With empty/nonexistent PATH, should fail (missing required tools)
+if PATH="/nonexistent" /bin/bash "$CHECK_SCRIPT" >/dev/null 2>&1; then
   echo "  FAIL: expected exit 1 with empty PATH"
   fail=$((fail + 1))
 else


### PR DESCRIPTION
## Summary
- make `scripts/test-check-tools.sh` hermetic for the success path by stubbing required tools (`gh`, `jq`, `go`, `bun`) in a temporary bin directory
- avoid ambient PATH dependency by invoking the checker with a controlled PATH
- keep and validate the missing-tools failure path with a nonexistent PATH
- clean up temporary artifacts via trap

## Testing
- bash scripts/test-check-tools.sh

Closes #972
