### PR TITLE
test(scripts): use printf for make_stub one-liner

### DIFF
--- a/scripts/test-check-tools.sh
+++ b/scripts/test-check-tools.sh
@@ -14,10 +14,7 @@ trap 'rm -rf "$TMP_BIN"' EXIT
 
 make_stub() {
   local tool="$1"
-  cat >"$TMP_BIN/$tool" <<'STUB'
-#!/usr/bin/env bash
-echo "stub 0.0.0"
-STUB
+  printf '#!/usr/bin/env bash\necho "stub 0.0.0"\n' >"$TMP_BIN/$tool"
   chmod +x "$TMP_BIN/$tool"
 }
 


### PR DESCRIPTION
## Summary
- replace `make_stub` heredoc with `printf` in `scripts/test-check-tools.sh`
- keep generated stub content identical

## Testing
- `bash scripts/test-check-tools.sh`

Closes #976
