### PR TITLE
refactor(agentd): harden JSON body decoding + malformed-body regression tests

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -31,6 +32,8 @@ const (
 	shutdownTimeout = 30 * time.Second
 	defaultLogsTail = 200
 	maxLogsTail     = 1000
+	// maxBodySize is the maximum allowed request body size (1 MB).
+	maxBodySize = 1 << 20
 )
 
 // agentIDPattern allows alphanumeric characters, hyphens, underscores, and dots.
@@ -511,8 +514,17 @@ type agentIDBody struct {
 }
 
 func decodeBody(w http.ResponseWriter, r *http.Request, v interface{}) bool {
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+	// Cap request body to maxBodySize to prevent DoS.
+	limited := io.LimitReader(r.Body, maxBodySize+1)
+	dec := json.NewDecoder(limited)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return false
+	}
+	// Reject trailing JSON values (e.g. `{}{}`)
+	if dec.More() {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: unexpected trailing data")
 		return false
 	}
 	return true

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -447,6 +447,66 @@ func TestPairingMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestDecodeBodyMalformed(t *testing.T) {
+	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
+		t.Fatal(err)
+	}
+	mux := buildTestMux(svc, true)
+
+	// We POST to /api/install which calls decodeBody then validateAgentID.
+	// For "valid" JSON the decode succeeds but install may fail downstream,
+	// so we only assert that bad bodies get 400 and valid ones do NOT get 400.
+	tests := []struct {
+		name    string
+		body    string
+		want400 bool
+	}{
+		{
+			name:    "valid baseline",
+			body:    `{"agentId":"openclaw"}`,
+			want400: false,
+		},
+		{
+			name:    "unknown field rejected",
+			body:    `{"agentId":"openclaw","extra":"bad"}`,
+			want400: true,
+		},
+		{
+			name:    "malformed JSON",
+			body:    `{agentId: openclaw}`,
+			want400: true,
+		},
+		{
+			name:    "trailing JSON object",
+			body:    `{"agentId":"openclaw"}{"agentId":"openclaw"}`,
+			want400: true,
+		},
+		{
+			name:    "empty body",
+			body:    ``,
+			want400: true,
+		},
+		{
+			name:    "oversized body",
+			body:    `{"agentId":"` + strings.Repeat("a", 1<<20+100) + `"}`,
+			want400: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/install", strings.NewReader(tt.body))
+			mux.ServeHTTP(rec, req)
+			got400 := rec.Code == http.StatusBadRequest
+			if got400 != tt.want400 {
+				t.Fatalf("status=%d, want400=%v; body=%s", rec.Code, tt.want400, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestBearerAuthMiddlewareBoundaryCases(t *testing.T) {
 	token := "secret-token"
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

Hardens the `decodeBody` helper in `cmd/agentd/main.go` to address security and correctness gaps:

- **Body size cap (1 MB)** — prevents DoS via oversized payloads using `io.LimitReader`
- **Unknown field rejection** — `DisallowUnknownFields()` returns 400 for unexpected JSON keys
- **Trailing data rejection** — `dec.More()` check rejects payloads like `{}{}`

### Tests added

Table-driven tests in `main_test.go` covering:
- Valid baseline (not 400)
- Unknown fields → 400
- Malformed JSON → 400
- Trailing JSON objects → 400
- Empty body → 400
- Oversized body (>1 MB) → 400

All existing tests continue to pass.

Closes #946