### PR TITLE
ci(release/security): sign and publish release artifacts in workflow

### DIFF
--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,45 @@
+# Release Artifact Signing
+
+Carrier release artifacts are cryptographically signed so that users can verify
+authenticity before installation.
+
+## How It Works
+
+The CI release workflow (`release.yml`) signs every `.zip` and `.sha256` file
+using **cosign keyless signing** (OIDC-based, via GitHub Actions' built-in
+identity token). No long-lived keys are stored in secrets.
+
+Each artifact `foo.zip` gets a companion `foo.zip.sig` file published alongside
+it in the GitHub Release.
+
+## Verifying a Release
+
+Download both the artifact and its `.sig` file, then run:
+
+```bash
+./scripts/verify-signature.sh carrier-<commit>-linux-x64.zip
+```
+
+The script auto-detects cosign or GPG. For cosign keyless verification the
+expected identity is the release workflow in this repository and the OIDC issuer
+is `https://token.actions.githubusercontent.com`.
+
+You can also verify manually:
+
+```bash
+cosign verify-blob \
+  --certificate-identity "https://github.com/Keith-CY/carrier/.github/workflows/release.yml@refs/heads/main" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --signature carrier-<commit>-linux-x64.zip.sig \
+  carrier-<commit>-linux-x64.zip
+```
+
+## Signing Methods
+
+| Method | When Used | Details |
+|--------|-----------|---------|
+| cosign (keyless) | GitHub Actions CI | OIDC token from GitHub, no stored keys |
+| GPG | Local / fallback | Requires `GPG_KEY_ID` env var |
+
+See `scripts/sign-artifacts.sh` and `scripts/verify-signature.sh` for
+implementation details.


### PR DESCRIPTION
## Summary

Add artifact signing to the CI release pipeline so every published release includes `.sig` signature files alongside the archives and checksums. Closes #961.

### What this PR includes

- **`docs/release-signing.md`** — user-facing guide explaining how signing works and how to verify downloaded artifacts.

### Workflow changes needed (requires `workflow` scope)

The following diff must be applied to `.github/workflows/release.yml` by a maintainer with the `workflow` push scope. This bot lacks that permission.

#### 1. Add cosign install + signing step to `build-packages` job

After the existing `Build release package` step and before `Upload package`, add:

```yaml
      - name: Install cosign
        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da  # v3.7.0

      - name: Sign release artifacts
        env:
          SIGNING_METHOD: cosign
        run: ./scripts/sign-artifacts.sh dist/
```

#### 2. Update the `Upload package` step to include `.sig` files

```yaml
      - name: Upload package
        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
        with:
          name: carrier-${{ matrix.label }}
          path: |
            dist/carrier-${{ github.sha }}-${{ matrix.label }}.${{ matrix.archive_ext }}
            dist/carrier-${{ github.sha }}-${{ matrix.label }}.${{ matrix.archive_ext }}.sha256
            dist/**/*.sig
          if-no-files-found: error
```

#### 3. Update the `Publish Release` step to include `.sig` files

```yaml
      - name: Publish Release
        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          tag_name: main-${{ github.sha }}
          name: "main-${{ github.sha }}"
          generate_release_notes: true
          files: |
            dist/**/*.zip
            dist/**/*.sha256
            dist/**/*.sig
```

#### 4. Add `id-token: write` permission

At the top-level `permissions` block, add `id-token: write` for cosign keyless OIDC:

```yaml
permissions:
  contents: write
  id-token: write
```

### How it works

- **cosign keyless signing** uses GitHub Actions OIDC identity — no stored keys needed.
- Each `.zip` and `.sha256` gets a `.sig` companion file.
- Users verify with `./scripts/verify-signature.sh <artifact>` (already in repo).
