### PR TITLE
feat: add first-class ZeroClaw support

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -65,6 +65,9 @@ func main() {
 	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
 		log.Fatalf("register openclaw manifest: %v", err)
 	}
+	if err := svc.RegisterManifest(catalog.ZeroClawManifest()); err != nil {
+		log.Fatalf("register zeroclaw manifest: %v", err)
+	}
 
 	logger.Info("agentd scaffold booted")
 	fmt.Printf("agentd scaffold booted (listen=%s:%d log=%s/%s)\n",

--- a/daemon/internal/catalog/catalog.go
+++ b/daemon/internal/catalog/catalog.go
@@ -64,6 +64,14 @@ func DefaultEntries() []Entry {
 			Description:  "Compact coding assistant",
 		},
 		{
+			ID:           "zeroclaw",
+			Name:         "ZeroClaw",
+			Version:      "0.1.0",
+			Status:       StatusActive,
+			Capabilities: []string{"chat", "code"},
+			Description:  "Rust-based AI assistant with chat and code capabilities",
+		},
+		{
 			ID:           "picoclaw",
 			Name:         "Pico Claw",
 			Version:      "0.1.0",

--- a/daemon/internal/catalog/catalog_test.go
+++ b/daemon/internal/catalog/catalog_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestDefaultEntriesContainsOpenClawAsActive(t *testing.T) {
 	entries := DefaultEntries()
-	if len(entries) != 4 {
-		t.Fatalf("expected 4 entries, got %d", len(entries))
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
 	}
 
 	openclaw, ok := FindByID("openclaw")
@@ -32,18 +32,25 @@ func TestCandidateAgentsPresent(t *testing.T) {
 
 func TestListReturnsAllEntries(t *testing.T) {
 	all := List()
-	if len(all) != 4 {
-		t.Fatalf("expected 4 entries from List(), got %d", len(all))
+	if len(all) != 5 {
+		t.Fatalf("expected 5 entries from List(), got %d", len(all))
 	}
 }
 
 func TestListByStatusActive(t *testing.T) {
 	active := ListByStatus(StatusActive)
-	if len(active) != 1 {
-		t.Fatalf("expected 1 active entry, got %d", len(active))
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active entries, got %d", len(active))
 	}
-	if active[0].ID != "openclaw" {
-		t.Fatalf("expected openclaw, got %s", active[0].ID)
+	activeIDs := map[string]bool{}
+	for _, a := range active {
+		activeIDs[a.ID] = true
+	}
+	if !activeIDs["openclaw"] {
+		t.Fatal("expected openclaw in active entries")
+	}
+	if !activeIDs["zeroclaw"] {
+		t.Fatal("expected zeroclaw in active entries")
 	}
 }
 
@@ -78,6 +85,25 @@ func TestEntryCapabilities(t *testing.T) {
 	}
 	if openclaw.HasCapability("nonexistent") {
 		t.Fatal("expected openclaw not to have nonexistent capability")
+	}
+}
+
+func TestZeroClawEntry(t *testing.T) {
+	entry, ok := FindByID("zeroclaw")
+	if !ok {
+		t.Fatal("expected zeroclaw in catalog")
+	}
+	if entry.Status != StatusActive {
+		t.Fatalf("expected zeroclaw status active, got %s", entry.Status)
+	}
+	if !entry.HasCapability("chat") {
+		t.Fatal("expected zeroclaw to have chat capability")
+	}
+	if !entry.HasCapability("code") {
+		t.Fatal("expected zeroclaw to have code capability")
+	}
+	if !entry.IsRunnable() {
+		t.Fatal("expected zeroclaw to be runnable")
 	}
 }
 

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -101,6 +101,107 @@ func getNetworkSpec() manifest.NetworkSpec {
 	return spec
 }
 
+// getZeroClawInstallCommand returns the install command for ZeroClaw.
+// ZeroClaw is installed via cargo (Rust toolchain required).
+// In dev mode, a placeholder script is created instead.
+func getZeroClawInstallCommand() string {
+	if os.Getenv("CARRIER_DEV_MODE") == "1" {
+		return getZeroClawDevInstallCommand()
+	}
+	return "cargo install --git https://github.com/theonlyhennygod/zeroclaw.git --force"
+}
+
+// getZeroClawDevInstallCommand creates a placeholder binary for development testing.
+func getZeroClawDevInstallCommand() string {
+	return `sh -c '
+mkdir -p "$HOME/.cargo/bin"
+cat > "$HOME/.cargo/bin/zeroclaw" << '\''SCRIPT'\''
+#!/bin/sh
+if [ "$1" = "gateway" ] && [ "$2" = "start" ]; then
+  echo "ZeroClaw dev placeholder running (pid $$)"
+  trap "exit 0" TERM INT
+  while true; do sleep 1; done
+elif [ "$1" = "gateway" ] && [ "$2" = "stop" ]; then
+  echo "ZeroClaw dev stop"
+elif [ "$1" = "status" ]; then
+  echo "ZeroClaw dev placeholder: ok"
+else
+  echo "ZeroClaw dev placeholder"
+fi
+SCRIPT
+chmod +x "$HOME/.cargo/bin/zeroclaw"
+echo "Dev placeholder created at $HOME/.cargo/bin/zeroclaw" >&2
+'`
+}
+
+// getZeroClawStartCommand returns the start command for ZeroClaw.
+func getZeroClawStartCommand() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "zeroclaw gateway start"
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = os.Getenv("HOME")
+		}
+		return filepath.Join(home, ".cargo", "bin", "zeroclaw") + " gateway start"
+	}
+}
+
+// getZeroClawStopCommand returns the stop command for ZeroClaw.
+func getZeroClawStopCommand() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "zeroclaw gateway stop"
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = os.Getenv("HOME")
+		}
+		return filepath.Join(home, ".cargo", "bin", "zeroclaw") + " gateway stop"
+	}
+}
+
+// ZeroClawManifest returns the manifest for the ZeroClaw agent.
+func ZeroClawManifest() manifest.Manifest {
+	installCmd := getZeroClawInstallCommand()
+
+	return manifest.Manifest{
+		ID:           "zeroclaw",
+		Name:         "ZeroClaw",
+		Version:      "latest",
+		Description:  "Rust-based AI assistant with chat and code capabilities",
+		Capabilities: []string{"chat", "code"},
+		Runtime: manifest.RuntimeSpec{
+			Type:    manifest.RuntimeTypeLocalBinary,
+			Install: manifest.CommandSpec{Command: installCmd},
+			Upgrade: manifest.CommandSpec{Command: installCmd},
+			Start:   manifest.CommandSpec{Command: getZeroClawStartCommand()},
+			Stop:    manifest.CommandSpec{Command: getZeroClawStopCommand()},
+		},
+		Network: manifest.NetworkSpec{
+			Healthcheck: manifest.HealthcheckSpec{
+				Type: "process",
+			},
+		},
+		Env: manifest.EnvSpec{
+			Optional: []manifest.EnvVar{
+				{Name: "ZEROCLAW_API_KEY", Secret: true, Description: "API key for LLM provider"},
+				{Name: "ZEROCLAW_PROVIDER", Default: "openrouter", Description: "LLM provider name"},
+			},
+		},
+		Upgrade: manifest.UpgradeSpec{Channel: "stable", Strategy: "in_place_or_reinstall"},
+		Health: manifest.HealthSpec{
+			IntervalSeconds:   30,
+			TimeoutSeconds:    5,
+			Retries:           3,
+			RestartLoopWindow: 300,
+			RestartLoopMax:    5,
+		},
+		Diagnostics: manifest.Diagnostics{Include: []string{"runtime_logs", "process_state", "env_sanitized"}},
+	}
+}
+
 func OpenClawManifest() manifest.Manifest {
 	installCmd := getInstallCommand()
 

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -20,6 +20,38 @@ func TestOpenClawManifestUsesDaemonHealthContract(t *testing.T) {
 	}
 }
 
+func TestZeroClawManifestBasic(t *testing.T) {
+	m := ZeroClawManifest()
+
+	if m.ID != "zeroclaw" {
+		t.Fatalf("expected id zeroclaw, got %s", m.ID)
+	}
+	if m.Network.Healthcheck.Type != "process" {
+		t.Fatalf("expected healthcheck type process, got %s", m.Network.Healthcheck.Type)
+	}
+	if m.Runtime.Start.Command == "" {
+		t.Fatal("expected start command to be set")
+	}
+	if m.Runtime.Stop.Command == "" {
+		t.Fatal("expected stop command to be set")
+	}
+	if m.Runtime.Install.Command == "" {
+		t.Fatal("expected install command to be set")
+	}
+}
+
+func TestZeroClawManifestDevMode(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "1")
+	m := ZeroClawManifest()
+	if m.Runtime.Install.Command == "" {
+		t.Fatal("expected dev install command to be set")
+	}
+	// Dev mode should not use cargo install
+	if m.Runtime.Install.Command == "cargo install --git https://github.com/theonlyhennygod/zeroclaw.git --force" {
+		t.Fatal("dev mode should not use production install command")
+	}
+}
+
 func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "catalog", "openclaw.manifest.json")
 	fileManifest, err := manifest.LoadFile(path)


### PR DESCRIPTION
## Summary

Adds first-class ZeroClaw support to the Carrier daemon, implementing issue #980.

### Changes

- **manifests.go**: Added `ZeroClawManifest()` with cargo-based install (`cargo install --git https://github.com/theonlyhennygod/zeroclaw.git --force`), `zeroclaw gateway start/stop` commands, process-alive health checking, and dev mode placeholder script
- **catalog.go**: Added `zeroclaw` entry with `StatusActive` and `["chat", "code"]` capabilities
- **main.go**: Registered ZeroClaw manifest in agentd startup
- **Tests**: Added manifest and catalog tests for ZeroClaw; updated existing test counts

### ZeroClaw Details
- Rust-based AI assistant (~3.4MB binary, <5MB RAM)
- Installs to `~/.cargo/bin/zeroclaw` via cargo
- CLI: `zeroclaw gateway start` / `zeroclaw gateway stop` / `zeroclaw status`

Closes #980, Closes #988, Closes #989, Closes #990, Closes #991, Closes #992