### PR TITLE
refactor(gateway/session): validate persisted SessionStore records on load

### DIFF
--- a/gateway/src/session/store.test.ts
+++ b/gateway/src/session/store.test.ts
@@ -341,6 +341,54 @@ describe("SessionStore", () => {
       expect(after!.lastSeenAt).not.toBe(before!.lastSeenAt);
     });
 
+    test("skips records missing required fields", async () => {
+      const testPath = getTestPath("missing-fields");
+      const validRecord = {
+        provider: "telegram",
+        chatId: "good",
+        sessionToken: "session-abc",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+      };
+      const missingToken = {
+        provider: "telegram",
+        chatId: "bad-1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+      };
+      const missingProvider = {
+        chatId: "bad-2",
+        sessionToken: "session-xyz",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastSeenAt: "2026-01-01T00:00:00.000Z",
+      };
+      const nullRecord = null;
+      const numberRecord = 42;
+
+      await Bun.write(testPath, JSON.stringify([validRecord, missingToken, missingProvider, nullRecord, numberRecord]));
+
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      expect(store.sessionCount).toBe(1);
+      expect(store.getSession("telegram", "good")).not.toBeNull();
+      expect(store.getSession("telegram", "bad-1")).toBeNull();
+    });
+
+    test("handles empty persistence file gracefully", async () => {
+      const testPath = getTestPath("empty-file");
+      await Bun.write(testPath, "");
+
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      expect(store.sessionCount).toBe(0);
+    });
+
+    test("handles non-array JSON gracefully", async () => {
+      const testPath = getTestPath("non-array");
+      await Bun.write(testPath, JSON.stringify({ not: "an array" }));
+
+      const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"), 30 * 24 * 60 * 60, testPath);
+      expect(store.sessionCount).toBe(0);
+    });
+
     test("without persistence path, store works in-memory only", async () => {
       const store = new SessionStore(() => new Date("2026-01-01T00:00:00Z"));
       

--- a/gateway/src/session/store.ts
+++ b/gateway/src/session/store.ts
@@ -180,17 +180,40 @@ export class SessionStore {
 
     try {
       const data = readFileSync(this.persistencePath, "utf-8");
+      if (data.trim() === "") {
+        return;
+      }
       const parsed = JSON.parse(data);
       
       if (Array.isArray(parsed)) {
-        for (const session of parsed) {
-          this.sessions.set(sessionKey(session.provider, session.chatId), session);
+        for (const record of parsed) {
+          if (!this.isValidSessionRecord(record)) {
+            console.warn("Skipping malformed session record:", record);
+            continue;
+          }
+          this.sessions.set(sessionKey(record.provider, record.chatId), record);
         }
+      } else {
+        console.warn("Session persistence file does not contain an array, starting fresh");
       }
     } catch (error) {
       // If the file is corrupt or invalid, start fresh
       console.error("Failed to load sessions from disk:", error);
     }
+  }
+
+  private isValidSessionRecord(record: unknown): record is SessionRecord {
+    if (typeof record !== "object" || record === null) {
+      return false;
+    }
+    const r = record as Record<string, unknown>;
+    return (
+      typeof r.provider === "string" &&
+      typeof r.chatId === "string" &&
+      typeof r.sessionToken === "string" &&
+      typeof r.createdAt === "string" &&
+      typeof r.lastSeenAt === "string"
+    );
   }
 
   private scheduleSave(): void {


### PR DESCRIPTION
## Summary

Validate persisted SessionStore records on load and handle malformed data gracefully instead of blindly trusting disk contents.

## Changes

- **`store.ts`**: Added `isValidSessionRecord()` that checks all required `SessionRecord` fields (`provider`, `chatId`, `sessionToken`, `createdAt`, `lastSeenAt`). Malformed records are skipped with a warning. Empty files and non-array JSON are handled gracefully.
- **`store.test.ts`**: Added 3 regression tests: missing fields / null / non-string values, empty file, non-array JSON.

All 30 tests pass.

Closes #973