### PR TITLE
test(catalog): lock shell-contract invariants for install/start/stop commands

### DIFF
--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -2,7 +2,9 @@ package catalog
 
 import (
 	"carrier/daemon/internal/manifest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -36,5 +38,114 @@ func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
 	}
 	if fileManifest.Network.Ports[0].Port != generated.Network.Ports[0].Port {
 		t.Fatalf("catalog port = %d, generated = %d", fileManifest.Network.Ports[0].Port, generated.Network.Ports[0].Port)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Install-command shell-contract tests
+// ---------------------------------------------------------------------------
+
+func TestGetInstallCommand_Unix(t *testing.T) {
+	// Ensure dev mode is off so we get the production command.
+	t.Setenv("CARRIER_DEV_MODE", "")
+
+	cmd := getInstallCommand()
+
+	for _, want := range []string{
+		"curl",
+		"-fsSL",
+		`--proto "=https"`,
+		"--tlsv1.2",
+		installScriptURL,
+		"| bash",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("install command missing %q\ngot: %s", want, cmd)
+		}
+	}
+}
+
+func TestGetInstallCommand_DevMode(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "1")
+
+	cmd := getInstallCommand()
+
+	for _, want := range []string{
+		"mkdir -p",
+		".local/bin",
+		"base64 -d",
+		"chmod +x",
+		"openclaw",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("dev install command missing %q\ngot: %s", want, cmd)
+		}
+	}
+
+	// Must NOT contain the production URL.
+	if strings.Contains(cmd, installScriptURL) {
+		t.Error("dev install command should not reference the production install URL")
+	}
+}
+
+func TestGetStartCommand_Unix(t *testing.T) {
+	cmd := getStartCommand()
+
+	home, _ := os.UserHomeDir()
+	wantPrefix := filepath.Join(home, ".local", "bin", "openclaw")
+
+	if !strings.HasPrefix(cmd, wantPrefix) {
+		t.Errorf("start command should use absolute path\ngot: %s\nwant prefix: %s", cmd, wantPrefix)
+	}
+	if !strings.HasSuffix(cmd, "gateway start") {
+		t.Errorf("start command should end with 'gateway start'\ngot: %s", cmd)
+	}
+}
+
+func TestGetStopCommand_Unix(t *testing.T) {
+	cmd := getStopCommand()
+
+	home, _ := os.UserHomeDir()
+	wantPrefix := filepath.Join(home, ".local", "bin", "openclaw")
+
+	if !strings.HasPrefix(cmd, wantPrefix) {
+		t.Errorf("stop command should use absolute path\ngot: %s\nwant prefix: %s", cmd, wantPrefix)
+	}
+	if !strings.HasSuffix(cmd, "gateway stop") {
+		t.Errorf("stop command should end with 'gateway stop'\ngot: %s", cmd)
+	}
+}
+
+func TestGetNetworkSpec_ProductionIncludesPorts(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+
+	spec := getNetworkSpec()
+
+	if len(spec.Ports) == 0 {
+		t.Fatal("production network spec must declare ports")
+	}
+	if spec.Ports[0].Port != defaultDaemonPort {
+		t.Fatalf("port = %d, want %d", spec.Ports[0].Port, defaultDaemonPort)
+	}
+}
+
+func TestGetNetworkSpec_DevModeSkipsPorts(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "1")
+
+	spec := getNetworkSpec()
+
+	if len(spec.Ports) != 0 {
+		t.Fatalf("dev mode should skip ports, got %d", len(spec.Ports))
+	}
+}
+
+func TestOpenClawManifest_InstallAndUpgradeMatch(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+
+	m := OpenClawManifest()
+
+	if m.Runtime.Install.Command != m.Runtime.Upgrade.Command {
+		t.Errorf("install and upgrade commands should be identical\ninstall: %s\nupgrade: %s",
+			m.Runtime.Install.Command, m.Runtime.Upgrade.Command)
 	}
 }


### PR DESCRIPTION
Add focused tests that lock the shell contract for install-command generation.

## Tests added
- **TestGetInstallCommand_Unix** – verifies curl, TLS flags, proto restriction, and official URL
- **TestGetInstallCommand_DevMode** – verifies dev placeholder (base64, mkdir, chmod) and no production URL leak
- **TestGetStartCommand_Unix** – absolute path + 'gateway start'
- **TestGetStopCommand_Unix** – absolute path + 'gateway stop'
- **TestGetNetworkSpec_ProductionIncludesPorts** – port declared in production
- **TestGetNetworkSpec_DevModeSkipsPorts** – ports omitted in dev mode
- **TestOpenClawManifest_InstallAndUpgradeMatch** – install == upgrade command

Closes #966