### PR TITLE
fix: guard RegisterManifest against overwriting running agent state

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -33,6 +33,7 @@ var (
 	ErrRemoteDiagnosisNotNeeded   = errors.New("remote diagnosis is not required for this agent")
 	ErrUpgradeFailed              = errors.New("agent upgrade failed")
 	ErrUpgradeStrategyUnsupported = errors.New("upgrade strategy is not supported")
+	ErrAgentAlreadyRunning        = errors.New("cannot re-register manifest while agent is running")
 )
 
 const (
@@ -258,6 +259,21 @@ func (s *Service) RegisterManifest(m manifest.Manifest) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Guard: reject re-registration when the agent is currently running.
+	if existing, ok := s.states[m.ID]; ok && existing.Runtime == RuntimeStateRunning {
+		return ErrAgentAlreadyRunning
+	}
+
+	// Preserve runtime state for non-running agents that already exist.
+	if existing, ok := s.states[m.ID]; ok {
+		existing.Name = m.Name
+		existing.Version = m.Version
+		existing.UpdatedAt = s.now()
+		s.states[m.ID] = existing
+		s.manifests[m.ID] = m
+		return nil
+	}
 
 	s.manifests[m.ID] = m
 	s.states[m.ID] = AgentState{

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -1684,3 +1684,82 @@ func (f *fakeTriager) Analyze(ctx context.Context, e baseagent.Evidence) (baseag
 	}
 	return baseagent.TriageResult{}, nil
 }
+
+func TestRegisterManifest_RejectsRunningAgent(t *testing.T) {
+	svc := NewService(nil)
+	m := sampleManifest()
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	// Simulate running state
+	svc.mu.Lock()
+	st := svc.states[m.ID]
+	st.Runtime = RuntimeStateRunning
+	svc.states[m.ID] = st
+	svc.mu.Unlock()
+
+	m.Version = "2.0.0"
+	if err := svc.RegisterManifest(m); !errors.Is(err, ErrAgentAlreadyRunning) {
+		t.Fatalf("expected ErrAgentAlreadyRunning, got %v", err)
+	}
+
+	// Verify state was not overwritten
+	status, _ := svc.Status(m.ID)
+	if status.Version != "1.0.0" {
+		t.Fatalf("expected version 1.0.0 preserved, got %s", status.Version)
+	}
+	if status.Runtime != RuntimeStateRunning {
+		t.Fatalf("expected runtime still running, got %s", status.Runtime)
+	}
+}
+
+func TestRegisterManifest_UpdatesStoppedAgent(t *testing.T) {
+	svc := NewService(nil)
+	m := sampleManifest()
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	// Set to installed+stopped
+	svc.mu.Lock()
+	st := svc.states[m.ID]
+	st.Install = InstallStateInstalled
+	st.Runtime = RuntimeStateStopped
+	svc.states[m.ID] = st
+	svc.mu.Unlock()
+
+	m.Version = "2.0.0"
+	m.Name = "OpenClaw v2"
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatalf("re-register stopped agent: %v", err)
+	}
+
+	status, _ := svc.Status(m.ID)
+	if status.Version != "2.0.0" {
+		t.Fatalf("expected version 2.0.0, got %s", status.Version)
+	}
+	if status.Install != InstallStateInstalled {
+		t.Fatalf("expected install state preserved, got %s", status.Install)
+	}
+}
+
+func TestRegisterManifest_FreshRegistration(t *testing.T) {
+	svc := NewService(nil)
+	m := sampleManifest()
+	m.ID = "brand-new-agent"
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatalf("fresh register: %v", err)
+	}
+
+	status, err := svc.Status("brand-new-agent")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Install != InstallStateNotInstalled {
+		t.Fatalf("expected not-installed, got %s", status.Install)
+	}
+	if status.Runtime != RuntimeStateStopped {
+		t.Fatalf("expected stopped, got %s", status.Runtime)
+	}
+}


### PR DESCRIPTION
## Problem
When `RegisterManifest` is called for an agent that's already running, it silently overwrites the agent's state, potentially losing runtime information (install status, health, runtime state, etc.).

Fixes #730

## Solution
- **Running agents**: Return `ErrAgentAlreadyRunning` — caller must stop the agent first
- **Stopped/crashed agents**: Update manifest fields (name, version) while preserving existing runtime state
- **New agents**: Unchanged behavior — full initialization

## Tests
- `TestRegisterManifest_RejectsRunningAgent` — verifies running agents are protected
- `TestRegisterManifest_UpdatesStoppedAgent` — verifies stopped agents get updated without state loss
- `TestRegisterManifest_FreshRegistration` — verifies new agent initialization is unchanged