### PR TITLE
feat(security): add rate limiting to pairing verify endpoint

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -26,6 +26,7 @@ import (
 	"carrier/daemon/internal/config"
 	"carrier/daemon/internal/lifecycle"
 	"carrier/daemon/internal/logging"
+	"carrier/daemon/internal/ratelimit"
 )
 
 const (
@@ -92,7 +93,8 @@ func main() {
 	// Build HTTP server
 	ready := &atomic.Bool{}
 	ready.Store(false)
-	mux := buildHTTPMux(svc, ready, pairStore)
+	pairLimiter := ratelimit.New(ratelimit.WithMax(5), ratelimit.WithWindow(1*time.Minute))
+	mux := buildHTTPMux(svc, ready, pairStore, pairLimiter)
 	var handler http.Handler = mux
 	if cfg.Server.APIToken != "" {
 		handler = bearerAuthMiddleware(cfg.Server.APIToken, mux)
@@ -137,7 +139,7 @@ func main() {
 	fmt.Println("agentd stopped gracefully")
 }
 
-func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.PairingCodeStore) *http.ServeMux {
+func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.PairingCodeStore, pairLimiter *ratelimit.Limiter) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Health checks
@@ -247,6 +249,15 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.Pai
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
+
+		// Rate-limit by remote IP.
+		ip := remoteIP(r)
+		if !pairLimiter.Allow(ip) {
+			w.Header().Set("Retry-After", "60")
+			writeJSONError(w, http.StatusTooManyRequests, "too many pairing attempts, try again later")
+			return
+		}
+
 		var body struct {
 			Code string `json:"code"`
 		}
@@ -651,6 +662,20 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// remoteIP extracts the client IP from the request, preferring X-Forwarded-For.
+func remoteIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if parts := strings.SplitN(xff, ",", 2); len(parts) > 0 {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 // isLoopback returns true when the host string resolves to a loopback address.

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -18,6 +18,7 @@ import (
 	"carrier/daemon/internal/commandexec"
 	"carrier/daemon/internal/lifecycle"
 	"carrier/daemon/internal/manifest"
+	"carrier/daemon/internal/ratelimit"
 	"carrier/daemon/internal/runtimecheck"
 )
 
@@ -52,7 +53,7 @@ func buildTestMux(svc *lifecycle.Service, ready bool) *http.ServeMux {
 	var readyFlag atomic.Bool
 	readyFlag.Store(ready)
 	pairStore := api.NewPairingCodeStore(nil)
-	return buildHTTPMux(svc, &readyFlag, pairStore)
+	return buildHTTPMux(svc, &readyFlag, pairStore, ratelimit.New())
 }
 
 func (m *fakeProcessManager) Start(agentID string, _ string, _ []string) (int, error) {
@@ -393,7 +394,7 @@ func TestPairingVerifyConsumeEndpoint(t *testing.T) {
 
 	var readyFlag atomic.Bool
 	readyFlag.Store(true)
-	mux := buildHTTPMux(svc, &readyFlag, pairStore)
+	mux := buildHTTPMux(svc, &readyFlag, pairStore, ratelimit.New())
 
 	// Test POST /api/pairing/verify-consume with valid code
 	body := fmt.Sprintf(`{"code":"%s"}`, record.Code)
@@ -504,6 +505,51 @@ func TestDecodeBodyMalformed(t *testing.T) {
 				t.Fatalf("status=%d, want400=%v; body=%s", rec.Code, tt.want400, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestPairingVerifyRateLimit(t *testing.T) {
+	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
+		t.Fatal(err)
+	}
+	pairStore := api.NewPairingCodeStore(nil)
+
+	var readyFlag atomic.Bool
+	readyFlag.Store(true)
+	limiter := ratelimit.New(ratelimit.WithMax(3), ratelimit.WithWindow(1*time.Minute))
+	mux := buildHTTPMux(svc, &readyFlag, pairStore, limiter)
+
+	// Make 3 requests (all allowed, even if codes are wrong)
+	for i := 0; i < 3; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/pairing/verify-consume", strings.NewReader(`{"code":"badcode1"}`))
+		req.RemoteAddr = "1.2.3.4:12345"
+		mux.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d should not be rate-limited", i+1)
+		}
+	}
+
+	// 4th request should be rate-limited
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/pairing/verify-consume", strings.NewReader(`{"code":"badcode1"}`))
+	req.RemoteAddr = "1.2.3.4:12345"
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") != "60" {
+		t.Fatal("expected Retry-After header")
+	}
+
+	// Different IP should still be allowed
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/pairing/verify-consume", strings.NewReader(`{"code":"badcode1"}`))
+	req.RemoteAddr = "5.6.7.8:12345"
+	mux.ServeHTTP(rec, req)
+	if rec.Code == http.StatusTooManyRequests {
+		t.Fatal("different IP should not be rate-limited")
 	}
 }
 

--- a/daemon/internal/ratelimit/ratelimit.go
+++ b/daemon/internal/ratelimit/ratelimit.go
@@ -1,0 +1,101 @@
+// Package ratelimit provides an in-memory sliding-window rate limiter.
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter tracks request attempts per key (typically IP address) using a
+// sliding window. After maxAttempts failures within the window, subsequent
+// requests are rejected until the window slides past.
+type Limiter struct {
+	mu          sync.Mutex
+	attempts    map[string][]time.Time
+	maxAttempts int
+	window      time.Duration
+	now         func() time.Time
+}
+
+// Option configures a Limiter.
+type Option func(*Limiter)
+
+// WithWindow sets the sliding window duration.
+func WithWindow(d time.Duration) Option {
+	return func(l *Limiter) { l.window = d }
+}
+
+// WithMax sets the maximum number of attempts within the window.
+func WithMax(n int) Option {
+	return func(l *Limiter) { l.maxAttempts = n }
+}
+
+// WithNow overrides the time source (for testing).
+func WithNow(fn func() time.Time) Option {
+	return func(l *Limiter) { l.now = fn }
+}
+
+// New creates a rate limiter. Defaults: 5 attempts per 1 minute window.
+func New(opts ...Option) *Limiter {
+	l := &Limiter{
+		attempts:    make(map[string][]time.Time),
+		maxAttempts: 5,
+		window:      1 * time.Minute,
+		now:         time.Now,
+	}
+	for _, o := range opts {
+		o(l)
+	}
+	return l
+}
+
+// Allow checks whether the given key is within the rate limit.
+// Returns true if the request is allowed, false if it should be rejected.
+// Each call to Allow that returns true is recorded as an attempt.
+func (l *Limiter) Allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	cutoff := now.Add(-l.window)
+
+	// Prune old attempts.
+	entries := l.attempts[key]
+	start := 0
+	for start < len(entries) && entries[start].Before(cutoff) {
+		start++
+	}
+	entries = entries[start:]
+
+	if len(entries) >= l.maxAttempts {
+		l.attempts[key] = entries
+		return false
+	}
+
+	l.attempts[key] = append(entries, now)
+	return true
+}
+
+// Record records a failed attempt for the given key without checking the limit.
+// Use this when you want to count failures separately from Allow.
+func (l *Limiter) Record(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	cutoff := now.Add(-l.window)
+
+	entries := l.attempts[key]
+	start := 0
+	for start < len(entries) && entries[start].Before(cutoff) {
+		start++
+	}
+	l.attempts[key] = append(entries[start:], now)
+}
+
+// Reset removes all tracked attempts for a key.
+func (l *Limiter) Reset(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.attempts, key)
+}

--- a/daemon/internal/ratelimit/ratelimit_test.go
+++ b/daemon/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,68 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAllowWithinLimit(t *testing.T) {
+	l := New(WithMax(3), WithWindow(1*time.Minute))
+	for i := 0; i < 3; i++ {
+		if !l.Allow("ip1") {
+			t.Fatalf("attempt %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestDenyAfterLimit(t *testing.T) {
+	l := New(WithMax(3), WithWindow(1*time.Minute))
+	for i := 0; i < 3; i++ {
+		l.Allow("ip1")
+	}
+	if l.Allow("ip1") {
+		t.Fatal("4th attempt should be denied")
+	}
+}
+
+func TestWindowSlides(t *testing.T) {
+	now := time.Now()
+	current := now
+	l := New(WithMax(2), WithWindow(1*time.Minute), WithNow(func() time.Time { return current }))
+
+	l.Allow("ip1")
+	l.Allow("ip1")
+	if l.Allow("ip1") {
+		t.Fatal("should be denied")
+	}
+
+	// Advance past window
+	current = now.Add(61 * time.Second)
+	if !l.Allow("ip1") {
+		t.Fatal("should be allowed after window slides")
+	}
+}
+
+func TestDifferentKeysIndependent(t *testing.T) {
+	l := New(WithMax(1), WithWindow(1*time.Minute))
+	if !l.Allow("ip1") {
+		t.Fatal("ip1 should be allowed")
+	}
+	if l.Allow("ip1") {
+		t.Fatal("ip1 should be denied")
+	}
+	if !l.Allow("ip2") {
+		t.Fatal("ip2 should be allowed independently")
+	}
+}
+
+func TestReset(t *testing.T) {
+	l := New(WithMax(1), WithWindow(1*time.Minute))
+	l.Allow("ip1")
+	if l.Allow("ip1") {
+		t.Fatal("should be denied")
+	}
+	l.Reset("ip1")
+	if !l.Allow("ip1") {
+		t.Fatal("should be allowed after reset")
+	}
+}


### PR DESCRIPTION
## Summary

Add in-memory sliding-window rate limiter to `/api/pairing/verify-consume` endpoint to prevent brute-force attacks against pairing codes.

## Changes

- New `daemon/internal/ratelimit` package with configurable sliding-window rate limiter
- Default: 5 attempts per IP per minute
- Returns `429 Too Many Requests` with `Retry-After` header when limit exceeded
- Per-IP tracking via `X-Forwarded-For` or `RemoteAddr`
- Unit tests for rate limiter + integration test for the endpoint

Closes #731