### PR TITLE
ci(release): sign and publish release artifacts with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   e2e-deploy:
@@ -112,10 +112,55 @@ jobs:
             dist/carrier-${{ github.sha }}-${{ matrix.label }}.${{ matrix.archive_ext }}.sha256
           if-no-files-found: error
 
-  release:
+  sign-artifacts:
     needs: build-packages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write   # Required for cosign keyless OIDC signing
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Download packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: dist
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Sign release artifacts
+        run: ./scripts/sign-artifacts.sh dist
+        env:
+          SIGNING_METHOD: cosign
+
+      - name: Verify signatures (spot-check)
+        run: |
+          set -euo pipefail
+          # Find the first .zip file and verify its signature
+          first_zip=$(find dist -name '*.zip' -type f | head -n 1)
+          if [[ -z "$first_zip" ]]; then
+            echo "ERROR: No zip artifacts found to verify"
+            exit 1
+          fi
+          echo "Spot-checking signature for: $first_zip"
+          ./scripts/verify-signature.sh "$first_zip"
+
+      - name: Upload signatures
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: carrier-signatures
+          path: dist/**/*.sig
+          if-no-files-found: error
+
+  release:
+    needs: [build-packages, sign-artifacts]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write  # Required for creating GitHub releases
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Download packages
@@ -133,3 +178,4 @@ jobs:
           files: |
             dist/**/*.zip
             dist/**/*.sha256
+            dist/**/*.sig


### PR DESCRIPTION
Wire artifact signing into the release workflow using cosign keyless OIDC signing, closing the docs-vs-implementation gap.

## Changes

- New `sign-artifacts` job between `build-packages` and `release`
- Installs cosign, runs `scripts/sign-artifacts.sh`, spot-checks with `scripts/verify-signature.sh`
- Uploads `.sig` files alongside `.zip` and `.sha256` in GitHub Release
- Least-privilege permissions: `id-token: write` scoped to signing job only

Closes #961