### PR TITLE
fix(daemon): close Stop/monitorProcess race with RuntimeStateStopping

### DIFF
--- a/daemon/internal/lifecycle/start_stop.go
+++ b/daemon/internal/lifecycle/start_stop.go
@@ -116,19 +116,22 @@ func (s *Service) Start(ctx context.Context, agentID string) error {
 }
 
 func (s *Service) Stop(ctx context.Context, agentID string) error {
-	_, state, err := s.getManifestAndState(agentID)
-	if err != nil {
-		return err
+	// Atomically check preconditions and transition to RuntimeStateStopping in
+	// a single lock acquisition.  This closes the race window where
+	// monitorProcess() could observe RuntimeStateRunning between the old
+	// getManifestAndState (RLock) and the subsequent write-Lock, recording a
+	// false crash-loop restart.
+	s.mu.Lock()
+	if _, ok := s.manifests[agentID]; !ok {
+		s.mu.Unlock()
+		return ErrAgentNotFound
 	}
-	if state.Runtime == RuntimeStateStopped {
+	state := s.states[agentID]
+	if state.Runtime == RuntimeStateStopped || state.Runtime == RuntimeStateStopping {
+		s.mu.Unlock()
 		return ErrAlreadyStopped
 	}
-
-	// Mark as stopped before killing the process so that monitorProcess
-	// (which races on the same lock) won't overwrite the state to Crashing.
-	s.mu.Lock()
-	state = s.states[agentID]
-	state.Runtime = RuntimeStateStopped
+	state.Runtime = RuntimeStateStopping
 	state.UpdatedAt = s.now()
 	s.states[agentID] = state
 	s.mu.Unlock()
@@ -154,6 +157,7 @@ func (s *Service) Stop(ctx context.Context, agentID string) error {
 
 	s.mu.Lock()
 	state = s.states[agentID]
+	state.Runtime = RuntimeStateStopped
 	state.Health = HealthStateUnknown
 	state.LastError = ""
 	state.UpdatedAt = s.now()

--- a/daemon/internal/lifecycle/types.go
+++ b/daemon/internal/lifecycle/types.go
@@ -18,6 +18,7 @@ const (
 	RuntimeStateStopped   RuntimeState = "stopped"
 	RuntimeStateStarting  RuntimeState = "starting"
 	RuntimeStateRunning   RuntimeState = "running"
+	RuntimeStateStopping  RuntimeState = "stopping"
 	RuntimeStateCrashing  RuntimeState = "crashing"
 	RuntimeStateCrashLoop RuntimeState = "crash_loop"
 )


### PR DESCRIPTION
## Summary

Fixes #659 — Stop() races with monitorProcess(), causing false crash-loop triggers.

## Root Cause

Stop() used two separate lock acquisitions: `getManifestAndState()` (RLock) followed by a write-Lock to set `RuntimeStateStopped`. In the gap between them, `monitorProcess()` could acquire the lock, observe `RuntimeStateRunning`, and call `recordRestart()` — recording a false crash.

## Fix

1. **New `RuntimeStateStopping` state** — intermediate state between Running and Stopped
2. **Atomic check-and-transition** — Stop() checks preconditions and sets `RuntimeStateStopping` in a single Lock acquisition, eliminating the race window
3. **monitorProcess() unchanged** — it only reacts to `RuntimeStateRunning`, so it naturally ignores processes being intentionally stopped
4. **Final transition** — after successful process termination, Stop() sets `RuntimeStateStopped`

## Changes

- `types.go`: Add `RuntimeStateStopping` constant
- `start_stop.go`: Rewrite Stop() to atomically transition to Stopping before killing the process; set Stopped after success