### PR TITLE
fix(daemon): stop agents concurrently during shutdown to respect shutdownTimeout

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -623,7 +624,7 @@ func shutdownAgents(svc *lifecycle.Service, timeout time.Duration) error {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- stopAllAgents(svc)
+		done <- stopAllAgents(ctx, svc)
 	}()
 
 	select {
@@ -635,19 +636,33 @@ func shutdownAgents(svc *lifecycle.Service, timeout time.Duration) error {
 	}
 }
 
-func stopAllAgents(svc *lifecycle.Service) error {
+func stopAllAgents(ctx context.Context, svc *lifecycle.Service) error {
 	agents := svc.ListAgents()
-	var firstErr error
+
+	var (
+		mu       sync.Mutex
+		firstErr error
+		wg       sync.WaitGroup
+	)
+
 	for _, agent := range agents {
 		if agent.Runtime == lifecycle.RuntimeStateRunning {
-			if err := svc.Stop(context.Background(), agent.ID); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to stop agent %s: %v\n", agent.ID, err)
-				if firstErr == nil {
-					firstErr = err
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				if err := svc.Stop(ctx, id); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to stop agent %s: %v\n", id, err)
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
 				}
-			}
+			}(agent.ID)
 		}
 	}
+
+	wg.Wait()
 	svc.Cleanup()
 	return firstErr
 }

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -118,7 +118,7 @@ func TestStopAllAgents_NoRunning(t *testing.T) {
 	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
 		t.Fatal(err)
 	}
-	if err := stopAllAgents(svc); err != nil {
+	if err := stopAllAgents(context.Background(), svc); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

`stopAllAgents()` stopped agents sequentially. Each `ProcessManager.Stop()` blocks up to 10s for graceful termination. With N unresponsive agents this took N×10s, exceeding the 30s `shutdownTimeout` (e.g. 4 agents × 10s = 40s > 30s), causing `context.DeadlineExceeded` and `log.Fatalf`.

## Fix

Stop agents concurrently using `sync.WaitGroup`. The shutdown context is passed through so all stops share the same deadline. Total shutdown time is now bounded by `max(single agent stop time)` rather than `sum(all agent stop times)`.

Fixes #686