### PR TITLE
fix(daemon): persist crash-loop cooldown state across daemon restarts

### DIFF
--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -188,6 +188,7 @@ type Service struct {
 	crashLoopCooldown  time.Duration
 	memoryStore        *memory.Store
 	stateFile          *StateFile
+	pendingPersisted   map[string]*PersistedAgentState // loaded on startup, applied during RegisterManifest
 	processManager     ProcessController
 	processLogDir      string
 	backoffPolicy      BackoffPolicy
@@ -292,9 +293,23 @@ func (s *Service) RegisterManifest(m manifest.Manifest) error {
 		s.memoryLinks[m.ID] = nil
 	}
 	s.logs[m.ID] = nil
-	s.restarts[m.ID] = nil
-	s.cooldowns[m.ID] = time.Time{}
 	s.backoffStates[m.ID] = BackoffState{}
+
+	// Apply any pending persisted state (crash-loop cooldown, restart timestamps)
+	// from a prior daemon run. If none exists, initialise to zero values.
+	if pState, ok := s.pendingPersisted[m.ID]; ok {
+		state := s.states[m.ID]
+		s.applyPersistedState(m.ID, pState, &state)
+		s.states[m.ID] = state
+		delete(s.pendingPersisted, m.ID)
+	} else {
+		if _, ok := s.restarts[m.ID]; !ok {
+			s.restarts[m.ID] = nil
+		}
+		if _, ok := s.cooldowns[m.ID]; !ok {
+			s.cooldowns[m.ID] = time.Time{}
+		}
+	}
 
 	return nil
 }
@@ -544,26 +559,14 @@ func (s *Service) loadPersistedState() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Stash persisted state so RegisterManifest can apply it when agents
+	// are registered (agents may not exist yet at this point).
+	s.pendingPersisted = persisted
+
 	for id, pState := range persisted {
 		// Only restore state for agents that have been registered
 		if state, ok := s.states[id]; ok {
-			if pState.Installed {
-				state.Install = InstallStateInstalled
-			} else {
-				state.Install = InstallStateNotInstalled
-			}
-
-			// Restore runtime state, but verify process liveness
-			restoredState := RuntimeState(pState.RuntimeState)
-			if restoredState == RuntimeStateRunning {
-				// Verify the process is actually alive
-				if !s.processManager.IsRunning(id) {
-					// Process is not actually running, mark as stopped
-					restoredState = RuntimeStateStopped
-				}
-			}
-			state.Runtime = restoredState
-			state.UpdatedAt = pState.LastTransition
+			s.applyPersistedState(id, pState, &state)
 			s.states[id] = state
 		}
 	}
@@ -571,22 +574,60 @@ func (s *Service) loadPersistedState() error {
 	return nil
 }
 
-// saveState persists the current agent states to disk.
+// applyPersistedState applies a single persisted record to the given AgentState
+// and restores crash-loop cooldown/restart data on the service. Caller must hold s.mu.
+func (s *Service) applyPersistedState(id string, pState *PersistedAgentState, state *AgentState) {
+	if pState.Installed {
+		state.Install = InstallStateInstalled
+	} else {
+		state.Install = InstallStateNotInstalled
+	}
+
+	restoredState := RuntimeState(pState.RuntimeState)
+	if restoredState == RuntimeStateRunning {
+		if !s.processManager.IsRunning(id) {
+			restoredState = RuntimeStateStopped
+		}
+	}
+	state.Runtime = restoredState
+	state.UpdatedAt = pState.LastTransition
+
+	// Restore crash-loop cooldown state
+	if len(pState.Restarts) > 0 {
+		s.restarts[id] = make([]time.Time, len(pState.Restarts))
+		copy(s.restarts[id], pState.Restarts)
+	}
+	if !pState.CooldownUntil.IsZero() {
+		s.cooldowns[id] = pState.CooldownUntil
+	}
+}
+
+// saveState persists the current agent states to disk, including crash-loop
+// cooldown and restart timestamps so they survive daemon restarts.
 func (s *Service) saveState() {
 	if s.stateFile == nil {
 		return
 	}
 
 	s.mu.RLock()
-	// Create a map of pointers for Save
-	agents := make(map[string]*AgentState, len(s.states))
-	for id := range s.states {
-		state := s.states[id]
-		agents[id] = &state
+	persisted := make(map[string]PersistedAgentState, len(s.states))
+	for id, state := range s.states {
+		p := PersistedAgentState{
+			ID:             state.ID,
+			Installed:      state.Install == InstallStateInstalled,
+			RuntimeState:   string(state.Runtime),
+			LastTransition: state.UpdatedAt,
+		}
+		if restarts, ok := s.restarts[id]; ok && len(restarts) > 0 {
+			p.Restarts = make([]time.Time, len(restarts))
+			copy(p.Restarts, restarts)
+		}
+		if cooldownUntil, ok := s.cooldowns[id]; ok && !cooldownUntil.IsZero() {
+			p.CooldownUntil = cooldownUntil
+		}
+		persisted[id] = p
 	}
 	s.mu.RUnlock()
 
-	// Save asynchronously to avoid blocking lifecycle operations
-	// In production, you might want to handle errors more carefully
-	_ = s.stateFile.Save(agents)
+	_ = s.stateFile.SavePersisted(persisted)
 }

--- a/daemon/internal/lifecycle/state_file.go
+++ b/daemon/internal/lifecycle/state_file.go
@@ -15,10 +15,12 @@ type StateFile struct {
 
 // PersistedAgentState represents the minimal state needed to restore agent lifecycle.
 type PersistedAgentState struct {
-	ID             string    `json:"id"`
-	Installed      bool      `json:"installed"`
-	RuntimeState   string    `json:"runtime_state"`
-	LastTransition time.Time `json:"last_transition"`
+	ID             string      `json:"id"`
+	Installed      bool        `json:"installed"`
+	RuntimeState   string      `json:"runtime_state"`
+	LastTransition time.Time   `json:"last_transition"`
+	Restarts       []time.Time `json:"restarts,omitempty"`
+	CooldownUntil  time.Time   `json:"cooldown_until,omitempty"`
 }
 
 // NewStateFile creates a StateFile with the given path.
@@ -33,11 +35,6 @@ func NewStateFile(path string) *StateFile {
 // Save writes the agent states to disk atomically.
 // It writes to a temporary file first, then renames to prevent partial writes.
 func (sf *StateFile) Save(agents map[string]*AgentState) error {
-	if sf == nil || sf.path == "" {
-		return nil // no-op if not configured
-	}
-
-	// Convert to persisted format
 	persisted := make(map[string]PersistedAgentState, len(agents))
 	for id, state := range agents {
 		if state == nil {
@@ -49,6 +46,14 @@ func (sf *StateFile) Save(agents map[string]*AgentState) error {
 			RuntimeState:   string(state.Runtime),
 			LastTransition: state.UpdatedAt,
 		}
+	}
+	return sf.SavePersisted(persisted)
+}
+
+// SavePersisted writes pre-built persisted state to disk atomically.
+func (sf *StateFile) SavePersisted(persisted map[string]PersistedAgentState) error {
+	if sf == nil || sf.path == "" {
+		return nil // no-op if not configured
 	}
 
 	// Marshal to JSON

--- a/daemon/internal/lifecycle/state_persistence_test.go
+++ b/daemon/internal/lifecycle/state_persistence_test.go
@@ -157,6 +157,87 @@ func TestStatePersistence_Crash(t *testing.T) {
 	}
 }
 
+// TestStatePersistence_CrashLoopCooldownSurvivesRestart verifies that crash-loop
+// cooldown state is persisted and restored after a simulated daemon restart.
+func TestStatePersistence_CrashLoopCooldownSurvivesRestart(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	checker := &fakeChecker{}
+	clock := &fakeClock{current: time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)}
+
+	svc := NewService(nil,
+		WithRunner(&fakeRunner{}),
+		WithRuntimeChecker(checker),
+		WithDiagnoseDir(t.TempDir()),
+		WithNow(clock.Now),
+		WithStateFile(statePath),
+		WithCrashLoopConfig(3, 5*time.Minute, 5*time.Minute),
+	)
+
+	m := sampleManifest()
+	if err := svc.RegisterManifest(m); err != nil {
+		t.Fatalf("register manifest: %v", err)
+	}
+	if err := svc.Install(context.Background(), "openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Trigger crash-loop: 3 failures within window
+	for i := 0; i < 3; i++ {
+		clock.Advance(10 * time.Second)
+		svc.updateStateOnStartError("openclaw", errMockFailure)
+	}
+	// Persist state including crash-loop cooldown
+	svc.saveState()
+
+	// Verify cooldown is active in original service
+	svc.mu.RLock()
+	_, hasCooldown := svc.cooldowns["openclaw"]
+	svc.mu.RUnlock()
+	if !hasCooldown {
+		t.Fatal("expected cooldown to be active after crash-loop")
+	}
+
+	// Simulate daemon restart: create a new Service with the same state file.
+	svc2 := NewService(nil,
+		WithRunner(&fakeRunner{}),
+		WithRuntimeChecker(checker),
+		WithDiagnoseDir(t.TempDir()),
+		WithNow(clock.Now),
+		WithStateFile(statePath),
+		WithCrashLoopConfig(3, 5*time.Minute, 5*time.Minute),
+	)
+	if err := svc2.RegisterManifest(m); err != nil {
+		t.Fatalf("register manifest on restart: %v", err)
+	}
+
+	// Cooldown should still be enforced after daemon restart
+	_, stateCheck, err := svc2.getManifestAndState("openclaw")
+	if err != nil {
+		t.Fatalf("getManifestAndState: %v", err)
+	}
+	if err := svc2.blockIfCrashLoopCoolingDown("openclaw", stateCheck); err == nil {
+		t.Error("expected crash-loop cooldown to be enforced after daemon restart, but start was allowed")
+	}
+
+	// Verify restart timestamps were also restored
+	svc2.mu.RLock()
+	restartCount := len(svc2.restarts["openclaw"])
+	svc2.mu.RUnlock()
+	if restartCount != 3 {
+		t.Errorf("expected 3 restart timestamps after restore, got %d", restartCount)
+	}
+
+	// Advance past cooldown — should be allowed
+	clock.Advance(6 * time.Minute)
+	_, stateCheck, _ = svc2.getManifestAndState("openclaw")
+	if err := svc2.blockIfCrashLoopCoolingDown("openclaw", stateCheck); err != nil {
+		t.Errorf("expected cooldown to expire after waiting, got: %v", err)
+	}
+}
+
 // TestStatePersistence_MultipleAgents verifies state is persisted for multiple agents.
 func TestStatePersistence_MultipleAgents(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")


### PR DESCRIPTION
Fixes #757 — crash-loop cooldown state was not persisted, so a daemon restart cleared cooldown allowing immediate re-crash.

## Changes
- Add `Restarts` and `CooldownUntil` fields to `PersistedAgentState`
- `saveState` now includes crash-loop data via new `SavePersisted` method
- `loadPersistedState` stashes state in `pendingPersisted` (runs before manifests registered)
- `RegisterManifest` applies pending persisted cooldown/restart state instead of resetting
- New `applyPersistedState` helper restores lifecycle + crash-loop state

## Test
`TestStatePersistence_CrashLoopCooldownSurvivesRestart`: triggers crash-loop → persists → simulates restart → verifies cooldown enforced → verifies expiry works