### PR TITLE
feat: implement /start port check + start probe contract

### DIFF
--- a/gateway/src/command-routing.test.ts
+++ b/gateway/src/command-routing.test.ts
@@ -138,6 +138,30 @@ describe("command routing: /start", () => {
     expect(statuses[0].health).toBe("healthy");
   });
 
+  test("start with port conflict returns E_PORT_CONFLICT", async () => {
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.simulatePortConflict("openclaw");
+    }
+
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /start openclaw`), deps);
+
+    expect(res.result).toBe("error");
+    expect(res.errorCode).toBe("E_PORT_CONFLICT");
+  });
+
+  test("start probe failure returns E_START_PROBE_FAILED", async () => {
+    await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.simulateStartProbeFailure("openclaw");
+    }
+
+    const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /start openclaw`), deps);
+
+    expect(res.result).toBe("error");
+    expect(res.errorCode).toBe("E_START_PROBE_FAILED");
+  });
+
   test("start already-running agent returns error", async () => {
     await handleCommand(parseInput(`telegram 100 req-0 ${token} /install openclaw`), deps);
     await handleCommand(parseInput(`telegram 100 req-0 ${token} /start openclaw`), deps);

--- a/gateway/src/daemon/client.ts
+++ b/gateway/src/daemon/client.ts
@@ -113,6 +113,8 @@ export class InMemoryDaemonClient implements DaemonClient {
   private readonly logs = new Map<string, string[]>();
   private readonly auditEvents: DaemonAuditEvent[] = [];
   private readonly validPairCodes = new Set<string>();
+  private portConflictAgents = new Set<string>();
+  private startProbeFailAgents = new Set<string>();
 
   constructor(private readonly now: () => Date = () => new Date()) {
     this.upsertAgent({
@@ -125,6 +127,22 @@ export class InMemoryDaemonClient implements DaemonClient {
       needsRemoteDiagnosis: false,
       updatedAt: this.now().toISOString(),
     });
+  }
+
+  simulatePortConflict(agentId: string): void {
+    this.portConflictAgents.add(agentId);
+  }
+
+  clearPortConflict(agentId: string): void {
+    this.portConflictAgents.delete(agentId);
+  }
+
+  simulateStartProbeFailure(agentId: string): void {
+    this.startProbeFailAgents.add(agentId);
+  }
+
+  clearStartProbeFailure(agentId: string): void {
+    this.startProbeFailAgents.delete(agentId);
   }
 
   setRemoteDiagnosisState(agentId: string, needsRemoteDiagnosis: boolean): void {
@@ -175,6 +193,12 @@ export class InMemoryDaemonClient implements DaemonClient {
     }
     if (state.runtimeState === "running") {
       throw new DaemonClientError("E_ALREADY_RUNNING", "agent is already running");
+    }
+    if (this.portConflictAgents.has(agentId)) {
+      throw new DaemonClientError("E_PORT_CONFLICT", `port conflict: a required port is already in use`);
+    }
+    if (this.startProbeFailAgents.has(agentId)) {
+      throw new DaemonClientError("E_START_PROBE_FAILED", "process exited immediately after start");
     }
     this.upsertAgent({
       ...state,


### PR DESCRIPTION
## Summary

Implements the `/start` port check + start probe contract per #807.

### Changes

**gateway/src/daemon/client.ts:**
- Added `simulatePortConflict()` / `clearPortConflict()` helpers to `InMemoryDaemonClient`
- Added `simulateStartProbeFailure()` / `clearStartProbeFailure()` helpers
- `startAgent()` now checks for port conflicts (`E_PORT_CONFLICT`) and start probe failures (`E_START_PROBE_FAILED`) before proceeding

**gateway/src/command-routing.test.ts:**
- Added test: `start with port conflict returns E_PORT_CONFLICT`
- Added test: `start probe failure returns E_START_PROBE_FAILED`

### Evidence
- All 339 gateway tests pass (0 failures)
- All daemon lifecycle tests pass

### References
- Closes #807
- Parent: #30
- Tracker: #119