### PR TITLE
feat: implement /logs merged tail output + bounded tail parameter

### DIFF
--- a/daemon/internal/api/server.go
+++ b/daemon/internal/api/server.go
@@ -48,6 +48,7 @@ func (s *Server) Handler() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agents", s.handleListAgents)
 	mux.HandleFunc("/api/v1/agents/", s.handleAgentAction)
+	mux.HandleFunc("/api/v1/logs", s.handleMergedLogs)
 	mux.HandleFunc("/api/v1/pairing/codes", s.handleIssuePairCode)
 	mux.HandleFunc("/api/v1/pairing/verify-consume", s.handleVerifyConsumePairCode)
 	mux.HandleFunc("/api/v1/diagnosis/handoffs", s.handleCreateDiagnosisHandoff)
@@ -101,6 +102,29 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 		resp.Agents = append(resp.Agents, s.agentFromState(state))
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleMergedLogs(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodGet) {
+		return
+	}
+	if r.URL.Path != "/api/v1/logs" {
+		http.NotFound(w, r)
+		return
+	}
+
+	tail := 200
+	if raw := strings.TrimSpace(r.URL.Query().Get("tail")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			tail = parsed
+		}
+	}
+	lines := s.lifecycle.MergedLogs(tail)
+	redactedLines := make([]string, len(lines))
+	for i, line := range lines {
+		redactedLines[i] = redact.RedactText(line)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"lines": redactedLines, "truncated": false})
 }
 
 func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -363,12 +363,47 @@ func (s *Service) Logs(agentID string, tail int) ([]string, error) {
 	if !ok {
 		return nil, ErrAgentNotFound
 	}
+	tail = boundTail(tail)
 	if tail <= 0 || tail >= len(logs) {
 		return append([]string(nil), logs...), nil
 	}
 
 	start := len(logs) - tail
 	return append([]string(nil), logs[start:]...), nil
+}
+
+// MergedLogs returns the last `tail` log lines merged from all agents, sorted
+// lexicographically (which equals chronological order for ISO-8601 prefixed
+// lines produced by the process logger).
+func (s *Service) MergedLogs(tail int) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tail = boundTail(tail)
+
+	var merged []string
+	for _, lines := range s.logs {
+		merged = append(merged, lines...)
+	}
+	sort.Strings(merged)
+
+	if tail > 0 && tail < len(merged) {
+		merged = merged[len(merged)-tail:]
+	}
+	return merged
+}
+
+// MaxTailLines is the upper bound accepted for the tail parameter.
+const MaxTailLines = 1000
+
+func boundTail(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	if n > MaxTailLines {
+		return MaxTailLines
+	}
+	return n
 }
 
 func (s *Service) HandleFailure(ctx context.Context, agentID, lastError string) (baseagent.TriageResult, error) {

--- a/gateway/src/command-routing.test.ts
+++ b/gateway/src/command-routing.test.ts
@@ -208,11 +208,11 @@ describe("command routing: /logs", () => {
     token = pairChat(deps);
   });
 
-  test("missing agent returns usage error", async () => {
+  test("missing agent returns merged logs", async () => {
     const res = await handleCommand(parseInput(`telegram 100 req-1 ${token} /logs`), deps);
 
-    expect(res.result).toBe("error");
-    expect(res.errorCode).toBe("E_USAGE");
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("all agents");
   });
 
   test("returns logs for agent", async () => {

--- a/gateway/src/daemon/client.ts
+++ b/gateway/src/daemon/client.ts
@@ -58,6 +58,7 @@ export interface DaemonClient {
   stopAgent(agentId: string, ctx: RequestContext): Promise<void>;
   getStatus(agentId: string | undefined, ctx: RequestContext): Promise<DaemonAgentState[]>;
   getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult>;
+  getMergedLogs(tail: number, ctx: RequestContext): Promise<LogsResult>;
   upgradeAgent(agentId: string, ctx: RequestContext): Promise<UpgradeResult>;
   diagnoseAgent(agentId: string, ctx: RequestContext): Promise<DiagnoseResult>;
   createRemoteDiagnosisHandoff(input: CreateRemoteDiagnosisHandoffInput): Promise<RemoteDiagnosisHandoff>;
@@ -215,11 +216,26 @@ export class InMemoryDaemonClient implements DaemonClient {
   async getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult> {
     this.requireAgent(agentId);
     const entries = this.logs.get(agentId) ?? [];
-    const safeTail = tail > 0 ? tail : 200;
+    const safeTail = boundTail(tail);
     const start = entries.length > safeTail ? entries.length - safeTail : 0;
     this.recordAudit(ctx, "logs", agentId, `tail=${safeTail}`);
     return {
       lines: entries.slice(start),
+      truncated: start > 0,
+    };
+  }
+
+  async getMergedLogs(tail: number, ctx: RequestContext): Promise<LogsResult> {
+    const safeTail = boundTail(tail);
+    const merged: string[] = [];
+    for (const entries of this.logs.values()) {
+      merged.push(...entries);
+    }
+    merged.sort();
+    const start = merged.length > safeTail ? merged.length - safeTail : 0;
+    this.recordAudit(ctx, "logs", "*", `merged tail=${safeTail}`);
+    return {
+      lines: merged.slice(start),
       truncated: start > 0,
     };
   }
@@ -350,6 +366,13 @@ export class InMemoryDaemonClient implements DaemonClient {
       updatedAt: state.updatedAt,
     };
   }
+}
+
+const MAX_TAIL_LINES = 1000;
+
+function boundTail(n: number): number {
+  if (!Number.isFinite(n) || n <= 0) return 200;
+  return Math.min(n, MAX_TAIL_LINES);
 }
 
 function bumpPatchVersion(version: string): string {

--- a/gateway/src/daemon/http_client.ts
+++ b/gateway/src/daemon/http_client.ts
@@ -78,10 +78,20 @@ export class HttpDaemonClient implements DaemonClient {
   }
 
   async getLogs(agentId: string, tail: number, ctx: RequestContext): Promise<LogsResult> {
-    const safeTail = Number.isFinite(tail) && tail > 0 ? Math.floor(tail) : 200;
+    const safeTail = Number.isFinite(tail) && tail > 0 ? Math.min(Math.floor(tail), 1000) : 200;
     return await this.requestJSON<LogsResult>(
       "GET",
       `/api/v1/agents/${encodeURIComponent(agentId)}/logs?tail=${safeTail}`,
+      undefined,
+      ctx,
+    );
+  }
+
+  async getMergedLogs(tail: number, ctx: RequestContext): Promise<LogsResult> {
+    const safeTail = Number.isFinite(tail) && tail > 0 ? Math.min(Math.floor(tail), 1000) : 200;
+    return await this.requestJSON<LogsResult>(
+      "GET",
+      `/api/v1/logs?tail=${safeTail}`,
       undefined,
       ctx,
     );

--- a/gateway/src/e2e.test.ts
+++ b/gateway/src/e2e.test.ts
@@ -210,11 +210,11 @@ describe("E2E slash command test suite", () => {
       expect(result.message).toContain("openclaw");
     });
 
-    test("/logs without agent ID fails", async () => {
+    test("/logs without agent ID returns merged logs", async () => {
       const result = await sendCommand(runtime, `telegram chat1 req-22 ${token} /logs`);
       
-      expect(result.result).toBe("error");
-      expect(result.errorCode).toBe("E_USAGE");
+      expect(result.result).toBe("ok");
+      expect(result.message).toContain("all agents");
     });
 
     test("/diagnose openclaw creates artifact", async () => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -224,22 +224,27 @@ export async function handleCommand(
         };
       }
       case "/logs": {
-        const [agentId, tailRaw] = cmd.args;
-        if (!agentId) {
-          return usageError(cmd.requestId, "/logs <agent_id> [tail]");
-        }
+        const [firstArg, secondArg] = cmd.args;
+        // When no args or first arg looks like a number → merged logs
+        const isMerged = !firstArg || /^\d+$/.test(firstArg);
+        const agentId = isMerged ? undefined : firstArg;
+        const tailRaw = isMerged ? (firstArg || undefined) : secondArg;
         const tail = parsePositiveInt(tailRaw, 200);
-        const logs = await deps.daemon.getLogs(agentId, tail, ctx);
+        const logs = agentId
+          ? await deps.daemon.getLogs(agentId, tail, ctx)
+          : await deps.daemon.getMergedLogs(tail, ctx);
+        const label = agentId ?? "all agents";
         const message = logs.lines.length === 0
-          ? `no logs for ${agentId}`
-          : `returned ${logs.lines.length} log lines for ${agentId}`;
+          ? `no logs for ${label}`
+          : `returned ${logs.lines.length} log lines for ${label}`;
         const response: GatewayResponse = {
           requestId: cmd.requestId,
           result: "ok",
           message,
         };
         if (logs.truncated || logs.lines.length > 50) {
-          const logFilePath = `/tmp/${agentId}-logs-${cmd.requestId}.txt`;
+          const fileLabel = agentId ?? "merged";
+          const logFilePath = `/tmp/${fileLabel}-logs-${cmd.requestId}.txt`;
           const logContent = logs.lines.join("\n");
           await Bun.write(logFilePath, logContent);
           const token = deps.downloads.issue(logFilePath, 300, true, {

--- a/gateway/src/integration.test.ts
+++ b/gateway/src/integration.test.ts
@@ -175,7 +175,7 @@ describe("E2E: error propagation", () => {
     const deps = buildDeps();
     const token = pair(deps);
 
-    const commands = ["/install", "/start", "/stop", "/logs", "/upgrade", "/diagnose"];
+    const commands = ["/install", "/start", "/stop", "/upgrade", "/diagnose"];
     for (const cmd of commands) {
       const res = await safeHandleCommand(`telegram 100 req-1 ${token} ${cmd}`, deps);
       expect(res.result).toBe("error");


### PR DESCRIPTION
## Summary

Implements merged tail output and bounded tail parameter behavior for the `/logs` command.

### Changes

**Daemon (Go):**
- Added `MergedLogs(tail int)` method to lifecycle service — merges logs from all agents, sorts chronologically, returns last N lines
- Added `/api/v1/logs?tail=N` HTTP endpoint for merged logs
- Added `MaxTailLines = 1000` constant and `boundTail()` helper to cap the tail parameter

**Gateway (TypeScript):**
- Added `getMergedLogs(tail, ctx)` to `DaemonClient` interface + both implementations (InMemory, HTTP)
- Updated `/logs` command: omitting `agentId` now returns merged logs from all agents
- Passing only a number (e.g. `/logs 50`) is treated as tail for merged mode
- Tail parameter bounded to max 1000 in both daemon and gateway layers

**Tests:**
- Updated 3 tests that expected `/logs` without agentId to fail — now succeeds with merged output
- All 337 gateway tests pass

Closes #809