### PR TITLE
docs: resolve ADR ownership ambiguity after #1040

### DIFF
--- a/docs/phase1-runtime-adr.md
+++ b/docs/phase1-runtime-adr.md
@@ -76,10 +76,16 @@ Accepted tradeoffs:
 3. **Risk**: Conflicting wording across docs
    - **Mitigation**: treat PRD as source of truth and keep docs aligned through micro tasks under #75.
 
+## Canonical Source Note
+
+This file (`docs/phase1-runtime-adr.md`) is the canonical runtime ADR for Phase 1.
+
+`docs/plans/adr-runtime-model.md` is retained as historical context and is superseded for decision authority.
+
 ## References
 
 - PRD source-of-truth scope: `docs/Agent_Installation_Platform_PRD.md`
 - Product design runtime model: `docs/Agent_Installation_Platform_Product_Design.md`
-- Existing ADR draft: `docs/plans/adr-runtime-model.md`
+- Historical (superseded) ADR context: `docs/plans/adr-runtime-model.md`
 - Parent plan: issue #74
 - Micro task: issue #796

--- a/docs/plans/adr-runtime-model.md
+++ b/docs/plans/adr-runtime-model.md
@@ -1,8 +1,11 @@
 # ADR: Phase 1 Runtime Model — Local-First, No Docker
 
+> Superseded for authority by `docs/phase1-runtime-adr.md`.
+> This file is kept as historical context from earlier planning drafts.
+
 ## Status
 
-**Accepted**
+**Superseded (historical)**
 
 ## Context
 


### PR DESCRIPTION
## Summary
- clarify that `docs/phase1-runtime-adr.md` is the canonical Phase-1 runtime ADR
- mark `docs/plans/adr-runtime-model.md` as superseded historical context
- update wording to avoid split authority/drift

## Why
Follow-up to review feedback on #1040 about duplicate ADR ownership ambiguity.

## Scope
- docs-only
- no runtime/API behavior changes
