### PR TITLE
security(gateway): require API token for /command on exposed hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Optional local flow from repo root:
   - `GET /healthz`
 - Command ingress route:
   - `POST /command` with JSON body `{ "input": "<provider> <chat_id> <request_id> <command> [...args]" }`
+  - If `CARRIER_GATEWAY_API_TOKEN` is set, send `Authorization: Bearer <gateway_api_token>`
 - Artifact download route:
   - `GET /downloads/<token>/<filename>`
 
@@ -146,6 +147,7 @@ Runtime environment variables:
 - `CARRIER_DAEMON_BASE_URL` (default: `http://127.0.0.1:9090`)
 - `CARRIER_GATEWAY_HOST` (default: `127.0.0.1`)
 - `CARRIER_GATEWAY_PORT` (default: `8787`)
+- `CARRIER_GATEWAY_API_TOKEN` (optional on loopback; required for non-loopback bind)
 
 #### Merge Queue
 - This repository supports GitHub Merge Queue for `main`.

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -18,6 +18,10 @@ All commands are parsed from a single string with the format:
 | `command`   | `CommandName`                         | One of the commands listed below   |
 | `args`      | `string[]`                            | Positional arguments (space-split) |
 
+When commands are sent via gateway HTTP (`POST /command`):
+- request body: `{ "input": "<provider> <chat_id> <request_id> <command> [...args]" }`
+- if `CARRIER_GATEWAY_API_TOKEN` is configured, include `Authorization: Bearer <gateway_api_token>`
+
 ## Response Schema
 
 Every command returns a `GatewayResponse`:
@@ -41,6 +45,8 @@ type GatewayResponse = {
 |----------------------------|------------------------------------------------------|
 | `E_PARSE`                  | Input string could not be parsed                     |
 | `E_USAGE`                  | Missing required argument(s)                         |
+| `E_GATEWAY_AUTH_REQUIRED`  | Gateway API token is required for `/command` access  |
+| `E_GATEWAY_AUTH_INVALID`   | Provided gateway API token is invalid                |
 | `E_PAIR_CODE_INVALID`      | Pairing code is invalid or expired                   |
 | `E_SESSION_REQUIRED`       | Chat is not paired; must run `/pair` first           |
 | `E_NOT_INSTALLED`          | Agent is not installed                               |

--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -25,6 +25,24 @@ function makeDeps() {
   };
 }
 
+async function withEnvVar<T>(name: string, value: string | undefined, run: () => Promise<T> | T): Promise<T> {
+  const previous = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
 describe("composeMiddleware", () => {
   test("runs middleware in deterministic order", async () => {
     const trace: string[] = [];
@@ -508,9 +526,124 @@ describe("port resolution fallback behavior", () => {
       delete process.env.CARRIER_GATEWAY_PORT;
     }
   });
+
+  test("rejects non-loopback host when gateway api token is missing", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", undefined, () => {
+      const deps = makeDeps();
+      expect(() => startGatewayServer({
+        deps,
+        hostname: "0.0.0.0",
+        port: 0,
+      })).toThrow("CARRIER_GATEWAY_API_TOKEN is required");
+    });
+  });
+
+  test("allows non-loopback host when gateway api token is configured", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", "gw-test-token", () => {
+      const deps = makeDeps();
+      const server = startGatewayServer({
+        deps,
+        hostname: "0.0.0.0",
+        port: 0,
+      });
+      expect(server.port).toBeGreaterThan(0);
+      server.stop();
+    });
+  });
 });
 
 describe("command authentication", () => {
+  test("requires gateway api token when configured", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", "gw-secret", async () => {
+      const deps = makeDeps();
+      if (deps.daemon instanceof InMemoryDaemonClient) {
+        deps.daemon.registerPairCode("pair-code");
+      }
+      const runtime = createGatewayRuntime({ deps });
+
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: "telegram 100 req-1 /pair pair-code" }),
+      }));
+
+      expect(response.status).toBe(401);
+      const payload = await response.json() as { errorCode?: string };
+      expect(payload.errorCode).toBe("E_GATEWAY_AUTH_REQUIRED");
+    });
+  });
+
+  test("rejects invalid gateway api token when configured", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", "gw-secret", async () => {
+      const deps = makeDeps();
+      if (deps.daemon instanceof InMemoryDaemonClient) {
+        deps.daemon.registerPairCode("pair-code");
+      }
+      const runtime = createGatewayRuntime({ deps });
+
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer wrong-token",
+        },
+        body: JSON.stringify({ input: "telegram 100 req-1 /pair pair-code" }),
+      }));
+
+      expect(response.status).toBe(401);
+      const payload = await response.json() as { errorCode?: string };
+      expect(payload.errorCode).toBe("E_GATEWAY_AUTH_INVALID");
+    });
+  });
+
+  test("accepts valid gateway api token and keeps session auth in body", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", "gw-secret", async () => {
+      const deps = makeDeps();
+      if (deps.daemon instanceof InMemoryDaemonClient) {
+        deps.daemon.registerPairCode("pair-code");
+      }
+      const runtime = createGatewayRuntime({ deps });
+
+      const pairResponse = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer gw-secret",
+        },
+        body: JSON.stringify({ input: "telegram 100 req-1 /pair pair-code" }),
+      }));
+      expect(pairResponse.status).toBe(200);
+      const pairPayload = await pairResponse.json() as { result: string; sessionToken?: string };
+      expect(pairPayload.result).toBe("ok");
+      expect(pairPayload.sessionToken).toBeDefined();
+
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer gw-secret",
+        },
+        body: JSON.stringify({
+          input: "telegram 100 req-2 /agents",
+          sessionToken: pairPayload.sessionToken,
+        }),
+      }));
+
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { result: string };
+      expect(payload.result).toBe("ok");
+    });
+  });
+
+  test("healthz remains unauthenticated even when gateway api token is configured", async () => {
+    await withEnvVar("CARRIER_GATEWAY_API_TOKEN", "gw-secret", async () => {
+      const deps = makeDeps();
+      const runtime = createGatewayRuntime({ deps });
+      const response = await runtime.fetch(new Request("http://gateway.local/healthz"));
+      expect(response.status).toBe(200);
+    });
+  });
+
   test("rejects authenticated commands without session token", async () => {
     const deps = makeDeps();
     const runtime = createGatewayRuntime({ deps });

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -3,6 +3,7 @@ import { HttpDaemonClient } from "./daemon/http_client";
 import { DownloadTokenStore } from "./downloads/token_store";
 import { SessionStore } from "./session/store";
 import { join } from "node:path";
+import { timingSafeEqual } from "node:crypto";
 
 export type GatewayRequestContext = {
   request: Request;
@@ -83,6 +84,11 @@ export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): Gatew
     }
 
     if (ctx.request.method === "POST" && url.pathname === "/command") {
+      const gatewayAuthError = validateGatewayAPIToken(ctx.request, ctx.requestId);
+      if (gatewayAuthError) {
+        return jsonResponse(gatewayAuthError, 401);
+      }
+
       const parsed = await parseCommandRequest(ctx.request);
       if (!parsed.commandInput) {
         return jsonResponse({
@@ -142,6 +148,10 @@ export function startGatewayServer(options: StartGatewayServerOptions = {}): Ret
   });
   const port = options.port ?? parsePort(process.env.CARRIER_GATEWAY_PORT, 8787);
   const hostname = options.hostname ?? process.env.CARRIER_GATEWAY_HOST ?? "127.0.0.1";
+  const gatewayApiToken = loadGatewayAPIToken();
+  if (!gatewayApiToken && !isLoopbackHost(hostname)) {
+    throw new Error("CARRIER_GATEWAY_API_TOKEN is required when binding gateway to non-loopback host");
+  }
   return Bun.serve({
     port,
     hostname,
@@ -328,17 +338,26 @@ type ParsedCommandRequest = {
 };
 
 async function parseCommandRequest(request: Request): Promise<ParsedCommandRequest> {
+  const allowAuthorizationSessionToken = !loadGatewayAPIToken();
   const result: ParsedCommandRequest = {
     commandInput: null,
     sessionToken: null,
   };
-  
-  // Check Authorization header for session token
-  const authHeader = request.headers.get("authorization");
-  if (authHeader) {
-    const match = authHeader.match(/^Bearer\s+(.+)$/i);
-    if (match && match[1]) {
-      result.sessionToken = match[1].trim();
+
+  // Prefer an explicit session token header when present.
+  const sessionHeader = request.headers.get("x-session-token");
+  if (sessionHeader && sessionHeader.trim().length > 0) {
+    result.sessionToken = sessionHeader.trim();
+  }
+
+  // Backward-compatible session token transport: Authorization header.
+  if (!result.sessionToken && allowAuthorizationSessionToken) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader) {
+      const match = authHeader.match(/^Bearer\s+(.+)$/i);
+      if (match && match[1]) {
+        result.sessionToken = match[1].trim();
+      }
     }
   }
   
@@ -448,6 +467,58 @@ function validateCommandAuth(
   
   // Authentication successful
   return null;
+}
+
+function loadGatewayAPIToken(): string | null {
+  const token = process.env.CARRIER_GATEWAY_API_TOKEN?.trim() ?? "";
+  return token.length > 0 ? token : null;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "::1" || normalized === "localhost";
+}
+
+function validateGatewayAPIToken(
+  request: Request,
+  requestId: string,
+): { requestId: string; result: "error"; errorCode: string; message: string } | null {
+  const expectedToken = loadGatewayAPIToken();
+  if (!expectedToken) {
+    return null;
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const providedToken = match?.[1]?.trim();
+  if (!providedToken) {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_GATEWAY_AUTH_REQUIRED",
+      message: "gateway api token required",
+    };
+  }
+
+  if (!constantTimeTokenEquals(providedToken, expectedToken)) {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_GATEWAY_AUTH_INVALID",
+      message: "invalid gateway api token",
+    };
+  }
+
+  return null;
+}
+
+function constantTimeTokenEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(leftBuffer, rightBuffer);
 }
 
 export function parsePort(raw: string | undefined, fallback: number): number {


### PR DESCRIPTION
## Summary
- add gateway-level bearer auth enforcement for `POST /command` when `CARRIER_GATEWAY_API_TOKEN` is set
- compare provided/expected gateway tokens with constant-time `timingSafeEqual`
- keep `/healthz` unauthenticated
- require `CARRIER_GATEWAY_API_TOKEN` when binding the gateway to non-loopback hosts
- preserve existing session-token command auth and keep backward compatibility for Authorization-based session token usage when gateway API token is not configured
- document new auth behavior and error codes in README and command contract docs

## Why
Issue #631 reports that `/command` lacks an independent gateway API auth layer and allows non-loopback exposure without token protection.

## Test Commands and Evidence
- `cd gateway && bun run check`
- `cd gateway && bun test src/server.test.ts --test-name-pattern "command authentication|port resolution fallback behavior"`
  - Evidence: `24 pass, 0 fail` for targeted auth/binding coverage, including new tests for:
    - `E_GATEWAY_AUTH_REQUIRED`
    - `E_GATEWAY_AUTH_INVALID`
    - non-loopback bind guard with/without token

Closes #631
