### PR TITLE
security(daemon): hash-before-compare for bearer auth

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -674,8 +675,10 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			auth := r.Header.Get("Authorization")
 			expected := "Bearer " + token
-			// Use constant-time comparison to prevent timing attacks
-			if subtle.ConstantTimeCompare([]byte(auth), []byte(expected)) != 1 {
+			// Compare fixed-length digests to avoid early length-based differences.
+			authDigest := sha256.Sum256([]byte(auth))
+			expectedDigest := sha256.Sum256([]byte(expected))
+			if subtle.ConstantTimeCompare(authDigest[:], expectedDigest[:]) != 1 {
 				writeJSONError(w, http.StatusUnauthorized, "unauthorized")
 				return
 			}

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -569,6 +569,7 @@ func TestBearerAuthMiddlewareBoundaryCases(t *testing.T) {
 		{name: "api missing auth", path: "/api/v1/agents", auth: "", want: http.StatusUnauthorized},
 		{name: "api wrong scheme", path: "/api/v1/agents", auth: "Token secret-token", want: http.StatusUnauthorized},
 		{name: "api near miss token", path: "/api/v1/agents", auth: "Bearer secret-token ", want: http.StatusUnauthorized},
+		{name: "api length mismatch token", path: "/api/v1/agents", auth: "Bearer secret-token-x", want: http.StatusUnauthorized},
 		{name: "api correct token", path: "/api/v1/agents", auth: "Bearer secret-token", want: http.StatusOK},
 		{name: "healthz exempt", path: "/healthz", auth: "", want: http.StatusOK},
 	}


### PR DESCRIPTION
## Summary
- harden daemon bearer auth comparison by hashing both `Authorization` and expected bearer token before `subtle.ConstantTimeCompare`
- keep `/healthz` and `/readyz` exemption behavior unchanged
- extend middleware boundary tests with explicit length-mismatch token case

## Why
Issue #587 calls out timing-side-channel risk around token comparisons. This keeps constant-time verification while avoiding early length-based comparison differences on raw strings.

## Test Commands and Evidence
- `cd daemon && CGO_ENABLED=0 go test ./cmd/agentd -run TestBearerAuthMiddlewareBoundaryCases`
  - Evidence: `ok   carrier/daemon/cmd/agentd`
- `cd daemon && CGO_ENABLED=0 go test ./cmd/agentd`
  - Evidence: `ok   carrier/daemon/cmd/agentd`

## Notes
- Local default `go test` (without `CGO_ENABLED=0`) hits a macOS linker/runtime `LC_UUID` issue in this environment; test suite passes with `CGO_ENABLED=0`.

Closes #587
