### PR TITLE
test(gateway): add failure-parity drift assertions

### DIFF
--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -188,3 +188,15 @@ Telegram adapter rendering should preserve response semantics while formatting f
 - Success messages are prefixed with `✅`.
 - Error messages are prefixed with `❌ <errorCode>:`.
 - Optional fields (`sessionToken`, `downloadUrl`, `handoffId`) are appended as additional lines.
+
+## Failure Parity Drift Reporting
+
+Failure parity checks are implemented in `gateway/src/parity/failure_parity.ts`.
+
+- `assertFailureParity` validates that all provider responses for a failure scenario:
+  - return `result: "error"`
+  - share the same `errorCode`
+  - share the same `message`
+- Drift output includes provider + field-level expected/actual values for fast diagnosis.
+
+These checks are exercised by `gateway/src/cross-provider.test.ts` and `gateway/src/parity/failure_parity.test.ts`.

--- a/gateway/src/cross-provider.test.ts
+++ b/gateway/src/cross-provider.test.ts
@@ -4,6 +4,7 @@ import type { Provider, GatewayResponse } from "./contracts/commands";
 import { InMemoryDaemonClient } from "./daemon/client";
 import { SessionStore } from "./session/store";
 import { DownloadTokenStore } from "./downloads/token_store";
+import { assertFailureParity, type ProviderFailureResponse } from "./parity/failure_parity";
 
 /**
  * Cross-provider consistency tests.
@@ -46,19 +47,23 @@ async function runAcrossProviders(
   tokens: Map<Provider, string>,
   commandSuffix: string,
   chatId = "100",
-): Promise<GatewayResponse[]> {
-  const results: GatewayResponse[] = [];
+): Promise<ProviderFailureResponse[]> {
+  const results: ProviderFailureResponse[] = [];
   for (const provider of PROVIDERS) {
     const token = tokens.get(provider) || "";
     const input = `${provider} ${chatId} req-${provider} ${token} ${commandSuffix}`;
     const res = await handleCommand(parseInput(input), deps);
-    results.push(res);
+    results.push({ provider, response: res });
   }
   return results;
 }
 
-function assertAllConsistent(results: GatewayResponse[]): void {
-  const normalized = results.map(normalize);
+function responses(results: ProviderFailureResponse[]): GatewayResponse[] {
+  return results.map((entry) => entry.response);
+}
+
+function assertAllConsistent(results: ProviderFailureResponse[]): void {
+  const normalized = responses(results).map(normalize);
   for (let i = 1; i < normalized.length; i++) {
     expect(normalized[i]).toEqual(normalized[0]);
   }
@@ -76,7 +81,7 @@ describe("cross-provider consistency", () => {
   test("/agents returns same result across all providers", async () => {
     const results = await runAcrossProviders(deps, tokens, "/agents");
     assertAllConsistent(results);
-    expect(results[0].result).toBe("ok");
+    expect(results[0].response.result).toBe("ok");
   });
 
   test("/install returns same result across all providers", async () => {
@@ -87,14 +92,16 @@ describe("cross-provider consistency", () => {
   test("/start error is consistent across all providers", async () => {
     // Without installing first, all providers should get the same error
     const results = await runAcrossProviders(deps, tokens, "/start myagent");
+    assertFailureParity(results);
     assertAllConsistent(results);
-    expect(results[0].result).toBe("error");
+    expect(results[0].response.result).toBe("error");
   });
 
   test("/stop error is consistent across all providers", async () => {
     const results = await runAcrossProviders(deps, tokens, "/stop myagent");
+    assertFailureParity(results);
     assertAllConsistent(results);
-    expect(results[0].result).toBe("error");
+    expect(results[0].response.result).toBe("error");
   });
 
   test("/status returns same result across all providers", async () => {
@@ -119,52 +126,55 @@ describe("cross-provider consistency", () => {
 
   test("usage errors are identical across providers", async () => {
     const results = await runAcrossProviders(deps, tokens, "/install");
+    assertFailureParity(results);
     assertAllConsistent(results);
-    expect(results[0].result).toBe("error");
-    expect(results[0].errorCode).toBe("E_USAGE");
+    expect(results[0].response.result).toBe("error");
+    expect(results[0].response.errorCode).toBe("E_USAGE");
   });
 
   test("session-required errors are identical across providers (unpaired)", async () => {
     const freshDeps = buildDeps();
-    const results: GatewayResponse[] = [];
+    const results: ProviderFailureResponse[] = [];
     for (const provider of PROVIDERS) {
       const input = `${provider} 999 req-${provider} /agents`;
       const res = await handleCommand(parseInput(input), freshDeps);
-      results.push(res);
+      results.push({ provider, response: res });
     }
+    assertFailureParity(results);
     assertAllConsistent(results);
-    expect(results[0].errorCode).toBe("E_SESSION_REQUIRED");
+    expect(results[0].response.errorCode).toBe("E_SESSION_REQUIRED");
   });
 
   test("/pair success is consistent across providers", async () => {
     const freshDeps = buildDeps();
-    const results: GatewayResponse[] = [];
+    const results: ProviderFailureResponse[] = [];
     for (const provider of PROVIDERS) {
       if (freshDeps.daemon instanceof InMemoryDaemonClient) {
         freshDeps.daemon.registerPairCode(`p-${provider}`);
       }
       const input = `${provider} 200 req-${provider} /pair p-${provider}`;
       const res = await handleCommand(parseInput(input), freshDeps);
-      results.push(res);
+      results.push({ provider, response: res });
     }
     // All should succeed with session tokens
-    for (const r of results) {
+    for (const r of responses(results)) {
       expect(r.result).toBe("ok");
       expect(r.sessionToken).toBeDefined();
     }
     // result field and errorCode should be the same
-    expect(results.map((r) => r.result)).toEqual(["ok", "ok", "ok"]);
+    expect(responses(results).map((r) => r.result)).toEqual(["ok", "ok", "ok"]);
   });
 
   test("/pair invalid code is consistent across providers", async () => {
     const freshDeps = buildDeps();
-    const results: GatewayResponse[] = [];
+    const results: ProviderFailureResponse[] = [];
     for (const provider of PROVIDERS) {
       const input = `${provider} 200 req-${provider} /pair bad-code`;
       const res = await handleCommand(parseInput(input), freshDeps);
-      results.push(res);
+      results.push({ provider, response: res });
     }
+    assertFailureParity(results);
     assertAllConsistent(results);
-    expect(results[0].errorCode).toBe("E_PAIR_CODE_INVALID");
+    expect(results[0].response.errorCode).toBe("E_PAIR_CODE_INVALID");
   });
 });

--- a/gateway/src/parity/failure_parity.test.ts
+++ b/gateway/src/parity/failure_parity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { assertFailureParity, collectFailureParityDrifts, formatFailureParityDrifts, type ProviderFailureResponse } from "./failure_parity";
+
+function err(provider: ProviderFailureResponse["provider"], errorCode: string, message: string): ProviderFailureResponse {
+  return {
+    provider,
+    response: {
+      requestId: `req-${provider}`,
+      result: "error",
+      errorCode,
+      message,
+    },
+  };
+}
+
+describe("failure parity checks", () => {
+  test("returns no drift when providers share identical failure response", () => {
+    const responses = [
+      err("telegram", "E_NOT_INSTALLED", "agent is not installed"),
+      err("discord", "E_NOT_INSTALLED", "agent is not installed"),
+      err("feishu", "E_NOT_INSTALLED", "agent is not installed"),
+    ] as const;
+
+    expect(collectFailureParityDrifts(responses)).toEqual([]);
+    expect(() => assertFailureParity(responses)).not.toThrow();
+  });
+
+  test("reports response-shape drift by provider and field", () => {
+    const responses = [
+      err("telegram", "E_NOT_INSTALLED", "agent is not installed"),
+      err("discord", "E_ALREADY_RUNNING", "agent already running"),
+      {
+        provider: "feishu" as const,
+        response: {
+          requestId: "req-feishu",
+          result: "ok" as const,
+          message: "unexpected success",
+        },
+      },
+    ];
+
+    const drifts = collectFailureParityDrifts(responses);
+    expect(drifts).toEqual([
+      { provider: "feishu", field: "result", expected: "error", actual: "ok" },
+      { provider: "discord", field: "errorCode", expected: "E_NOT_INSTALLED", actual: "E_ALREADY_RUNNING" },
+      { provider: "discord", field: "message", expected: "agent is not installed", actual: "agent already running" },
+    ]);
+
+    const message = formatFailureParityDrifts(responses, drifts);
+    expect(message).toContain("baseline=telegram");
+    expect(message).toContain("provider=discord field=errorCode");
+    expect(message).toContain("provider=feishu field=result");
+    expect(() => assertFailureParity(responses)).toThrow("failure parity drift detected");
+  });
+});

--- a/gateway/src/parity/failure_parity.ts
+++ b/gateway/src/parity/failure_parity.ts
@@ -1,0 +1,93 @@
+import type { Provider, GatewayResponse } from "../contracts/commands";
+
+export type ProviderFailureResponse = {
+  provider: Provider;
+  response: GatewayResponse;
+};
+
+export type FailureParityDrift = {
+  provider: Provider;
+  field: "result" | "errorCode" | "message";
+  expected: string;
+  actual: string;
+};
+
+export function collectFailureParityDrifts(
+  responses: readonly ProviderFailureResponse[],
+): FailureParityDrift[] {
+  if (responses.length === 0) {
+    return [];
+  }
+
+  const drifts: FailureParityDrift[] = [];
+  const baseline = responses[0];
+  const baselineCode = baseline.response.errorCode ?? "";
+  const baselineMessage = baseline.response.message;
+
+  for (const entry of responses) {
+    if (entry.response.result !== "error") {
+      drifts.push({
+        provider: entry.provider,
+        field: "result",
+        expected: "error",
+        actual: entry.response.result,
+      });
+    }
+  }
+
+  if (baseline.response.result !== "error") {
+    return drifts;
+  }
+
+  for (const entry of responses.slice(1)) {
+    if (entry.response.result !== "error") {
+      continue;
+    }
+    const code = entry.response.errorCode ?? "";
+    if (code !== baselineCode) {
+      drifts.push({
+        provider: entry.provider,
+        field: "errorCode",
+        expected: baselineCode,
+        actual: code,
+      });
+    }
+    if (entry.response.message !== baselineMessage) {
+      drifts.push({
+        provider: entry.provider,
+        field: "message",
+        expected: baselineMessage,
+        actual: entry.response.message,
+      });
+    }
+  }
+
+  return drifts;
+}
+
+export function formatFailureParityDrifts(
+  responses: readonly ProviderFailureResponse[],
+  drifts: readonly FailureParityDrift[],
+): string {
+  if (responses.length === 0) {
+    return "no provider responses to compare";
+  }
+
+  const baseline = responses[0];
+  const lines = [
+    `failure parity drift detected (baseline=${baseline.provider})`,
+    ...drifts.map((drift) =>
+      `provider=${drift.provider} field=${drift.field} expected=${JSON.stringify(drift.expected)} actual=${JSON.stringify(drift.actual)}`),
+  ];
+  return lines.join("\n");
+}
+
+export function assertFailureParity(
+  responses: readonly ProviderFailureResponse[],
+): void {
+  const drifts = collectFailureParityDrifts(responses);
+  if (drifts.length === 0) {
+    return;
+  }
+  throw new Error(formatFailureParityDrifts(responses, drifts));
+}


### PR DESCRIPTION
## Summary
- add a dedicated failure parity assertion module at `gateway/src/parity/failure_parity.ts`
- include provider+field expected/actual drift diagnostics for failure scenarios
- wire `assertFailureParity` into cross-provider failure-path tests
- add focused parity unit tests in `gateway/src/parity/failure_parity.test.ts`
- document failure parity drift reporting in `docs/command-contract.md`

## Why
Issue #422 requires failure-parity assertions across providers with actionable diff output.

## Test Commands and Evidence
- `cd gateway && bun run check`
- `cd gateway && bun test src/cross-provider.test.ts`
  - Evidence: `12 pass, 0 fail`
- `cd gateway && bun test src/parity/failure_parity.test.ts`
  - Evidence: `2 pass, 0 fail`

Closes #422


Closes #318
