### PR TITLE
docs: add runtime source-of-truth link and PR runtime-impact checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ For this repository we use Merge Queue:
 - Open the queue from the GitHub PR page after CI is green.
 - Do not use direct push-to-main flows except via merge queue/release process.
 
+### PR checklist (required)
+
+Before requesting review, include this checklist in your PR body:
+
+- [ ] Scope is mapped to issue/phase labels.
+- [ ] Validation evidence is included (tests/checks/docs as applicable).
+- [ ] **Runtime-model impact is explicitly stated**:
+  - `none` (no runtime model change), or
+  - `yes` (describe what changed and why it is consistent with `docs/phase1-runtime-adr.md`).
+
 ## Scope Policy
 
 Phase milestones define delivery scope and must be respected in all planning and review.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Phase 1 scaffold for the Agent Installation Platform.
 ## Read order (single source of truth)
 For product scope/priority decisions, use this order:
 1. `docs/Agent_Installation_Platform_PRD.md` (source of truth for scope and requirements)
-2. `docs/Agent_Installation_Platform_Implementation_Plan.md` (execution sequence and delivery plan)
-3. `README.md` (quick orientation and current implementation status)
+2. `docs/phase1-runtime-adr.md` (canonical runtime-model ADR for Phase 1)
+3. `docs/Agent_Installation_Platform_Implementation_Plan.md` (execution sequence and delivery plan)
+4. `README.md` (quick orientation and current implementation status)
 
 
 ## Quick Navigation


### PR DESCRIPTION
## Summary
- update README read-order to include the canonical Phase-1 runtime ADR
- add a required PR checklist section in CONTRIBUTING with explicit runtime-model-impact declaration

## Scope
- docs-only change
- no runtime/API behavior changes

## References
- Refs #797
- Parent: #74
- Tracker: #119
