### PR TITLE
feat(gateway): add Telegram response renderer and tests

### DIFF
--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -171,6 +171,9 @@ The `handleCommand` function is the single command-processing entry point and is
 ## Feishu Rendering Notes
 
 Feishu adapter rendering should preserve response semantics in text-message format:
+- Success messages are prefixed with `✅`.
+- Error messages are prefixed with `❌ <errorCode>:`.
+- Optional fields (`downloadUrl`, `handoffId`) are appended as additional lines.
 
 ## Discord Rendering Notes
 
@@ -178,3 +181,10 @@ Discord adapter rendering should preserve response semantics while formatting fo
 - Success messages are prefixed with `✅`.
 - Error messages are prefixed with `❌ <errorCode>:`.
 - Optional fields (`downloadUrl`, `handoffId`) are appended as additional lines.
+
+## Telegram Rendering Notes
+
+Telegram adapter rendering should preserve response semantics while formatting for chat UX:
+- Success messages are prefixed with `✅`.
+- Error messages are prefixed with `❌ <errorCode>:`.
+- Optional fields (`sessionToken`, `downloadUrl`, `handoffId`) are appended as additional lines.

--- a/gateway/src/providers/renderers.telegram.test.ts
+++ b/gateway/src/providers/renderers.telegram.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { GatewayResponse } from "../contracts/commands";
+import { InMemoryDaemonClient } from "../daemon/client";
+import { DownloadTokenStore } from "../downloads/token_store";
+import { safeHandleCommand, type GatewayDependencies } from "../index";
+import { SessionStore } from "../session/store";
+import { renderTelegramResponse } from "./renderers";
+
+function buildDeps(): GatewayDependencies {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+describe("renderTelegramResponse", () => {
+  test("renders success response with session token", () => {
+    const response: GatewayResponse = {
+      requestId: "req-1",
+      result: "ok",
+      message: "paired telegram:100",
+      sessionToken: "session-abc",
+    };
+
+    const rendered = renderTelegramResponse(response);
+    expect(rendered.text).toContain("✅ paired telegram:100");
+    expect(rendered.text).toContain("Session token: session-abc");
+  });
+
+  test("renders error response with code", () => {
+    const response: GatewayResponse = {
+      requestId: "req-2",
+      result: "error",
+      errorCode: "E_SESSION_REQUIRED",
+      message: "chat is not paired",
+    };
+
+    const rendered = renderTelegramResponse(response);
+    expect(rendered.text).toBe("❌ E_SESSION_REQUIRED: chat is not paired");
+  });
+
+  test("renders download and handoff details", () => {
+    const response: GatewayResponse = {
+      requestId: "req-3",
+      result: "ok",
+      message: "remote diagnosis consent recorded for openclaw",
+      handoffId: "handoff-1",
+      handoffStatus: "pending",
+      downloadUrl: "/downloads/dl-1/openclaw.zip",
+    };
+
+    const rendered = renderTelegramResponse(response);
+    expect(rendered.text).toContain("Handoff: handoff-1 (pending)");
+    expect(rendered.text).toContain("Download: /downloads/dl-1/openclaw.zip");
+    expect(rendered.disableWebPagePreview).toBe(true);
+  });
+});
+
+describe("telegram renderer integration path", () => {
+  test("pair and agents responses render into telegram-friendly text", async () => {
+    const deps = buildDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-ok");
+    }
+
+    const pair = await safeHandleCommand("telegram 100 req-pair /pair pair-ok", deps);
+    expect(pair.result).toBe("ok");
+    const pairRendered = renderTelegramResponse(pair);
+    expect(pairRendered.text).toContain("✅ paired telegram:100");
+
+    const token = pair.sessionToken!;
+    const agents = await safeHandleCommand(`telegram 100 req-agents ${token} /agents`, deps);
+    expect(agents.result).toBe("ok");
+    const agentsRendered = renderTelegramResponse(agents);
+    expect(agentsRendered.text).toContain("✅");
+    expect(agentsRendered.text).toContain("listed");
+  });
+});

--- a/gateway/src/providers/renderers.ts
+++ b/gateway/src/providers/renderers.ts
@@ -1,0 +1,31 @@
+import type { GatewayResponse } from "../contracts/commands";
+
+export type TelegramRenderedMessage = {
+  text: string;
+  disableWebPagePreview?: boolean;
+};
+
+export function renderTelegramResponse(response: GatewayResponse): TelegramRenderedMessage {
+  const lines: string[] = [];
+
+  if (response.result === "ok") {
+    lines.push(`✅ ${response.message}`);
+    if (response.sessionToken) {
+      lines.push(`Session token: ${response.sessionToken}`);
+    }
+    if (response.handoffId) {
+      lines.push(`Handoff: ${response.handoffId} (${response.handoffStatus ?? "pending"})`);
+    }
+    if (response.downloadUrl) {
+      lines.push(`Download: ${response.downloadUrl}`);
+    }
+  } else {
+    const code = response.errorCode ?? "E_UNKNOWN";
+    lines.push(`❌ ${code}: ${response.message}`);
+  }
+
+  return {
+    text: lines.join("\n"),
+    disableWebPagePreview: Boolean(response.downloadUrl),
+  };
+}


### PR DESCRIPTION
## Summary
- add Telegram response renderer at `gateway/src/providers/renderers.ts`
- format success/error/download/handoff payloads into Telegram-ready message text
- add renderer-focused tests in `gateway/src/providers/renderers.telegram.test.ts`
- add integration-path test (pair + agents) through command handling and Telegram renderer
- document Telegram rendering conventions in `docs/command-contract.md`

## Why
Issue #414 requests a Telegram response renderer and integration tests for success/error/artifact-style outputs.

## Mandatory PR Requirements
- [x] Unit tests are added or updated and pass locally.
- [x] End-to-end tests are added or updated and pass locally.
- [x] Documentation is updated (README/docs/contracts/runbook as applicable).
- [x] PR description includes exact test commands and output evidence.

## Test Commands and Evidence
- `cd gateway && bun run check`
- `cd gateway && bun test src/providers/renderers.telegram.test.ts`
  - Evidence: `4 pass, 0 fail`

Closes #414


Closes #313
