### PR TITLE
feat(gateway): add Discord response renderer and tests

### DIFF
--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -171,6 +171,10 @@ The `handleCommand` function is the single command-processing entry point and is
 ## Feishu Rendering Notes
 
 Feishu adapter rendering should preserve response semantics in text-message format:
+
+## Discord Rendering Notes
+
+Discord adapter rendering should preserve response semantics while formatting for chat UX:
 - Success messages are prefixed with `✅`.
 - Error messages are prefixed with `❌ <errorCode>:`.
 - Optional fields (`downloadUrl`, `handoffId`) are appended as additional lines.

--- a/gateway/src/providers/renderers.discord.test.ts
+++ b/gateway/src/providers/renderers.discord.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { GatewayResponse } from "../contracts/commands";
+import { InMemoryDaemonClient } from "../daemon/client";
+import { DownloadTokenStore } from "../downloads/token_store";
+import { safeHandleCommand, type GatewayDependencies } from "../index";
+import { SessionStore } from "../session/store";
+import { renderDiscordResponse } from "./renderers.discord";
+
+function buildDeps(): GatewayDependencies {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+describe("renderDiscordResponse", () => {
+  test("renders success response", () => {
+    const response: GatewayResponse = {
+      requestId: "req-1",
+      result: "ok",
+      message: "install completed for openclaw",
+    };
+    const rendered = renderDiscordResponse(response);
+    expect(rendered.content).toBe("✅ install completed for openclaw");
+  });
+
+  test("renders error response with code", () => {
+    const response: GatewayResponse = {
+      requestId: "req-2",
+      result: "error",
+      errorCode: "E_NOT_INSTALLED",
+      message: "agent is not installed",
+    };
+    const rendered = renderDiscordResponse(response);
+    expect(rendered.content).toBe("❌ E_NOT_INSTALLED: agent is not installed");
+  });
+
+  test("renders download and handoff metadata lines", () => {
+    const response: GatewayResponse = {
+      requestId: "req-3",
+      result: "ok",
+      message: "remote diagnosis consent recorded",
+      handoffId: "handoff-22",
+      handoffStatus: "pending",
+      downloadUrl: "/downloads/dl-22/openclaw.zip",
+    };
+    const rendered = renderDiscordResponse(response);
+    expect(rendered.content).toContain("Download: /downloads/dl-22/openclaw.zip");
+    expect(rendered.content).toContain("Handoff: handoff-22 (pending)");
+  });
+});
+
+describe("discord renderer integration path", () => {
+  test("pair and agents responses render for discord", async () => {
+    const deps = buildDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-ok");
+    }
+
+    const pair = await safeHandleCommand("discord chan-1 req-pair /pair pair-ok", deps);
+    expect(pair.result).toBe("ok");
+
+    const token = pair.sessionToken!;
+    const agents = await safeHandleCommand(`discord chan-1 req-agents ${token} /agents`, deps);
+    expect(agents.result).toBe("ok");
+
+    const rendered = renderDiscordResponse(agents);
+    expect(rendered.content).toContain("✅");
+    expect(rendered.content).toContain("listed");
+  });
+});

--- a/gateway/src/providers/renderers.discord.ts
+++ b/gateway/src/providers/renderers.discord.ts
@@ -1,0 +1,26 @@
+import type { GatewayResponse } from "../contracts/commands";
+
+export type DiscordRenderedMessage = {
+  content: string;
+};
+
+export function renderDiscordResponse(response: GatewayResponse): DiscordRenderedMessage {
+  const lines: string[] = [];
+
+  if (response.result === "ok") {
+    lines.push(`✅ ${response.message}`);
+    if (response.downloadUrl) {
+      lines.push(`Download: ${response.downloadUrl}`);
+    }
+    if (response.handoffId) {
+      lines.push(`Handoff: ${response.handoffId} (${response.handoffStatus ?? "pending"})`);
+    }
+  } else {
+    const code = response.errorCode ?? "E_UNKNOWN";
+    lines.push(`❌ ${code}: ${response.message}`);
+  }
+
+  return {
+    content: lines.join("\n"),
+  };
+}


### PR DESCRIPTION
## Summary
- add Discord response renderer at `gateway/src/providers/renderers.discord.ts`
- format success/error/download/handoff payloads into Discord-ready message content
- add renderer tests in `gateway/src/providers/renderers.discord.test.ts`
- add integration-path test (pair + agents) through command handling and Discord renderer
- document Discord rendering conventions in `docs/command-contract.md`

## Why
Issue #417 requests Discord response rendering and integration tests for command and failure output parity.

## Mandatory PR Requirements
- [x] Unit tests are added or updated and pass locally.
- [x] End-to-end tests are added or updated and pass locally.
- [x] Documentation is updated (README/docs/contracts/runbook as applicable).
- [x] PR description includes exact test commands and output evidence.

## Test Commands and Evidence
- `cd gateway && bun run check`
- `cd gateway && bun test src/providers/renderers.discord.test.ts`
  - Evidence: `4 pass, 0 fail`

Closes #417


Closes #315
