### PR TITLE
feat(gateway): add Feishu response renderer and tests

### DIFF
--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -161,3 +161,10 @@ Provider adapters MUST NOT:
 - Filter or transform `GatewayResponse` fields based on provider
 
 The `handleCommand` function is the single command-processing entry point and is provider-agnostic by design. The `provider` field in `GatewayCommand` is used only for session scoping (pairing is per-provider+chat), never for branching command logic.
+
+## Feishu Rendering Notes
+
+Feishu adapter rendering should preserve response semantics in text-message format:
+- Success messages are prefixed with `✅`.
+- Error messages are prefixed with `❌ <errorCode>:`.
+- Optional fields (`downloadUrl`, `handoffId`) are appended as additional lines.

--- a/gateway/src/providers/renderers.feishu.test.ts
+++ b/gateway/src/providers/renderers.feishu.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { GatewayResponse } from "../contracts/commands";
+import { InMemoryDaemonClient } from "../daemon/client";
+import { DownloadTokenStore } from "../downloads/token_store";
+import { safeHandleCommand, type GatewayDependencies } from "../index";
+import { SessionStore } from "../session/store";
+import { renderFeishuResponse } from "./renderers.feishu";
+
+function buildDeps(): GatewayDependencies {
+  return {
+    daemon: new InMemoryDaemonClient(),
+    sessions: new SessionStore(),
+    downloads: new DownloadTokenStore(),
+  };
+}
+
+describe("renderFeishuResponse", () => {
+  test("renders success response", () => {
+    const response: GatewayResponse = {
+      requestId: "req-1",
+      result: "ok",
+      message: "start completed for openclaw",
+    };
+    const rendered = renderFeishuResponse(response);
+    expect(rendered.msg_type).toBe("text");
+    expect(rendered.content.text).toBe("✅ start completed for openclaw");
+  });
+
+  test("renders error response with code", () => {
+    const response: GatewayResponse = {
+      requestId: "req-2",
+      result: "error",
+      errorCode: "E_SESSION_REQUIRED",
+      message: "chat is not paired",
+    };
+    const rendered = renderFeishuResponse(response);
+    expect(rendered.content.text).toBe("❌ E_SESSION_REQUIRED: chat is not paired");
+  });
+
+  test("renders download and handoff metadata", () => {
+    const response: GatewayResponse = {
+      requestId: "req-3",
+      result: "ok",
+      message: "remote diagnosis consent recorded",
+      handoffId: "handoff-99",
+      handoffStatus: "declined",
+      downloadUrl: "/downloads/dl-99/openclaw.zip",
+    };
+    const rendered = renderFeishuResponse(response);
+    expect(rendered.content.text).toContain("Download: /downloads/dl-99/openclaw.zip");
+    expect(rendered.content.text).toContain("Handoff: handoff-99 (declined)");
+  });
+});
+
+describe("feishu renderer integration path", () => {
+  test("pair and agents responses render for feishu", async () => {
+    const deps = buildDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-ok");
+    }
+
+    const pair = await safeHandleCommand("feishu chat-1 req-pair /pair pair-ok", deps);
+    expect(pair.result).toBe("ok");
+
+    const token = pair.sessionToken!;
+    const agents = await safeHandleCommand(`feishu chat-1 req-agents ${token} /agents`, deps);
+    expect(agents.result).toBe("ok");
+
+    const rendered = renderFeishuResponse(agents);
+    expect(rendered.msg_type).toBe("text");
+    expect(rendered.content.text).toContain("✅");
+    expect(rendered.content.text).toContain("listed");
+  });
+});

--- a/gateway/src/providers/renderers.feishu.ts
+++ b/gateway/src/providers/renderers.feishu.ts
@@ -1,0 +1,32 @@
+import type { GatewayResponse } from "../contracts/commands";
+
+export type FeishuRenderedMessage = {
+  msg_type: "text";
+  content: {
+    text: string;
+  };
+};
+
+export function renderFeishuResponse(response: GatewayResponse): FeishuRenderedMessage {
+  const lines: string[] = [];
+
+  if (response.result === "ok") {
+    lines.push(`✅ ${response.message}`);
+    if (response.downloadUrl) {
+      lines.push(`Download: ${response.downloadUrl}`);
+    }
+    if (response.handoffId) {
+      lines.push(`Handoff: ${response.handoffId} (${response.handoffStatus ?? "pending"})`);
+    }
+  } else {
+    const code = response.errorCode ?? "E_UNKNOWN";
+    lines.push(`❌ ${code}: ${response.message}`);
+  }
+
+  return {
+    msg_type: "text",
+    content: {
+      text: lines.join("\n"),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add Feishu response renderer at `gateway/src/providers/renderers.feishu.ts`
- format success/error/download/handoff payloads into Feishu text-message payloads
- add renderer tests in `gateway/src/providers/renderers.feishu.test.ts`
- add integration-path test (pair + agents) through command handling and Feishu renderer
- document Feishu rendering conventions in `docs/command-contract.md`

## Why
Issue #420 requests Feishu response rendering and integration tests for command and artifact output.

## Mandatory PR Requirements
- [x] Unit tests are added or updated and pass locally.
- [x] End-to-end tests are added or updated and pass locally.
- [x] Documentation is updated (README/docs/contracts/runbook as applicable).
- [x] PR description includes exact test commands and output evidence.

## Test Commands and Evidence
- `cd gateway && bun run check`
- `cd gateway && bun test src/providers/renderers.feishu.test.ts`
  - Evidence: `4 pass, 0 fail`

Closes #420


Closes #317
