### PR TITLE
fix: address review-followup issues (batch 2)

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -113,10 +113,17 @@ func main() {
 		Handler: handler,
 	}
 
+	// Bind the listener first so we know the port is ready before setting
+	// the readiness flag — avoids a race where /readyz returns OK before
+	// the server is actually accepting connections (#576).
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("listen %s: %v", addr, err)
+	}
 	serverErrCh := make(chan error, 1)
 	go func() {
 		fmt.Printf("HTTP API listening on %s\n", addr)
-		serverErrCh <- httpServer.ListenAndServe()
+		serverErrCh <- httpServer.Serve(ln)
 	}()
 	ready.Store(true)
 

--- a/daemon/internal/api/pairing_store.go
+++ b/daemon/internal/api/pairing_store.go
@@ -42,6 +42,9 @@ func NewPairingCodeStore(now func() time.Time) *PairingCodeStore {
 }
 
 func (s *PairingCodeStore) Issue(ttl time.Duration) (PairingCodeRecord, error) {
+	// Opportunistic cleanup to prevent unbounded memory growth.
+	s.CleanupExpired()
+
 	code, err := newPairingCodeValue()
 	if err != nil {
 		return PairingCodeRecord{}, err

--- a/daemon/internal/api/server.go
+++ b/daemon/internal/api/server.go
@@ -432,7 +432,8 @@ func readJSON(r *http.Request, dst any) error {
 	}
 
 	dec := json.NewDecoder(strings.NewReader(string(raw)))
-	dec.DisallowUnknownFields()
+	// Allow unknown fields for forward compatibility — newer clients may send
+	// fields that this version doesn't know about yet.
 	if err := dec.Decode(dst); err != nil {
 		return fmt.Errorf("invalid json: %w", err)
 	}

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -410,6 +410,8 @@ func (s *Service) MergedLogs(tail int) []string {
 }
 
 // MaxTailLines is the upper bound accepted for the tail parameter.
+// Set to 1000 as a memory/performance guard: higher values would require
+// buffering proportionally more log data in memory per request.
 const MaxTailLines = 1000
 
 func boundTail(n int) int {

--- a/daemon/internal/lifecycle/start_stop.go
+++ b/daemon/internal/lifecycle/start_stop.go
@@ -32,6 +32,7 @@ func (s *Service) Start(ctx context.Context, agentID string) error {
 	}
 
 	if err := s.blockIfCrashLoopCoolingDown(agentID, state); err != nil {
+		s.recordAudit("", "system", "start", agentID, AuditResultFailure, "E_CRASH_LOOP", err.Error())
 		return err
 	}
 

--- a/docs/phase1-runtime-adr.md
+++ b/docs/phase1-runtime-adr.md
@@ -2,6 +2,8 @@
 
 Status: Accepted (Phase 1)
 
+> Historical context: [`docs/plans/adr-runtime-model.md`](plans/adr-runtime-model.md)
+
 ## Context
 
 Carrier Phase 1 must provide a reliable local-first runtime for daemon-managed agents while keeping installation and troubleshooting approachable for contributors and operators.

--- a/docs/plans/adr-runtime-model.md
+++ b/docs/plans/adr-runtime-model.md
@@ -1,6 +1,6 @@
 # ADR: Phase 1 Runtime Model — Local-First, No Docker
 
-> Superseded for authority by `docs/phase1-runtime-adr.md`.
+> Superseded for authority by [`docs/phase1-runtime-adr.md`](../phase1-runtime-adr.md).
 > This file is kept as historical context from earlier planning drafts.
 
 ## Status

--- a/gateway/src/daemon/http_client.test.ts
+++ b/gateway/src/daemon/http_client.test.ts
@@ -103,9 +103,9 @@ describe("HttpDaemonClient header propagation", () => {
     await client.listAgents({ actor: "discord:channel:12345", requestId: "req-list-1" });
 
     expect(capturedHeaders).toBeDefined();
-    const headers = capturedHeaders as Record<string, string>;
-    expect(headers["x-carrier-actor"]).toBe("discord:channel:12345");
-    expect(headers["x-carrier-request-id"]).toBe("req-list-1");
+    const headers = new Headers(capturedHeaders as HeadersInit);
+    expect(headers.get("x-carrier-actor")).toBe("discord:channel:12345");
+    expect(headers.get("x-carrier-request-id")).toBe("req-list-1");
   });
 
   test("startAgent propagates actor and request-id headers", async () => {
@@ -119,9 +119,9 @@ describe("HttpDaemonClient header propagation", () => {
     await client.startAgent("openclaw", { actor: "telegram:user:999", requestId: "req-start-1" });
 
     expect(capturedHeaders).toBeDefined();
-    const headers = capturedHeaders as Record<string, string>;
-    expect(headers["x-carrier-actor"]).toBe("telegram:user:999");
-    expect(headers["x-carrier-request-id"]).toBe("req-start-1");
+    const headers = new Headers(capturedHeaders as HeadersInit);
+    expect(headers.get("x-carrier-actor")).toBe("telegram:user:999");
+    expect(headers.get("x-carrier-request-id")).toBe("req-start-1");
   });
 
   test("stopAgent propagates actor and request-id headers", async () => {
@@ -135,9 +135,9 @@ describe("HttpDaemonClient header propagation", () => {
     await client.stopAgent("openclaw", { actor: "whatsapp:chat:777", requestId: "req-stop-1" });
 
     expect(capturedHeaders).toBeDefined();
-    const headers = capturedHeaders as Record<string, string>;
-    expect(headers["x-carrier-actor"]).toBe("whatsapp:chat:777");
-    expect(headers["x-carrier-request-id"]).toBe("req-stop-1");
+    const headers = new Headers(capturedHeaders as HeadersInit);
+    expect(headers.get("x-carrier-actor")).toBe("whatsapp:chat:777");
+    expect(headers.get("x-carrier-request-id")).toBe("req-stop-1");
   });
 
   test("installAgent propagates actor and request-id headers", async () => {
@@ -151,8 +151,8 @@ describe("HttpDaemonClient header propagation", () => {
     await client.installAgent("newagent", { actor: "cli:user:alice", requestId: "req-install-1" });
 
     expect(capturedHeaders).toBeDefined();
-    const headers = capturedHeaders as Record<string, string>;
-    expect(headers["x-carrier-actor"]).toBe("cli:user:alice");
-    expect(headers["x-carrier-request-id"]).toBe("req-install-1");
+    const headers = new Headers(capturedHeaders as HeadersInit);
+    expect(headers.get("x-carrier-actor")).toBe("cli:user:alice");
+    expect(headers.get("x-carrier-request-id")).toBe("req-install-1");
   });
 });

--- a/gateway/src/providers/parsers.ts
+++ b/gateway/src/providers/parsers.ts
@@ -1,6 +1,9 @@
 import type { Provider } from "../contracts/commands";
 import { createPublicKey, timingSafeEqual, verify } from "node:crypto";
 
+/** ASN.1 DER prefix for wrapping a raw 32-byte Ed25519 public key into SPKI format. */
+const ED25519_SPKI_PREFIX = "302a300506032b6570032100";
+
 export type NormalizedGatewayCommand = {
   provider: Provider;
   chatId: string;
@@ -160,7 +163,7 @@ export function verifyDiscordRequestSignature(input: DiscordSignatureVerificatio
     }
 
     // Discord public keys are raw 32-byte Ed25519 keys. Node verify() expects SPKI.
-    const spkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
+    const spkiPrefix = Buffer.from(ED25519_SPKI_PREFIX, "hex");
     const publicKey = createPublicKey({
       key: Buffer.concat([spkiPrefix, publicKeyRaw]),
       format: "der",
@@ -363,18 +366,20 @@ function toID(value: unknown): string | null {
   return null;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
+export function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
   return value as Record<string, unknown>;
 }
 
+/**
+ * Constant-time string comparison that does not leak length information.
+ * Both inputs are hashed before comparison to normalize length.
+ */
 function constantTimeStringEquals(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left, "utf8");
-  const rightBuffer = Buffer.from(right, "utf8");
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
-  return timingSafeEqual(leftBuffer, rightBuffer);
+  const { createHash } = require("node:crypto");
+  const leftHash = createHash("sha256").update(left, "utf8").digest();
+  const rightHash = createHash("sha256").update(right, "utf8").digest();
+  return timingSafeEqual(leftHash, rightHash);
 }

--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -430,6 +430,10 @@ describe("gateway runtime routes", () => {
     const disposition = response.headers.get("content-disposition");
     // Should escape backslashes and quotes: test\"file\\\\name.txt
     expect(disposition).toBe('attachment; filename="test\\"file\\\\name.txt"');
+
+    // Clean up temporary directory
+    const { rmSync } = await import("node:fs");
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test("command route executes command pipeline", async () => {

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -5,6 +5,7 @@ import { SessionStore } from "./session/store";
 import { join } from "node:path";
 import { timingSafeEqual } from "node:crypto";
 import {
+  asRecord,
   parseDiscordPayloadToCommand,
   parseFeishuEventToCommand,
   toGatewayInput,
@@ -165,6 +166,9 @@ export function startGatewayServer(options: StartGatewayServerOptions = {}): Ret
   });
   const port = options.port ?? parsePort(process.env.CARRIER_GATEWAY_PORT, 8787);
   const hostname = options.hostname ?? process.env.CARRIER_GATEWAY_HOST ?? "127.0.0.1";
+  if (!loadDiscordPublicKey()) {
+    console.warn("[gateway] CARRIER_DISCORD_PUBLIC_KEY is not set — all Discord webhook requests will be rejected (401)");
+  }
   const gatewayApiToken = loadGatewayAPIToken();
   if (!gatewayApiToken && !isLoopbackHost(hostname)) {
     throw new Error("CARRIER_GATEWAY_API_TOKEN is required when binding gateway to non-loopback host");
@@ -376,13 +380,6 @@ function extractFeishuURLVerificationChallenge(payload: unknown): string | null 
     return null;
   }
   return typeof record.challenge === "string" ? record.challenge : "";
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
 }
 
 function buildContentDisposition(filename: string): string {

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -8,7 +8,7 @@ Guide agents to review pull requests like a human collaborator — with inline c
    - Re-review mine only when existing `BS` findings are present.
    - Skip re-review of others when previous review is complete with no new updates.
    - Re-review others when unresolved/new findings remain.
-1. Check CI first via `gh pr checks <number> --repo Keith-CY/carrier`.
+2. Check CI first via `gh pr checks <number> --repo Keith-CY/carrier`.
 2. **Only perform formal code review after all required CI checks are green.**
 3. If CI is pending or failing:
    - Do not submit Approve/Request Changes review yet.


### PR DESCRIPTION
## Summary
Addresses 43 review-followup issues in one batch.

### Code changes (15 issues)
- **#1083**: Extract ED25519_SPKI_PREFIX constant for readability
- **#1084**: Log warning at startup when CARRIER_DISCORD_PUBLIC_KEY is unset
- **#1087**: Deduplicate `asRecord` — export from parsers.ts, reuse in server.ts
- **#1077**: Fix `constantTimeStringEquals` to not leak length info via timing
- **#555**: Add doc comment explaining why MaxTailLines=1000
- **#573**: Add opportunistic cleanup to pairing store on Issue()
- **#571**: Remove `DisallowUnknownFields` for forward compatibility
- **#576**: Fix SetReady race — bind listener before setting ready flag
- **#73**: Record audit event when crash loop blocks start attempts
- **#549**: Use normalized `Headers` object in http_client tests
- **#554**: Clean up temp directory after route test assertion
- **#1054**: Make ADR reference clickable in phase1-runtime-adr.md
- **#1055**: Make canonical reference clickable in adr-runtime-model.md
- **#1069**: Fix numbered list collision in pr-review SKILL.md

### Closed as approval-only / no code change needed (14 issues)
#1064, #1066, #1067, #1068, #1070, #1071, #1073, #1076, #1078, #1079, #1080, #1081, #1082, #1086

### Closed as CI/process notes or future-work (3 issues)
#1063, #1065, #1072

### Closed as duplicates (5 issues)
- #572, #575 (dupes of #571)
- #577 (dupe of #573)
- #553 (dupe of #552)
- #551 (dupe of #550)

### Closed as already addressed (4 issues)
- #574: Bearer auth already implemented
- #550: Install script already has checksum verification
- #552: Install script already has shasum fallback
- #461: All sub-issues (#61, #63) already closed

### Closed with explanation (2 issues)
- #1085: No existing shared JSON.parse utility to deduplicate against
- #1074, #1075: CI workflow changes require workflow scope token

closes #73
closes #549
closes #554
closes #555
closes #571
closes #573
closes #576
closes #1054
closes #1055
closes #1069
closes #1077
closes #1083
closes #1084
closes #1087
