### PR TITLE
fix: batch sweep bug-label issues across gateway and daemon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -11,14 +11,13 @@ permissions:
 
 env:
   RELEASE_ARTIFACT_RETENTION_DAYS: "14"
-  MAIN_RELEASE_KEEP_COUNT: "20"
 
 jobs:
   e2e-deploy:
     name: End-to-End Tests (Deployment)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -166,7 +165,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write  # Required for creating GitHub releases
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -177,46 +176,10 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: main-${{ github.sha }}
-          name: "main-${{ github.sha }}"
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |
             dist/**/*.zip
             dist/**/*.sha256
             dist/**/*.sig
-
-  prune-main-releases:
-    name: Prune Old main-* Releases
-    needs: release
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Prune by count policy
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP_COUNT: ${{ env.MAIN_RELEASE_KEEP_COUNT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mapfile -t tags < <(
-            gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq '.[] | select(.tag_name | startswith("main-")) | [.created_at, .tag_name] | @tsv' \
-              | sort -r \
-              | awk -F '\t' '{print $2}'
-          )
-
-          keep="${KEEP_COUNT}"
-          total="${#tags[@]}"
-
-          echo "Found ${total} main-* releases. Keep newest ${keep}."
-
-          if (( total <= keep )); then
-            echo "No release pruning required."
-            exit 0
-          fi
-
-          for tag in "${tags[@]:keep}"; do
-            echo "Deleting release/tag: ${tag}"
-            gh release delete "${tag}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
-          done

--- a/README.md
+++ b/README.md
@@ -154,9 +154,12 @@ Optional local flow from repo root:
 
 Runtime environment variables:
 - `CARRIER_DAEMON_BASE_URL` (default: `http://127.0.0.1:9090`)
+- `CARRIER_DAEMON_TIMEOUT_MS` (default: `30000`)
+- `CARRIER_COMMAND_TIMEOUT` (default: `5m`, daemon lifecycle install/upgrade command timeout)
 - `CARRIER_GATEWAY_HOST` (default: `127.0.0.1`)
 - `CARRIER_GATEWAY_PORT` (default: `8787`)
 - `CARRIER_GATEWAY_API_TOKEN` (optional on loopback; required for non-loopback bind)
+- `CARRIER_MAX_COMMAND_BODY_BYTES` (default: `65536`)
 
 #### Merge Queue
 - This repository supports GitHub Merge Queue for `main`.

--- a/daemon/cmd/agentd/agents_path_test.go
+++ b/daemon/cmd/agentd/agents_path_test.go
@@ -108,8 +108,8 @@ func TestAgentsPathHTTPRouting(t *testing.T) {
 		// Empty ID segment (double slash) → 301 (ServeMux cleans path)
 		{name: "empty_id_segment", method: "GET", path: "/api/v1/agents//status", wantStatus: http.StatusMovedPermanently},
 
-		// Special characters → 301 for traversal (ServeMux cleans ..), 404 for others
-		{name: "traversal_id", method: "GET", path: "/api/v1/agents/..%2F..%2Fetc/status", wantStatus: http.StatusMovedPermanently},
+		// Special characters → traversal payload is rejected as not found
+		{name: "traversal_id", method: "GET", path: "/api/v1/agents/..%2F..%2Fetc/status", wantStatus: http.StatusNotFound},
 		{name: "slash_encoded_id", method: "GET", path: "/api/v1/agents/a%2Fb/status", wantStatus: http.StatusNotFound},
 		{name: "leading_dot_id", method: "GET", path: "/api/v1/agents/.hidden/status", wantStatus: http.StatusNotFound},
 

--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -32,9 +32,13 @@ import (
 )
 
 const (
-	shutdownTimeout = 30 * time.Second
-	defaultLogsTail = 200
-	maxLogsTail     = 1000
+	shutdownTimeout          = 30 * time.Second
+	defaultReadHeaderTimeout = 10 * time.Second
+	defaultReadTimeout       = 30 * time.Second
+	defaultWriteTimeout      = 60 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+	defaultLogsTail          = 200
+	maxLogsTail              = 1000
 	// maxBodySize is the maximum allowed request body size (1 MB).
 	maxBodySize = 1 << 20
 )
@@ -108,10 +112,7 @@ func main() {
 		handler = bearerAuthMiddleware(cfg.Server.APIToken, mux)
 	}
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: handler,
-	}
+	httpServer := newHTTPServer(addr, handler)
 
 	// Bind the listener first so we know the port is ready before setting
 	// the readiness flag — avoids a race where /readyz returns OK before
@@ -623,6 +624,17 @@ func writeServiceError(w http.ResponseWriter, err error) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 	default:
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		ReadTimeout:       defaultReadTimeout,
+		WriteTimeout:      defaultWriteTimeout,
+		IdleTimeout:       defaultIdleTimeout,
 	}
 }
 

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -56,6 +56,27 @@ func buildTestMux(svc *lifecycle.Service, ready bool) *http.ServeMux {
 	return buildHTTPMux(svc, &readyFlag, pairStore, ratelimit.New())
 }
 
+func TestNewHTTPServerAppliesTimeouts(t *testing.T) {
+	handler := http.NewServeMux()
+	server := newHTTPServer("127.0.0.1:9090", handler)
+
+	if server.ReadHeaderTimeout != defaultReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", server.ReadHeaderTimeout, defaultReadHeaderTimeout)
+	}
+	if server.ReadTimeout != defaultReadTimeout {
+		t.Fatalf("ReadTimeout = %v, want %v", server.ReadTimeout, defaultReadTimeout)
+	}
+	if server.WriteTimeout != defaultWriteTimeout {
+		t.Fatalf("WriteTimeout = %v, want %v", server.WriteTimeout, defaultWriteTimeout)
+	}
+	if server.IdleTimeout != defaultIdleTimeout {
+		t.Fatalf("IdleTimeout = %v, want %v", server.IdleTimeout, defaultIdleTimeout)
+	}
+	if server.Handler != handler {
+		t.Fatal("handler mismatch")
+	}
+}
+
 func (m *fakeProcessManager) Start(agentID string, _ string, _ []string) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,3 +1,5 @@
 module carrier/daemon
 
-go 1.21
+go 1.23
+
+toolchain go1.23.0

--- a/daemon/internal/api/server.go
+++ b/daemon/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -420,18 +421,27 @@ func allowMethod(w http.ResponseWriter, r *http.Request, method string) bool {
 }
 
 func readJSON(r *http.Request, dst any) error {
-	body := io.LimitReader(r.Body, 1<<20)
+	const maxJSONBodyBytes = 1 << 20
+
+	if r.ContentLength > maxJSONBodyBytes {
+		return fmt.Errorf("request body too large: max %d bytes", maxJSONBodyBytes)
+	}
+
+	body := io.LimitReader(r.Body, maxJSONBodyBytes+1)
 	defer r.Body.Close()
 
 	raw, err := io.ReadAll(body)
 	if err != nil {
 		return fmt.Errorf("read request body: %w", err)
 	}
-	if len(strings.TrimSpace(string(raw))) == 0 {
+	if len(raw) > maxJSONBodyBytes {
+		return fmt.Errorf("request body too large: max %d bytes", maxJSONBodyBytes)
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
 		return nil
 	}
 
-	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec := json.NewDecoder(bytes.NewReader(raw))
 	// Allow unknown fields for forward compatibility — newer clients may send
 	// fields that this version doesn't know about yet.
 	if err := dec.Decode(dst); err != nil {

--- a/daemon/internal/api/server_test.go
+++ b/daemon/internal/api/server_test.go
@@ -397,4 +397,31 @@ func TestParseAgentActionPathBoundaryCases(t *testing.T) {
 	}
 }
 
+func TestVerifyConsumePairCodeRejectsOversizedPayload(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, 2, 14, 17, 0, 0, 0, time.UTC)}
+	pairing := NewPairingCodeStore(clock.Now)
+	if _, err := pairing.Register("pair-test-code", 30*time.Second); err != nil {
+		t.Fatalf("register code: %v", err)
+	}
+
+	svc := newServiceForAPITest(t)
+	handler := NewServer(svc, WithPairingCodeStore(pairing)).Handler()
+	oversizedCode := strings.Repeat("x", (1<<20)+32)
+	rr := doRawJSONRequest(t, handler, http.MethodPost, "/api/v1/pairing/verify-consume", []byte(`{"code":"`+oversizedCode+`"}`))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+
+	var env errorEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error.Code != "E_USAGE" {
+		t.Fatalf("unexpected error code: %q", env.Error.Code)
+	}
+	if !strings.Contains(strings.ToLower(env.Error.Message), "too large") {
+		t.Fatalf("expected oversized payload error message, got %q", env.Error.Message)
+	}
+}
+
 var _ runtimecheck.Checker = (*fakeChecker)(nil)

--- a/daemon/internal/lifecycle/command_timeout_test.go
+++ b/daemon/internal/lifecycle/command_timeout_test.go
@@ -1,0 +1,136 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"carrier/daemon/internal/commandexec"
+	"carrier/daemon/internal/manifest"
+)
+
+type timeoutAwareRunner struct {
+	mu        sync.Mutex
+	blockOn   map[string]bool
+	startedAt map[string]time.Time
+	deadlines map[string]time.Time
+}
+
+func newTimeoutAwareRunner() *timeoutAwareRunner {
+	return &timeoutAwareRunner{
+		blockOn:   map[string]bool{},
+		startedAt: map[string]time.Time{},
+		deadlines: map[string]time.Time{},
+	}
+}
+
+func (r *timeoutAwareRunner) Run(ctx context.Context, command string) (commandexec.Result, error) {
+	now := time.Now()
+	r.mu.Lock()
+	r.startedAt[command] = now
+	if deadline, ok := ctx.Deadline(); ok {
+		r.deadlines[command] = deadline
+	}
+	shouldBlock := r.blockOn[command]
+	r.mu.Unlock()
+
+	if shouldBlock {
+		<-ctx.Done()
+		return commandexec.Result{ExitCode: -1}, ctx.Err()
+	}
+
+	return commandexec.Result{ExitCode: 0}, nil
+}
+
+func (r *timeoutAwareRunner) deadlineFor(command string) (time.Time, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	deadline, ok := r.deadlines[command]
+	return deadline, ok
+}
+
+func (r *timeoutAwareRunner) startFor(command string) (time.Time, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	start, ok := r.startedAt[command]
+	return start, ok
+}
+
+type alwaysPassChecker struct{}
+
+func (alwaysPassChecker) Check(manifest.Manifest) error { return nil }
+
+func TestInstallUsesConfiguredCommandTimeout(t *testing.T) {
+	runner := newTimeoutAwareRunner()
+	runner.blockOn["install-openclaw"] = true
+
+	svc := NewService(nil,
+		WithRunner(runner),
+		WithRuntimeChecker(alwaysPassChecker{}),
+		WithCommandTimeout(25*time.Millisecond),
+		WithDiagnoseDir(t.TempDir()),
+	)
+	if err := svc.RegisterManifest(sampleManifest()); err != nil {
+		t.Fatalf("register manifest: %v", err)
+	}
+
+	err := svc.Install(context.Background(), "openclaw")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("install error = %v, want context deadline exceeded", err)
+	}
+
+	startedAt, ok := runner.startFor("install-openclaw")
+	if !ok {
+		t.Fatal("expected install command to run")
+	}
+	deadline, ok := runner.deadlineFor("install-openclaw")
+	if !ok {
+		t.Fatal("expected install command context to have a deadline")
+	}
+	timeoutWindow := deadline.Sub(startedAt)
+	if timeoutWindow <= 0 || timeoutWindow > time.Second {
+		t.Fatalf("unexpected install timeout window: %v", timeoutWindow)
+	}
+}
+
+func TestUpgradeUsesConfiguredCommandTimeout(t *testing.T) {
+	runner := newTimeoutAwareRunner()
+	runner.blockOn["upgrade-openclaw"] = true
+
+	svc := NewService(nil,
+		WithRunner(runner),
+		WithRuntimeChecker(alwaysPassChecker{}),
+		WithCommandTimeout(25*time.Millisecond),
+		WithDiagnoseDir(t.TempDir()),
+	)
+	if err := svc.RegisterManifest(sampleManifest()); err != nil {
+		t.Fatalf("register manifest: %v", err)
+	}
+	if err := svc.Install(context.Background(), "openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	_, err := svc.Upgrade(context.Background(), "openclaw")
+	if err == nil {
+		t.Fatal("expected upgrade error")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("upgrade error = %v, want timeout signal", err)
+	}
+
+	startedAt, ok := runner.startFor("upgrade-openclaw")
+	if !ok {
+		t.Fatal("expected upgrade command to run")
+	}
+	deadline, ok := runner.deadlineFor("upgrade-openclaw")
+	if !ok {
+		t.Fatal("expected upgrade command context to have a deadline")
+	}
+	timeoutWindow := deadline.Sub(startedAt)
+	if timeoutWindow <= 0 || timeoutWindow > time.Second {
+		t.Fatalf("unexpected upgrade timeout window: %v", timeoutWindow)
+	}
+}

--- a/daemon/internal/lifecycle/install.go
+++ b/daemon/internal/lifecycle/install.go
@@ -16,7 +16,10 @@ func (s *Service) Install(ctx context.Context, agentID string) error {
 		return err
 	}
 
-	result, runErr := s.runner.Run(ctx, m.Runtime.Install.Command)
+	opCtx, cancel := context.WithTimeout(ctx, s.commandTimeout)
+	defer cancel()
+
+	result, runErr := s.runner.Run(opCtx, m.Runtime.Install.Command)
 	s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
 	if runErr != nil {
 		s.updateStateOnInstallError(agentID, runErr)

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -41,6 +41,7 @@ const (
 	defaultCrashLoopThreshold = 3
 	defaultCrashLoopWindow    = 5 * time.Minute
 	defaultCrashLoopCooldown  = 5 * time.Minute
+	defaultCommandTimeout     = 5 * time.Minute
 )
 
 var (
@@ -164,6 +165,14 @@ func WithBackoffPolicy(policy BackoffPolicy) Option {
 	}
 }
 
+func WithCommandTimeout(timeout time.Duration) Option {
+	return func(s *Service) {
+		if timeout > 0 {
+			s.commandTimeout = timeout
+		}
+	}
+}
+
 type Service struct {
 	mu                 sync.RWMutex
 	states             map[string]AgentState
@@ -195,6 +204,7 @@ type Service struct {
 	backoffStates      map[string]BackoffState
 	exitCodes          map[string]*int
 	evidenceCollector  *EvidenceCollector
+	commandTimeout     time.Duration
 }
 
 func NewService(triager baseagent.Triager, opts ...Option) *Service {
@@ -230,6 +240,7 @@ func NewService(triager baseagent.Triager, opts ...Option) *Service {
 		backoffPolicy:      DefaultBackoffPolicy(),
 		backoffStates:      make(map[string]BackoffState),
 		exitCodes:          exitCodes,
+		commandTimeout:     loadCommandTimeoutFromEnv(os.Getenv("CARRIER_COMMAND_TIMEOUT")),
 	}
 	svc.processManager = NewProcessManager(processLogDir)
 	svc.evidenceCollector = NewEvidenceCollector(logs, exitCodes, 1000)
@@ -254,6 +265,17 @@ func NewService(triager baseagent.Triager, opts ...Option) *Service {
 	}
 
 	return svc
+}
+
+func loadCommandTimeoutFromEnv(raw string) time.Duration {
+	if raw == "" {
+		return defaultCommandTimeout
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return defaultCommandTimeout
+	}
+	return timeout
 }
 
 func (s *Service) RegisterManifest(m manifest.Manifest) error {

--- a/daemon/internal/lifecycle/upgrade.go
+++ b/daemon/internal/lifecycle/upgrade.go
@@ -72,7 +72,10 @@ func (s *Service) Upgrade(ctx context.Context, agentID string) (UpgradeResult, e
 	}
 	s.recordAudit("", "system", "upgrade", agentID, AuditResultSuccess, "", fmt.Sprintf("upgrade_start backup=%q command=%q", backupPath, m.Runtime.Upgrade.Command))
 
-	result, runErr := s.runner.Run(ctx, m.Runtime.Upgrade.Command)
+	opCtx, cancel := context.WithTimeout(ctx, s.commandTimeout)
+	defer cancel()
+
+	result, runErr := s.runner.Run(opCtx, m.Runtime.Upgrade.Command)
 	s.appendCommandLog(agentID, "upgrade", m.Runtime.Upgrade.Command, result, runErr)
 	if runErr != nil {
 		updateErr := s.formatUpgradeFailure(runErr, backupPath)

--- a/docs/ci/release-artifact-retention.md
+++ b/docs/ci/release-artifact-retention.md
@@ -9,12 +9,12 @@ Retention policy is enforced by release workflow and documented here for operato
 - CI artifacts uploaded by `release.yml` use `retention-days: 14`.
 - Applies to packaged ZIP and checksum artifacts uploaded by `actions/upload-artifact`.
 
-## Count-Based Retention
+## Release Trigger Policy
 
-- For `main-<sha>` releases, workflow keeps the newest `20` releases.
-- Older `main-*` releases are pruned automatically after a successful new release.
+- Release publication is tag-driven (`v*`) in `.github/workflows/release.yml`.
+- Main-branch pushes do not create GitHub Releases automatically.
 
-## Why both rules
+## Why this rule
 
 - Time-based retention limits storage for workflow artifacts.
-- Count-based retention limits release history growth while preserving rollback headroom.
+- Tag-driven releases prevent noisy non-release artifacts on routine main merges.

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -21,6 +21,7 @@ All commands are parsed from a single string with the format:
 When commands are sent via gateway HTTP (`POST /command`):
 - request body: `{ "input": "<provider> <chat_id> <request_id> <command> [...args]" }`
 - if `CARRIER_GATEWAY_API_TOKEN` is configured, include `Authorization: Bearer <gateway_api_token>`
+- command request body is capped by `CARRIER_MAX_COMMAND_BODY_BYTES` (default: `65536`); oversized requests return `413 E_PAYLOAD_TOO_LARGE`
 
 **Session token transport:** When `CARRIER_GATEWAY_API_TOKEN` is enabled, the
 `Authorization` header is reserved for the gateway API token. Session tokens
@@ -51,6 +52,7 @@ type GatewayResponse = {
 |----------------------------|------------------------------------------------------|
 | `E_PARSE`                  | Input string could not be parsed                     |
 | `E_USAGE`                  | Missing required argument(s)                         |
+| `E_PAYLOAD_TOO_LARGE`      | `/command` request body exceeds size limit           |
 | `E_GATEWAY_AUTH_REQUIRED`  | Gateway API token is required for `/command` access  |
 | `E_GATEWAY_AUTH_INVALID`   | Provided gateway API token is invalid                |
 | `E_PAIR_CODE_INVALID`      | Pairing code is invalid or expired                   |

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -28,7 +28,7 @@ You can also verify manually:
 
 ```bash
 cosign verify-blob \
-  --certificate-identity "https://github.com/Keith-CY/carrier/.github/workflows/release.yml@refs/heads/main" \
+  --certificate-identity "https://github.com/Keith-CY/carrier/.github/workflows/release.yml@refs/tags/v<major.minor.patch>" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   --signature carrier-<commit>-linux-x64.zip.sig \
   carrier-<commit>-linux-x64.zip

--- a/docs/security-fallback-trust-model.md
+++ b/docs/security-fallback-trust-model.md
@@ -64,7 +64,7 @@ Operators who require deterministic, auditable deployments should pin exact rele
 install_url: https://github.com/Keith-CY/carrier/releases/latest/download/carrier-linux-x64.tar.gz
 
 # Prefer pinned release assets (example pattern):
-install_url: https://github.com/Keith-CY/carrier/releases/download/main-<sha>/carrier-<sha>-linux-x64.zip
+install_url: https://github.com/Keith-CY/carrier/releases/download/v<major.minor.patch>/carrier-<commit>-linux-x64.zip
 # and pin expected SHA-256 separately (e.g., OPENCLAW_CHECKSUM or deployment metadata)
 ```
 

--- a/gateway/src/daemon/http_client.test.ts
+++ b/gateway/src/daemon/http_client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { DaemonClientError, RemoteDiagnosisNotNeededError } from "./client";
-import { HttpDaemonClient, loadDaemonBaseUrl } from "./http_client";
+import { HttpDaemonClient, loadDaemonBaseUrl, loadDaemonTimeoutMs } from "./http_client";
 
 function makeFetch(response: Response): typeof fetch {
   return (async () => response.clone()) as unknown as typeof fetch;
@@ -13,6 +13,22 @@ describe("loadDaemonBaseUrl", () => {
 
   test("trims trailing slash from env value", () => {
     expect(loadDaemonBaseUrl({ CARRIER_DAEMON_BASE_URL: "http://localhost:8080/" })).toBe("http://localhost:8080");
+  });
+});
+
+describe("loadDaemonTimeoutMs", () => {
+  test("uses default when env is missing", () => {
+    expect(loadDaemonTimeoutMs({})).toBe(30_000);
+  });
+
+  test("uses configured timeout when env value is valid", () => {
+    expect(loadDaemonTimeoutMs({ CARRIER_DAEMON_TIMEOUT_MS: "12000" })).toBe(12_000);
+  });
+
+  test("falls back to default when env value is invalid", () => {
+    expect(loadDaemonTimeoutMs({ CARRIER_DAEMON_TIMEOUT_MS: "0" })).toBe(30_000);
+    expect(loadDaemonTimeoutMs({ CARRIER_DAEMON_TIMEOUT_MS: "-1" })).toBe(30_000);
+    expect(loadDaemonTimeoutMs({ CARRIER_DAEMON_TIMEOUT_MS: "abc" })).toBe(30_000);
   });
 });
 
@@ -154,5 +170,18 @@ describe("HttpDaemonClient header propagation", () => {
     const headers = new Headers(capturedHeaders as HeadersInit);
     expect(headers.get("x-carrier-actor")).toBe("cli:user:alice");
     expect(headers.get("x-carrier-request-id")).toBe("req-install-1");
+  });
+
+  test("propagates an abort signal to enforce request timeout", async () => {
+    let capturedSignal: AbortSignal | null = null;
+    const fetchMock = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedSignal = (init?.signal ?? null) as AbortSignal | null;
+      return new Response(JSON.stringify({ agents: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const client = new HttpDaemonClient("http://daemon.local", fetchMock);
+    await client.listAgents({ actor: "telegram:100", requestId: "req-timeout-signal" });
+
+    expect(capturedSignal).not.toBeNull();
   });
 });

--- a/gateway/src/daemon/http_client.ts
+++ b/gateway/src/daemon/http_client.ts
@@ -12,6 +12,7 @@ import {
 } from "./client";
 
 const DEFAULT_DAEMON_BASE_URL = "http://127.0.0.1:9090";
+const DEFAULT_DAEMON_TIMEOUT_MS = 30_000;
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -35,10 +36,23 @@ export function loadDaemonBaseUrl(env: Record<string, string | undefined> = proc
   return raw.replace(/\/+$/, "");
 }
 
+export function loadDaemonTimeoutMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.CARRIER_DAEMON_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_DAEMON_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_DAEMON_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
 export class HttpDaemonClient implements DaemonClient {
   constructor(
     private readonly baseUrl = loadDaemonBaseUrl(),
     private readonly fetchImpl: FetchLike = fetch,
+    private readonly requestTimeoutMs: number = loadDaemonTimeoutMs(),
   ) {}
 
   async listAgents(ctx: RequestContext): Promise<DaemonAgentState[]> {
@@ -151,6 +165,7 @@ export class HttpDaemonClient implements DaemonClient {
         "x-carrier-request-id": ctx.requestId,
       },
       body: body === undefined ? undefined : JSON.stringify(body),
+      signal: AbortSignal.timeout(this.requestTimeoutMs),
     });
 
     if (!response.ok) {

--- a/gateway/src/ratelimit/index.ts
+++ b/gateway/src/ratelimit/index.ts
@@ -57,6 +57,9 @@ export class RateLimiter {
     // Prune and check per-session
     let timestamps = this.sessionWindows.get(sessionKey) ?? [];
     timestamps = timestamps.filter((t) => t > cutoff);
+    if (timestamps.length === 0) {
+      this.sessionWindows.delete(sessionKey);
+    }
     if (timestamps.length >= this.config.perSession) {
       this.sessionWindows.set(sessionKey, timestamps);
       return {

--- a/gateway/src/server.test.ts
+++ b/gateway/src/server.test.ts
@@ -140,6 +140,13 @@ describe("runtime dependencies", () => {
     expect(deps.daemon).toBeInstanceOf(HttpDaemonClient);
     deps.downloads.stopPeriodicCleanup();
   });
+
+  test("instantiates rate limiter by default", () => {
+    const deps = createRuntimeDependencies();
+    expect(deps.rateLimiter).toBeDefined();
+    deps.rateLimiter?.stopPeriodicCleanup();
+    deps.downloads.stopPeriodicCleanup();
+  });
 });
 
 describe("gateway runtime routes", () => {
@@ -1024,6 +1031,105 @@ describe("command authentication", () => {
     expect(response.status).toBe(401);
     const payload = await response.json() as { errorCode?: string };
     expect(payload.errorCode).toBe("E_SESSION_REQUIRED");
+  });
+});
+
+describe("command route payload size limits", () => {
+  test("accepts JSON payload exactly at configured limit", async () => {
+    const deps = makeDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-limit-json");
+    }
+    const runtime = createGatewayRuntime({ deps });
+    const body = JSON.stringify({ input: "telegram 100 req-json-limit /pair pair-limit-json" });
+
+    await withEnvVar("CARRIER_MAX_COMMAND_BODY_BYTES", String(Buffer.byteLength(body)), async () => {
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }));
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { result: string };
+      expect(payload.result).toBe("ok");
+    });
+  });
+
+  test("rejects JSON payload larger than configured limit", async () => {
+    const deps = makeDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-limit-json-too-large");
+    }
+    const runtime = createGatewayRuntime({ deps });
+    const body = JSON.stringify({ input: "telegram 100 req-json-large /pair pair-limit-json-too-large" });
+
+    await withEnvVar("CARRIER_MAX_COMMAND_BODY_BYTES", String(Buffer.byteLength(body) - 1), async () => {
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }));
+      expect(response.status).toBe(413);
+      const payload = await response.json() as { errorCode?: string };
+      expect(payload.errorCode).toBe("E_PAYLOAD_TOO_LARGE");
+    });
+  });
+
+  test("accepts text payload exactly at configured limit", async () => {
+    const deps = makeDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-limit-text");
+    }
+    const runtime = createGatewayRuntime({ deps });
+    const command = "telegram 100 req-text-limit /pair pair-limit-text";
+
+    await withEnvVar("CARRIER_MAX_COMMAND_BODY_BYTES", String(Buffer.byteLength(command)), async () => {
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: command,
+      }));
+      expect(response.status).toBe(200);
+      const payload = await response.json() as { result: string };
+      expect(payload.result).toBe("ok");
+    });
+  });
+
+  test("rejects text payload larger than configured limit", async () => {
+    const deps = makeDeps();
+    if (deps.daemon instanceof InMemoryDaemonClient) {
+      deps.daemon.registerPairCode("pair-limit-text-too-large");
+    }
+    const runtime = createGatewayRuntime({ deps });
+    const command = "telegram 100 req-text-large /pair pair-limit-text-too-large";
+
+    await withEnvVar("CARRIER_MAX_COMMAND_BODY_BYTES", String(Buffer.byteLength(command) - 1), async () => {
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: command,
+      }));
+      expect(response.status).toBe(413);
+      const payload = await response.json() as { errorCode?: string };
+      expect(payload.errorCode).toBe("E_PAYLOAD_TOO_LARGE");
+    });
+  });
+
+  test("keeps malformed JSON behavior under size limit", async () => {
+    const deps = makeDeps();
+    const runtime = createGatewayRuntime({ deps });
+    const malformed = "{\"input\":";
+
+    await withEnvVar("CARRIER_MAX_COMMAND_BODY_BYTES", "1024", async () => {
+      const response = await runtime.fetch(new Request("http://gateway.local/command", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: malformed,
+      }));
+      expect(response.status).toBe(400);
+      const payload = await response.json() as { errorCode?: string };
+      expect(payload.errorCode).toBe("E_USAGE");
+    });
   });
 });
 

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -1,6 +1,7 @@
 import { safeHandleCommand, type GatewayDependencies } from "./index";
 import { HttpDaemonClient } from "./daemon/http_client";
 import { DownloadTokenStore } from "./downloads/token_store";
+import { RateLimiter } from "./ratelimit";
 import { SessionStore } from "./session/store";
 import { join } from "node:path";
 import { timingSafeEqual } from "node:crypto";
@@ -41,6 +42,15 @@ export type GatewayRuntime = {
   fetch: (request: Request) => Promise<Response>;
 };
 
+const DEFAULT_MAX_COMMAND_BODY_BYTES = 64 * 1024;
+
+class PayloadTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`request body exceeds ${maxBytes} bytes`);
+    this.name = "PayloadTooLargeError";
+  }
+}
+
 export function composeMiddleware(middlewares: GatewayMiddleware[], handler: GatewayHandler): GatewayHandler {
   return async (ctx: GatewayRequestContext): Promise<Response> => {
     let index = -1;
@@ -76,7 +86,7 @@ export function createRuntimeDependencies(overrides: Partial<GatewayDependencies
     daemon: overrides.daemon ?? new HttpDaemonClient(),
     sessions: overrides.sessions ?? new SessionStore(undefined, undefined, sessionPersistencePath).startPeriodicCleanup(),
     downloads: overrides.downloads ?? new DownloadTokenStore().startPeriodicCleanup(),
-    rateLimiter: overrides.rateLimiter,
+    rateLimiter: overrides.rateLimiter ?? new RateLimiter().startPeriodicCleanup(),
   };
 }
 
@@ -99,7 +109,20 @@ export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): Gatew
         return jsonResponse(gatewayAuthError, 401);
       }
 
-      const parsed = await parseCommandRequest(ctx.request);
+      let parsed: ParsedCommandRequest;
+      try {
+        parsed = await parseCommandRequest(ctx.request);
+      } catch (error) {
+        if (error instanceof PayloadTooLargeError) {
+          return jsonResponse({
+            requestId: ctx.requestId,
+            result: "error",
+            errorCode: "E_PAYLOAD_TOO_LARGE",
+            message: `request body exceeds ${error.maxBytes} bytes limit`,
+          }, 413);
+        }
+        throw error;
+      }
       if (!parsed.commandInput) {
         return jsonResponse({
           requestId: ctx.requestId,
@@ -487,6 +510,7 @@ type ParsedCommandRequest = {
 
 async function parseCommandRequest(request: Request): Promise<ParsedCommandRequest> {
   const allowAuthorizationSessionToken = !loadGatewayAPIToken();
+  const rawBody = await readBodyWithLimit(request, loadMaxCommandBodyBytes());
   const result: ParsedCommandRequest = {
     commandInput: null,
     sessionToken: null,
@@ -512,7 +536,7 @@ async function parseCommandRequest(request: Request): Promise<ParsedCommandReque
   const contentType = request.headers.get("content-type")?.toLowerCase() || "";
   if (contentType.includes("application/json")) {
     try {
-      const payload = await request.json() as { input?: unknown; sessionToken?: unknown };
+      const payload = JSON.parse(rawBody) as { input?: unknown; sessionToken?: unknown };
       
       // Extract command input
       if (typeof payload.input === "string" && payload.input.trim().length > 0) {
@@ -531,12 +555,60 @@ async function parseCommandRequest(request: Request): Promise<ParsedCommandReque
   }
 
   // For non-JSON requests, treat the entire body as command input
-  const raw = (await request.text()).trim();
+  const raw = rawBody.trim();
   if (raw.length > 0) {
     result.commandInput = raw;
   }
   
   return result;
+}
+
+function loadMaxCommandBodyBytes(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.CARRIER_MAX_COMMAND_BODY_BYTES?.trim();
+  if (!raw) {
+    return DEFAULT_MAX_COMMAND_BODY_BYTES;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_COMMAND_BODY_BYTES;
+  }
+  return parsed;
+}
+
+async function readBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(parsed) && parsed > maxBytes) {
+      throw new PayloadTooLargeError(maxBytes);
+    }
+  }
+
+  if (!request.body) {
+    return "";
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value) {
+      continue;
+    }
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new PayloadTooLargeError(maxBytes);
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
 }
 
 export function injectSessionTokenIfMissing(commandInput: string, sessionToken: string | null): string {


### PR DESCRIPTION
## Summary
- enable default gateway rate limiting and periodic cleanup in runtime deps
- enforce `/command` request size limits (`CARRIER_MAX_COMMAND_BODY_BYTES`) with deterministic `413 E_PAYLOAD_TOO_LARGE` handling and boundary tests
- add daemon client HTTP timeout support (`CARRIER_DAEMON_TIMEOUT_MS`) using `AbortSignal.timeout`
- add daemon lifecycle per-operation command timeout (`CARRIER_COMMAND_TIMEOUT`, default `5m`) for install/upgrade with regression tests
- harden daemon JSON body parsing with early oversize rejection
- configure daemon HTTP server read/read-header/write/idle timeouts
- move release workflow to tag-driven `v*` publishing to stop noisy main-branch releases
- bump daemon toolchain target to Go 1.23 with explicit toolchain directive
- update docs to reflect new limits/timeouts and tag-driven release policy

## Issues addressed in this PR
Fixes #635
Fixes #633
Fixes #620
Fixes #614
Fixes #604
Fixes #603
Fixes #602
Fixes #591
Fixes #588

## Bug-label sweep notes
- Reviewed all open `bug` label issues in the repo.
- Items #636, #618, #617, and #590 are already functionally covered in current `main` and were not reimplemented here.
- #598 appears obsolete against the current catalog install flow (no linux/amd64 fallback checksum branch remains in `main`).

## Verification
- `cd gateway && bun test src/server.test.ts -t "runtime dependencies"`
- `cd gateway && bun test src/server.test.ts -t "command route payload size limits"`
- `cd gateway && bun test src/daemon/http_client.test.ts src/ratelimit/index.test.ts`
- `cd daemon && go test ./internal/lifecycle`
- `cd daemon && go test ./internal/api`
- `cd daemon && go test ./cmd/agentd`
