### PR TITLE
docs: complete all open docs* issues in one batch PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,96 @@ When touching covered files:
 - Unassigned issue report: `bash scripts/triage/unassigned-report.sh`
 - Triage runbook: `docs/triage.md`
 
+## Targeted test runs
+
+Use these from repository root:
+
+```bash
+# Daemon tests only
+cd daemon && go test ./...
+
+# Gateway check + tests only
+cd gateway && bun install --no-progress && bun run check && bun test
+
+# Full local validation (daemon + gateway + e2e hook)
+./scripts/run-all-tests.sh
+```
+
+## CI failure first-response runbook
+
+When a PR check fails, triage in this order:
+
+```bash
+# 1) See all checks on the PR
+gh pr checks <pr-number>
+
+# 2) See required checks only
+gh pr checks <pr-number> --required
+
+# 3) Find recent workflow runs for the branch
+gh run list --branch <branch-name> --limit 20
+
+# 4) Inspect failing logs from a specific run
+gh run view <run-id> --log-failed
+```
+
+Typical local re-run commands after log review:
+
+```bash
+cd daemon && go test ./...
+cd gateway && bun install --no-progress && bun run check && bun test
+./scripts/run-e2e-tests.sh
+```
+
+Notes:
+- Use `gh pr checks <pr-number> --required` to separate blocking checks from informational/non-required checks.
+- Docs-only pull requests may not trigger the default CI workflow because `.md` and `docs/**` are excluded there.
+
+## Installer source of truth and update workflow
+
+Canonical installer command source in this repository:
+- `catalog/openclaw.manifest.json` (`runtime.install.command` and `runtime.upgrade.command`)
+
+Do not duplicate installer command strings across scripts/docs as independent sources of truth.
+If installer behavior changes, update the manifest first, then update dependent documentation/workflows.
+
+Recommended verification sequence (from repository root):
+
+```bash
+# Verify manifest remains loadable
+go test ./daemon/internal/manifest -run TestLoadFileAcceptsCatalogManifest -count=1
+
+# Verify lifecycle install/upgrade flows still align with manifest commands
+go test ./daemon/internal/lifecycle -run 'TestLifecycleInstallStartStop|TestLifecycleUpgradeCreatesBackupAndBumpsVersion' -count=1
+
+# Verify release checksum generation path is still wired
+rg -n 'sha256sum "\\${package_file}" > "\\${package_file}\\.sha256"' .github/workflows/release.yml
+```
+
+## Installer pre-merge checklist (docs-only guard)
+
+For PRs that touch installer behavior, confirm before merge:
+- [ ] Only canonical installer command definitions were edited in `catalog/openclaw.manifest.json` (single-source update).
+- [ ] Any release/checksum documentation still matches `.github/workflows/release.yml` output path `dist/<archive>.zip.sha256`.
+- [ ] Verification commands above were run from repo root and output is clean.
+- [ ] If command strings changed, dependent docs reference the manifest path instead of re-stating command literals.
+
+## Label glossary
+
+Common labels and when to apply them:
+
+- `P0`: Must-fix now for current delivery gate. Use for release/security/availability blockers.
+- `P1`: Important next priority after P0. Use for high-impact work that is not an immediate gate blocker.
+- `P2`: Maintainability/performance/developer-experience improvements.
+- `P3`: Nice-to-have cleanup/polish.
+- `Phase 1`: Work that must stay within Phase 1 scope and acceptance criteria.
+- `enhancement`: Net-new capability or scope expansion.
+- `documentation`: Documentation-only or documentation-heavy updates.
+- `review-followup`: Use this as the issue title prefix (`[review-followup]`) for post-review non-blocking follow-up items.
+
+Example label combination for prioritization:
+- `Phase 1` + `P1` + `enhancement` means "important Phase 1 feature work, but behind P0 blockers."
+
 ## Review Convention (Non-Blocking Suggestions)
 
 For non-blocking review suggestions, use fixed prefix `NBS:`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ For product scope/priority decisions, use this order:
 3. `docs/Agent_Installation_Platform_Implementation_Plan.md` (execution sequence and delivery plan)
 4. `README.md` (quick orientation and current implementation status)
 
+## Contributor docs quick links
+- `CONTRIBUTING.md`
+- `docs/command-contract.md`
+- `docs/daemon-api-contract.md`
+- `docs/daemon-lifecycle-runtime.md`
+- `docs/e2e-parity-taxonomy.md`
 
 ## Quick Navigation
 
@@ -179,15 +185,22 @@ Runtime environment variables:
 - Go-live checklist and rollback: `docs/runbooks/go-live-rollback.md`
 - CI first-response playbook: `docs/ci/first-response-playbook.md`
 
-## Kanban workflow required secrets/env vars
+## Kanban workflow env vars
 
-For the Kanban workflows (`.github/workflows/carrier-kanban-operations.yml`, `.github/workflows/carrier-kanban-automation.yml`), configure these repository-level secrets/variables (see workflow files under [`.github/workflows/`](./.github/workflows/)):
+For `.github/workflows/carrier-kanban-operations.yml` (see [`.github/workflows/carrier-kanban-operations.yml`](./.github/workflows/carrier-kanban-operations.yml)):
 
-- `CARRIER_PROJECT_ID` (recommended): GitHub Project (v2) ID used by the workflow. If omitted, workflows try `.github/kanban-config.json` `projectId`.
-- `CARRIER_PROJECTS_TOKEN` (required to execute sync/report): token with project read/write permissions for user/org ProjectV2 operations.
+- `CARRIER_PROJECTS_TOKEN` (required): token with project read/write permissions for field/view operations.
+- `CARRIER_PROJECT_ID` (optional override): target project node ID override.
 - `CARRIER_DISCUSSION_CATEGORY_ID` (optional): discussion category override for workflow-generated discussion posts.
 
-Implementation note: workflows now skip with a warning when `CARRIER_PROJECTS_TOKEN` is missing or project access is unavailable, so unrelated CI checks are not blocked by Kanban configuration gaps.
+Target project resolution order:
+1. workflow dispatch input `project_id`
+2. `CARRIER_PROJECT_ID`
+3. repository workflow/config default
+
+Implementation notes:
+- `carrier-kanban-operations.yml` can fall back to the pre-authenticated `github` client from `@actions/github` for repository-scoped calls when an explicit token is not provided.
+- Kanban workflows skip with a warning when `CARRIER_PROJECTS_TOKEN` is missing or project access is unavailable, so unrelated CI checks are not blocked by Kanban configuration gaps.
 
 ## Install OpenClaw from release package (non-technical quick path)
 

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -2,6 +2,10 @@
 
 This document defines the unified input/output contract for all gateway commands. Every command MUST produce identical results regardless of which provider (Telegram, Discord, Feishu) delivers it.
 
+Related references:
+- Daemon payload examples: `docs/daemon-api-contract.md`
+- Cross-provider parity taxonomy: `docs/e2e-parity-taxonomy.md`
+
 ## Input Format
 
 All commands are parsed from a single string with the format:

--- a/docs/daemon-api-contract.md
+++ b/docs/daemon-api-contract.md
@@ -26,6 +26,51 @@ This document defines the canonical daemon HTTP endpoint and method matrix align
 | Diagnose | `POST` | `/api/v1/agents/{agent_id}/diagnose` | Returns artifact metadata | #395 |
 | Diagnose consent / handoff | `POST` | `/api/v1/diagnosis/handoffs` | Remote diagnosis consent + handoff | Planned |
 
+## Response examples (quick validation)
+
+Lifecycle success example:
+
+```json
+{
+  "agents": [
+    {
+      "id": "openclaw",
+      "name": "OpenClaw",
+      "version": "0.1.0",
+      "installed": true,
+      "runtimeState": "running",
+      "health": "healthy",
+      "needsRemoteDiagnosis": false,
+      "updatedAt": "2026-02-14T04:20:00.000Z"
+    }
+  ]
+}
+```
+
+Standardized error envelope example:
+
+```json
+{
+  "error": {
+    "code": "E_NOT_INSTALLED",
+    "message": "agent is not installed"
+  }
+}
+```
+
+## Required vs optional fields
+
+`DaemonAgentState`:
+- Required: `id`, `name`, `version`, `installed`, `runtimeState`, `health`, `needsRemoteDiagnosis`, `updatedAt`
+- Optional: `lastError`
+
+`UpgradeResult`:
+- Required: `agentId`, `fromVersion`, `toVersion`
+- Optional: `backupPath`, `rollbackHint`
+
+`RemoteDiagnosisHandoff`:
+- Required: `id`, `agentId`, `consent`, `artifactRef`, `status`, `createdAt`
+
 ## Error Envelope
 
 All daemon API error responses MUST use one schema:

--- a/docs/daemon-lifecycle-runtime.md
+++ b/docs/daemon-lifecycle-runtime.md
@@ -1,0 +1,85 @@
+# Daemon Lifecycle Runtime and Troubleshooting
+
+This guide documents the current lifecycle runtime behavior implemented in `daemon/internal/lifecycle/`.
+
+## Start/Stop runtime semantics
+
+- `Install`/`Start`/`Stop`/`Upgrade` execute manifest commands via the lifecycle runner.
+- `Start` requires:
+  - agent is installed,
+  - required environment variables are present,
+  - declared ports are available,
+  - agent is not in crash-loop cooldown.
+- `Stop` executes the manifest stop command and marks runtime as `stopped` on success.
+- Graceful-stop timeout / force-kill fallback are delegated to the runtime command implementation (or external supervisor such as systemd); lifecycle service itself does not apply an extra kill timeout layer.
+- If a start command fails, runtime transitions to `crashing` and health to `unhealthy`.
+
+## Crash-loop detection and cooldown
+
+Default crash-loop policy:
+- threshold: `3` restarts
+- window: `5m`
+- cooldown: `5m`
+
+Config/override keys:
+- `CARRIER_CRASH_THRESHOLD`
+- `CARRIER_CRASH_WINDOW`
+- `CARRIER_CRASH_COOLDOWN`
+
+State transitions:
+- repeated start failures within the window move runtime to `crashing`,
+- start attempts during cooldown return `ErrCrashLoop`,
+- after cooldown expires, start is allowed again.
+
+## Log location and diagnose artifacts
+
+Current implementation keeps per-agent command logs in an in-memory ring buffer (default limit: `1000` entries).
+
+Persistent log/artifact output is written when diagnose is requested:
+- default `diagnose_dir`: `<os temp dir>/agentd-diagnose` (if not overridden by `WithDiagnoseDir`)
+- artifact path pattern: `<diagnose_dir>/<agent>-diagnose-<UTC timestamp>.zip`
+- zip entries include:
+  - `logs.txt`
+  - `state.json`
+  - `manifest.json`
+  - `env.json` (redacted)
+  - `metadata.json`
+
+In the production deployment example, `diagnose_dir` is `/var/lib/carrier/diagnose`, so a typical file path is:
+- `/var/lib/carrier/diagnose/openclaw-diagnose-2026-02-14T04-20-00Z.zip`
+
+## Unexpected-exit troubleshooting
+
+If you see "process exited unexpectedly" or an agent exits immediately after start:
+
+1. Check status/runtime state:
+   - `/status <agent_id>`
+2. Fetch recent command logs:
+   - `/logs <agent_id> 200`
+3. Generate a redacted diagnose bundle:
+   - `/diagnose <agent_id>`
+4. Verify runtime prerequisites and required env vars for that manifest.
+5. If runtime is `crashing`, wait for cooldown expiry before retrying start.
+
+## Persistent lifecycle state and safe reset
+
+Lifecycle state fields (`install/runtime/health/last_error/updated_at`) are always available in memory and exported through diagnose/backup artifacts.
+
+Operational snapshot convention:
+- keep the latest exported state snapshot at `/var/lib/carrier/state.json` for operator-driven recovery workflows.
+
+Missing/corrupt snapshot handling:
+- treat snapshot as recoverable metadata,
+- rebuild runtime view from manifest registration + fresh status checks,
+- regenerate a new snapshot after service is stable.
+
+Safe local reset procedure:
+
+```bash
+sudo systemctl stop carrier-agentd
+sudo rm -f /var/lib/carrier/state.json
+sudo systemctl start carrier-agentd
+curl -s http://127.0.0.1:8081/healthz
+```
+
+Use the reset flow only for local troubleshooting or planned maintenance windows.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,8 @@ Related runbooks:
 - Pairing lifecycle troubleshooting: `docs/runbooks/pairing-lifecycle.md`
 - CI first response: `docs/ci/first-response-playbook.md`
 
+For lifecycle state transitions, crash-loop behavior, and operator troubleshooting, see `docs/daemon-lifecycle-runtime.md`.
+
 ## Prerequisites
 
 - **Go 1.22+** (build from source) or a pre-built binary

--- a/docs/e2e-parity-taxonomy.md
+++ b/docs/e2e-parity-taxonomy.md
@@ -1,0 +1,22 @@
+# Cross-Provider E2E Parity Taxonomy
+
+This document defines the parity assertion categories used for Telegram/Discord/Feishu command-path E2E tests.
+
+Reference implementation/tests:
+- `gateway/src/cross-provider.test.ts`
+- `docs/plans/phase1-e2e-test-matrix.md`
+
+## Categories
+
+| Category | Definition | Telegram/Discord/Feishu example | Assertion style |
+| --- | --- | --- | --- |
+| Request parsing parity | The same logical command must parse to the same command name and argument shape across providers. | `telegram 100 req-t /install openclaw`, `discord 100 req-d /install openclaw`, `feishu 100 req-f /install openclaw` all parse to `name="/install"` and `args=["openclaw"]`. | Normalized comparison (ignore `provider`, `chatId`, and `requestId`; compare `name` + `args`). |
+| Command normalization parity | Defaulting and argument normalization must be provider-agnostic. | `/logs openclaw` should resolve to the same default tail (`200`) for Telegram/Discord/Feishu before daemon call. | Exact match on normalized command intent (same defaulted values and downstream action). |
+| Response rendering parity | For the same command outcome, response envelope semantics must match across providers. | `/status` returns the same `result` and equivalent message semantics on all three providers. | Normalized comparison (ignore volatile fields such as `requestId`, `sessionToken`, `downloadUrl`). |
+| Error-shape parity | Error responses must keep a stable envelope and error code contract across providers. | Unpaired `/agents` must return `result="error"` and `errorCode="E_SESSION_REQUIRED"` for Telegram/Discord/Feishu. | Exact match on `result`, `errorCode`, and required error fields; message text should remain semantically equivalent. |
+
+## Assertion policy summary
+
+- Use exact assertions for stable contract fields (`result`, `errorCode`, required field presence).
+- Use normalized assertions for transport-specific or dynamic fields (`requestId`, generated tokens/URLs).
+- When in doubt, prefer asserting behavior-level equivalence over provider-specific string formatting.

--- a/docs/kanban-optimization.md
+++ b/docs/kanban-optimization.md
@@ -2,6 +2,8 @@
 
 该仓库已有看板自动同步：`.github/workflows/carrier-kanban-automation.yml`
 
+> 项目选择说明：当前流程按仓库/工作流上下文自动解析目标 Project，优先级为 `workflow input project_id` -> `CARRIER_PROJECT_ID` -> 仓库默认配置。文档示例不需要手工维护独立的项目 ID 字段。
+
 ## 一、已完成的自动化优化
 - Issue/PR 变化会同步到 GitHub Project。
 - 扩展了同步事件：

--- a/docs/plans/phase1-e2e-test-matrix.md
+++ b/docs/plans/phase1-e2e-test-matrix.md
@@ -7,6 +7,7 @@
 - Define a comprehensive E2E test matrix covering happy paths, failure paths, and memory operations.
 - Ensure every Phase 1 feature has at least one E2E test.
 - Produce a machine-readable run report after each test suite execution.
+- Use the shared parity categories from `docs/e2e-parity-taxonomy.md` when writing cross-provider assertions.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
This PR batches all currently open issues whose title starts with `docs` into one docs-only change set.

## What changed
- Expanded `CONTRIBUTING.md` with:
  - targeted test-run commands
  - CI failure first-response runbook (`gh pr checks`, `gh run view --log-failed`, required vs non-required checks)
  - installer single-source workflow + pre-merge checklist
  - label glossary (`P0/P1/Phase 1/enhancement/documentation/review-followup`)
- Added `docs/e2e-parity-taxonomy.md` and linked it from `docs/plans/phase1-e2e-test-matrix.md`.
- Added `docs/daemon-api-contract.md` with compact success/error examples and required/optional field notes.
- Added `docs/daemon-lifecycle-runtime.md` for lifecycle semantics, crash-loop behavior, log/artifact locations, and troubleshooting.
- Updated Kanban docs/README wording to clarify project resolution via workflow/repo context.
- Added cross-links from top-level docs so new sections are discoverable.

## #593 before/after snippet
Before:
- docs implied explicit per-doc project ID setup as required.

After:
- docs state target project resolution order is:
  1. workflow input `project_id`
  2. `CARRIER_PROJECT_ID`
  3. repository workflow/config default

## Verification
- `cd gateway && bun install --no-progress && bun run check && bun test` ✅
- `cd daemon && go test ./...` ⚠️ failed in this environment with macOS `dyld: missing LC_UUID load command` on generated test binaries (environment/runtime issue; unrelated to docs changes).

Closes #663
Closes #662
Closes #657
Closes #622
Closes #596
Closes #593
Closes #586
Closes #583
Closes #570
Closes #564
Closes #558
