### PR TITLE
chore(triage): add issue summary and review-followup duplicate detector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,54 @@ Phase milestones define delivery scope and must be respected in planning/review.
 
 Before proposing changes, read `skills/` and follow repository instructions (especially `skills/pr-review/SKILL.md` and `skills/review-followup/SKILL.md`).
 
+## Triage Helper Scripts
+
+From repo root, these scripts provide read-only issue triage summaries.
+
+### 1) Open issue summary
+
+```bash
+./scripts/triage/issue-summary.sh
+```
+
+Expected output sections:
+- `Total Open Issues`
+- `Open Unassigned Issues`
+- `Top Assignees by Open Count`
+- `Top Labels by Open Count`
+
+Optional env var:
+- `ISSUE_SUMMARY_LIMIT` (default `500`)
+
+### 2) Duplicate detector for review-followup issues
+
+```bash
+./scripts/triage/detect-review-followup-duplicates.sh
+```
+
+Matching priority (clear criteria):
+1. `nbs_marker` (exact hidden marker in issue body comment)
+2. `normalized_suggestion` (normalized text from `## Suggestion`)
+3. `normalized_title` (normalized title after stripping `[review-followup]` and `PR #...:` prefix)
+
+Optional env vars:
+- `ISSUE_DUP_STATE` (`open`/`closed`/`all`, default `open`)
+- `ISSUE_DUP_LIMIT` (default `500`)
+
+Deterministic output format example:
+
+```text
+Group 1 (2 issues)
+criterion: normalized_suggestion
+match_key: add focused unit tests for invalid consent flag parsing
+- #901 (PR #882): [review-followup] PR #882: Add focused unit tests...
+  https://github.com/Keith-CY/carrier/issues/901
+  snippet: Add focused unit tests for invalid consent flag parsing.
+- #905 (PR #882): [review-followup] PR #882: Add focused unit tests...
+  https://github.com/Keith-CY/carrier/issues/905
+  snippet: Add focused unit tests for invalid consent flag parsing.
+```
+
 ## Testing Policy
 
 GitHub Actions is the source of truth for merge readiness.

--- a/scripts/triage/detect-review-followup-duplicates.sh
+++ b/scripts/triage/detect-review-followup-duplicates.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state="${ISSUE_DUP_STATE:-open}"   # open | closed | all
+limit="${ISSUE_DUP_LIMIT:-500}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd gh
+require_cmd jq
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: gh is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+issues_json="$(
+  gh issue list \
+    --state "$state" \
+    --search "review-followup in:title" \
+    --limit "$limit" \
+    --json number,title,url,body
+)"
+
+groups_json="$(
+  printf '%s' "$issues_json" | jq '
+    def trim:
+      gsub("^\\s+|\\s+$"; "");
+    def normalize:
+      ascii_downcase
+      | gsub("`"; " ")
+      | gsub("\\[[^\\]]*\\]\\([^\\)]*\\)"; " ")
+      | gsub("[^a-z0-9]+"; " ")
+      | gsub("\\s+"; " ")
+      | trim;
+    def title_core:
+      (.title // "")
+      | sub("(?i)^\\[review-followup\\]\\s*"; "")
+      | sub("(?i)^pr\\s*#[0-9]+\\s*:\\s*"; "")
+      | trim;
+    def suggestion_text:
+      (.body // "")
+      | split("## Suggestion")
+      | if length > 1 then .[1] else "" end
+      | split("\n## ")
+      | .[0]
+      | gsub("(?m)^- \\[ \\]\\s*"; "")
+      | trim;
+    def nbs_marker:
+      try ((.body // "") | capture("<!--\\s*(?<key>nbs:[^>]+)\\s*-->").key) catch "";
+
+    map(select(((.title // "") | ascii_downcase) | contains("review-followup")))
+    | map(
+        . + {
+          source_pr: (try ((.title // "") | capture("(?i)PR\\s*#(?<pr>[0-9]+)").pr) catch ""),
+          nbs_key: nbs_marker,
+          suggestion_raw: suggestion_text,
+          suggestion_key: (suggestion_text | normalize),
+          title_key: (title_core | normalize)
+        }
+      )
+    | map(
+        . + {
+          criterion: (
+            if .nbs_key != "" then "nbs_marker"
+            elif .suggestion_key != "" then "normalized_suggestion"
+            else "normalized_title"
+            end
+          ),
+          duplicate_key: (
+            if .nbs_key != "" then .nbs_key
+            elif .suggestion_key != "" then .suggestion_key
+            else .title_key
+            end
+          )
+        }
+      )
+    | sort_by([.criterion, .duplicate_key, .number])
+    | group_by(.criterion + "::" + .duplicate_key)
+    | map(select(length > 1))
+    | map({
+        criterion: .[0].criterion,
+        match_key: .[0].duplicate_key,
+        count: length,
+        issues: map({
+          number,
+          title,
+          url,
+          source_pr,
+          snippet: (
+            if .suggestion_raw != "" then .suggestion_raw else .title end
+            | if length > 180 then (.[:177] + "...") else . end
+          )
+        })
+      })
+    | sort_by([-.count, .criterion, .match_key])
+  '
+)"
+
+echo "Review-Followup Duplicate Candidates"
+echo "Generated (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "State: $state"
+echo "Scan limit: $limit"
+echo
+echo "Matching priority:"
+echo "1) nbs_marker (exact hidden marker in issue body comment)"
+echo "2) normalized_suggestion (from ## Suggestion block)"
+echo "3) normalized_title (title after stripping [review-followup] and PR prefix)"
+echo
+
+group_count="$(printf '%s' "$groups_json" | jq 'length')"
+if [[ "$group_count" -eq 0 ]]; then
+  echo "No potential duplicates found."
+  exit 0
+fi
+
+printf '%s' "$groups_json" | jq -r '
+  to_entries[]
+  | "Group \(.key + 1) (\(.value.count) issues)\n"
+    + "criterion: \(.value.criterion)\n"
+    + "match_key: \(.value.match_key)\n"
+    + (
+      .value.issues
+      | map(
+          "- #\(.number) (PR #\((if .source_pr != \"\" then .source_pr else \"?\" end))): \(.title)\n  \(.url)\n  snippet: \(.snippet)"
+        )
+      | join("\n")
+    )
+    + "\n"
+'

--- a/scripts/triage/issue-summary.sh
+++ b/scripts/triage/issue-summary.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+limit="${ISSUE_SUMMARY_LIMIT:-500}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd gh
+require_cmd jq
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: gh is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+issues_json="$(gh issue list --state open --limit "$limit" --json number,assignees,labels)"
+total_open="$(printf '%s' "$issues_json" | jq 'length')"
+unassigned_open="$(printf '%s' "$issues_json" | jq '[.[] | select((.assignees | length) == 0)] | length')"
+top_assignees="$(
+  printf '%s' "$issues_json" | jq -r '
+    [ .[] | .assignees[]?.login ]
+    | group_by(.)
+    | map({name: .[0], count: length})
+    | sort_by(-.count, .name)
+    | .[:10]
+    | .[]
+    | "\(.count)\t\(.name)"
+  '
+)"
+top_labels="$(
+  printf '%s' "$issues_json" | jq -r '
+    [ .[] | .labels[]?.name ]
+    | group_by(.)
+    | map({name: .[0], count: length})
+    | sort_by(-.count, .name)
+    | .[:10]
+    | .[]
+    | "\(.count)\t\(.name)"
+  '
+)"
+
+echo "Issue Summary (open issues)"
+echo "Generated (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "Scan limit: $limit"
+echo
+echo "=== Total Open Issues ==="
+echo "$total_open"
+echo
+echo "=== Open Unassigned Issues ==="
+echo "$unassigned_open"
+echo
+echo "=== Top Assignees by Open Count ==="
+if [[ -n "$top_assignees" ]]; then
+  printf "%-7s %s\n" "count" "assignee"
+  while IFS=$'\t' read -r count assignee; do
+    printf "%-7s %s\n" "$count" "$assignee"
+  done <<<"$top_assignees"
+else
+  echo "(none)"
+fi
+echo
+echo "=== Top Labels by Open Count ==="
+if [[ -n "$top_labels" ]]; then
+  printf "%-7s %s\n" "count" "label"
+  while IFS=$'\t' read -r count label; do
+    printf "%-7s %s\n" "$count" "$label"
+  done <<<"$top_labels"
+else
+  echo "(none)"
+fi


### PR DESCRIPTION
## Summary
- add a read-only issue summary script at `scripts/triage/issue-summary.sh`
- add a read-only duplicate detector for `[review-followup]` issues at `scripts/triage/detect-review-followup-duplicates.sh`
- document both scripts in `CONTRIBUTING.md` with usage, output fields, and deterministic example format

## Verification
- `bash -n scripts/triage/issue-summary.sh scripts/triage/detect-review-followup-duplicates.sh`
- `./scripts/triage/issue-summary.sh`
- `./scripts/triage/detect-review-followup-duplicates.sh`

Closes #658
Closes #595
