### PR TITLE
fix: harden runtime decodeBody JSON parsing

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -491,16 +492,37 @@ type agentIDBody struct {
 }
 
 func decodeBody(w http.ResponseWriter, r *http.Request, v interface{}) bool {
-	// Cap request body to maxBodySize to prevent DoS.
+	if r.ContentLength > maxBodySize {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("request body too large: max %d bytes", maxBodySize))
+		return false
+	}
+
+	// Read with a hard cap so oversized bodies are rejected deterministically.
 	limited := io.LimitReader(r.Body, maxBodySize+1)
-	dec := json.NewDecoder(limited)
+	defer r.Body.Close()
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return false
+	}
+	if len(raw) > maxBodySize {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("request body too large: max %d bytes", maxBodySize))
+		return false
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: empty body")
+		return false
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(v); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return false
 	}
-	// Reject trailing JSON values (e.g. `{}{}`)
-	if dec.More() {
+	// Reject trailing JSON values (e.g. `{}{}`) and trailing garbage.
+	var trailing struct{}
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body: unexpected trailing data")
 		return false
 	}

--- a/daemon/cmd/agentd/main_test.go
+++ b/daemon/cmd/agentd/main_test.go
@@ -505,8 +505,18 @@ func TestDecodeBodyMalformed(t *testing.T) {
 			want400: true,
 		},
 		{
+			name:    "trailing JSON primitive",
+			body:    `{"agentId":"openclaw"} 123`,
+			want400: true,
+		},
+		{
 			name:    "empty body",
 			body:    ``,
+			want400: true,
+		},
+		{
+			name:    "whitespace body",
+			body:    "   \n\t  ",
 			want400: true,
 		},
 		{
@@ -526,6 +536,23 @@ func TestDecodeBodyMalformed(t *testing.T) {
 				t.Fatalf("status=%d, want400=%v; body=%s", rec.Code, tt.want400, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestDecodeBodyRejectsOversizedContentLengthHeader(t *testing.T) {
+	svc := lifecycle.NewService(baseagent.NoopTriager{})
+	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
+		t.Fatal(err)
+	}
+	mux := buildTestMux(svc, true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/install", strings.NewReader(`{"agentId":"openclaw"}`))
+	req.ContentLength = maxBodySize + 1
+
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want=400; body=%s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- addresses post-merge review on #1099: https://github.com/Keith-CY/carrier/pull/1099#discussion_r2816248228
- hardens runtime decodeBody used by legacy/active buildHTTPMux handlers
- enforces max body checks via both Content-Length and read cap
- rejects trailing JSON data via second decode (EOF check)
- keeps strict unknown-field rejection to preserve current API contract
- adds regression tests for trailing primitive payload, whitespace-only body, and oversized Content-Length

## Testing
- go test ./cmd/agentd
- go test ./internal/api
