### PR TITLE
fix: address review followup issues batch 6

### DIFF
--- a/scripts/triage/detect-review-followup-duplicates.ts
+++ b/scripts/triage/detect-review-followup-duplicates.ts
@@ -20,7 +20,7 @@ function normalizeTitle(title: string): string {
     .toLowerCase()
     .replace(/\[review-followup\]/g, "")
     .replace(/review-followup/g, "")
-    .replace(/^\s*pr\s*#\d+:\s*/g, "")
+    .replace(/^\s*pr\s*#\d+:\s*/, "")
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
## Summary

Address 7 review-followup issues from PRs #1130 and #1131.

### Code fix
- **#1134**: Remove redundant `g` flag from PR-reference regex in `detect-review-followup-duplicates.ts`. The regex already anchors with `^`, so the global flag was misleading. Dropped to clarify intent.

### Closed as approval-only (no code changes needed)
- **#1132**: Approval review comment
- **#1133**: Approval review comment
- **#1135**: Approval review comment
- **#1136**: Approval review comment

### Closed as already addressed
- **#1137**: `classify()` already evaluates HEAVY keywords before LIGHTWEIGHT keywords
- **#1138**: `rotateAuditLogIfNeeded()` already caps audit.jsonl at 10 MB with rotation

closes #1134