### PR TITLE
fix(security): redact secrets from POST /setup response

### DIFF
--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -155,11 +155,16 @@ export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): Gatew
           body.token,
           body.webhook_secret,
         );
+        // Redact sensitive fields in the response — never echo secrets back
+        const redacted = {
+          provider: config.provider,
+          configured_at: config.configured_at,
+        };
         return jsonResponse({
           requestId: ctx.requestId,
           result: "ok" as const,
           message: `provider ${body.provider} configured`,
-          provider: config,
+          provider: redacted,
         });
       } catch {
         return jsonResponse({


### PR DESCRIPTION
## Problem

The `GET /api/v1/setup` endpoint correctly redacts sensitive fields (token, webhook_secret), but the `POST /api/v1/setup` response echoes the full `ProviderConfig` back — including plaintext secrets.

Flagged in review of #1148.

## Fix

Redact the POST response to only return `provider` type and `configured_at`, consistent with the GET handler. Secrets are stored server-side but never echoed back to the client.

## Changes

- `gateway/src/server.ts`: Redact `token` and `webhook_secret` from POST /setup response