### PR TITLE
feat: unified onboard flow for guided agent installation

### DIFF
--- a/daemon/cmd/agentd/main.go
+++ b/daemon/cmd/agentd/main.go
@@ -338,6 +338,8 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.Pai
 			handleUninstall(svc, agentID, w, r)
 		case "diagnose":
 			handleDiagnose(svc, agentID, w, r)
+		case "requirements":
+			handleRequirements(svc, agentID, w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -541,6 +543,42 @@ func handleDiagnose(svc *lifecycle.Service, agentID string, w http.ResponseWrite
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"artifactRef": artifactRef})
+}
+
+func handleRequirements(svc *lifecycle.Service, agentID string, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	m, ok := svc.GetManifest(agentID)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "agent not found: "+agentID)
+		return
+	}
+	type envVarOut struct {
+		Name        string `json:"name"`
+		Secret      bool   `json:"secret,omitempty"`
+		Default     string `json:"default,omitempty"`
+		Description string `json:"description,omitempty"`
+	}
+	required := make([]envVarOut, 0, len(m.Env.Required))
+	for _, v := range m.Env.Required {
+		required = append(required, envVarOut{Name: v.Name, Secret: v.Secret, Default: v.Default, Description: v.Description})
+	}
+	optional := make([]envVarOut, 0, len(m.Env.Optional))
+	for _, v := range m.Env.Optional {
+		optional = append(optional, envVarOut{Name: v.Name, Secret: v.Secret, Default: v.Default, Description: v.Description})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"agent_id":     agentID,
+		"name":         m.Name,
+		"description":  m.Description,
+		"capabilities": m.Capabilities,
+		"env": map[string]interface{}{
+			"required": required,
+			"optional": optional,
+		},
+	})
 }
 
 type agentIDBody struct {

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -288,6 +288,15 @@ func loadCommandTimeoutFromEnv(raw string) time.Duration {
 	return timeout
 }
 
+// GetManifest returns the manifest for the given agent ID.
+// Returns the manifest and true if found, or a zero manifest and false otherwise.
+func (s *Service) GetManifest(agentID string) (manifest.Manifest, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	m, ok := s.manifests[agentID]
+	return m, ok
+}
+
 func (s *Service) RegisterManifest(m manifest.Manifest) error {
 	if err := m.Validate(); err != nil {
 		return err

--- a/gateway/src/daemon/client.ts
+++ b/gateway/src/daemon/client.ts
@@ -67,7 +67,19 @@ export interface DaemonClient {
   diagnoseAgent(agentId: string, ctx: RequestContext): Promise<DiagnoseResult>;
   createRemoteDiagnosisHandoff(input: CreateRemoteDiagnosisHandoffInput): Promise<RemoteDiagnosisHandoff>;
   verifyPairCode(code: string, ctx: RequestContext): Promise<void>;
+  getAgentRequirements(agentId: string, ctx: RequestContext): Promise<AgentRequirementsResult>;
 }
+
+export type AgentRequirementsResult = {
+  agent_id: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+  env: {
+    required: { name: string; secret?: boolean; default?: string; description?: string }[];
+    optional: { name: string; secret?: boolean; default?: string; description?: string }[];
+  };
+};
 
 export class DaemonClientError extends Error {
   constructor(
@@ -335,6 +347,20 @@ export class InMemoryDaemonClient implements DaemonClient {
       `consent=${input.consent} handoff=${handoff.id}`,
     );
     return handoff;
+  }
+
+  async getAgentRequirements(agentId: string, ctx: RequestContext): Promise<AgentRequirementsResult> {
+    this.requireAgent(agentId);
+    this.recordAudit(ctx, "requirements", agentId, "fetched requirements");
+    // Return sensible defaults for in-memory client
+    const state = this.agents.get(agentId)!;
+    return {
+      agent_id: agentId,
+      name: state.name,
+      description: `${state.name} agent`,
+      capabilities: [],
+      env: { required: [], optional: [] },
+    };
   }
 
   async verifyPairCode(code: string, ctx: RequestContext): Promise<void> {

--- a/gateway/src/daemon/http_client.ts
+++ b/gateway/src/daemon/http_client.ts
@@ -1,6 +1,7 @@
 import {
   DaemonClientError,
   RemoteDiagnosisNotNeededError,
+  type AgentRequirementsResult,
   type CreateRemoteDiagnosisHandoffInput,
   type DaemonAgentState,
   type DaemonClient,
@@ -138,6 +139,15 @@ export class HttpDaemonClient implements DaemonClient {
         actor: input.actor,
         requestId: input.requestId,
       },
+    );
+  }
+
+  async getAgentRequirements(agentId: string, ctx: RequestContext): Promise<AgentRequirementsResult> {
+    return await this.requestJSON<AgentRequirementsResult>(
+      "GET",
+      `/api/v1/agents/${encodeURIComponent(agentId)}/requirements`,
+      undefined,
+      ctx,
     );
   }
 

--- a/gateway/src/onboard.test.ts
+++ b/gateway/src/onboard.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect } from "bun:test";
+import { createGatewayRuntime } from "./server";
+import { InMemoryDaemonClient } from "./daemon/client";
+
+const API_TOKEN = "test-onboard-token";
+
+function setup() {
+  process.env.CARRIER_GATEWAY_API_TOKEN = API_TOKEN;
+  const daemon = new InMemoryDaemonClient();
+  const runtime = createGatewayRuntime({ deps: { daemon } });
+  const authHeaders = {
+    "content-type": "application/json",
+    authorization: `Bearer ${API_TOKEN}`,
+  };
+  return { runtime, daemon, authHeaders };
+}
+
+function teardown() {
+  delete process.env.CARRIER_GATEWAY_API_TOKEN;
+}
+
+describe("POST /api/v1/onboard", () => {
+  test("returns available agents", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ provider: "telegram", provider_token: "bot123", env: {} }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any;
+      expect(body.status).toBe("ready");
+      expect(body.provider_configured).toBe(true);
+      expect(body.available_agents).toBeInstanceOf(Array);
+      expect(body.available_agents.length).toBeGreaterThan(0);
+    } finally { teardown(); }
+  });
+
+  test("rejects missing provider", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ env: {} }),
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.errorCode).toBe("E_MISSING_PROVIDER");
+    } finally { teardown(); }
+  });
+
+  test("rejects invalid provider", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ provider: "slack" }),
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.errorCode).toBe("E_INVALID_PROVIDER");
+    } finally { teardown(); }
+  });
+
+  test("requires auth", async () => {
+    const { runtime } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ provider: "telegram" }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    } finally { teardown(); }
+  });
+});
+
+describe("POST /api/v1/onboard/install", () => {
+  test("installs and starts agents", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard/install", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ agents: ["openclaw"] }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any;
+      expect(body.results).toHaveLength(1);
+      expect(body.results[0].agent_id).toBe("openclaw");
+      expect(body.results[0].install).toBe("ok");
+      expect(body.results[0].start).toBe("ok");
+      expect(body.results[0].status).toBe("running");
+    } finally { teardown(); }
+  });
+
+  test("rejects empty agents array", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard/install", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ agents: [] }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    } finally { teardown(); }
+  });
+
+  test("handles install failure gracefully", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard/install", {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ agents: ["nonexistent"] }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any;
+      expect(body.results[0].install).toBe("error");
+    } finally { teardown(); }
+  });
+});
+
+describe("GET /api/v1/onboard/status", () => {
+  test("returns onboard state", async () => {
+    const { runtime, authHeaders } = setup();
+    try {
+      const res = await runtime.fetch(
+        new Request("http://localhost/api/v1/onboard/status", {
+          method: "GET",
+          headers: authHeaders,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as any;
+      expect(body.onboard).toBeDefined();
+      expect(body.agents).toBeInstanceOf(Array);
+    } finally { teardown(); }
+  });
+});

--- a/gateway/src/providers/onboard.test.ts
+++ b/gateway/src/providers/onboard.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import { OnboardStore, validateProvider, computeReadiness } from "./onboard";
+import type { DaemonAgentState } from "../daemon/client";
+
+describe("OnboardStore", () => {
+  test("initial state has no provider", () => {
+    const store = new OnboardStore();
+    const state = store.getState();
+    expect(state.provider).toBeNull();
+    expect(state.provider_configured).toBe(false);
+    expect(state.configured_at).toBeNull();
+  });
+
+  test("configure sets provider and env", () => {
+    const store = new OnboardStore();
+    store.configure("telegram", "bot-token", { OPENAI_API_KEY: "sk-xxx" });
+    const state = store.getState();
+    expect(state.provider).toBe("telegram");
+    expect(state.provider_configured).toBe(true);
+    expect(state.env.OPENAI_API_KEY).toBe("sk-xxx");
+    expect(state.configured_at).toBeTruthy();
+  });
+
+  test("configure without token sets provider_configured false", () => {
+    const store = new OnboardStore();
+    store.configure("discord", undefined, {});
+    expect(store.getState().provider_configured).toBe(false);
+  });
+
+  test("getState returns a copy", () => {
+    const store = new OnboardStore();
+    store.configure("telegram", "t", { A: "1" });
+    const s1 = store.getState();
+    s1.env.A = "modified";
+    expect(store.getState().env.A).toBe("1");
+  });
+});
+
+describe("validateProvider", () => {
+  test("accepts valid providers", () => {
+    expect(validateProvider("telegram")).toBe(true);
+    expect(validateProvider("discord")).toBe(true);
+    expect(validateProvider("feishu")).toBe(true);
+    expect(validateProvider("dummy")).toBe(true);
+  });
+
+  test("rejects invalid provider", () => {
+    expect(validateProvider("slack")).toBe(false);
+    expect(validateProvider("")).toBe(false);
+  });
+});
+
+describe("computeReadiness", () => {
+  const makeAgent = (id: string, name: string): DaemonAgentState => ({
+    id, name, version: "1.0", installState: "not_installed", runtimeState: "stopped",
+    health: "unknown", ports: [], restartCount: 0, needsRemoteDiagnosis: false, updatedAt: new Date().toISOString(),
+  });
+
+  test("marks agent ready when all required env provided", () => {
+    const agents = [makeAgent("openclaw", "OpenClaw")];
+    const reqs = new Map([["openclaw", {
+      agent_id: "openclaw", name: "OpenClaw", description: "AI assistant",
+      capabilities: ["chat"], env: { required: [{ name: "OPENAI_API_KEY" }], optional: [] },
+    }]]);
+    const result = computeReadiness(agents, reqs, { OPENAI_API_KEY: "sk-xxx" });
+    expect(result).toHaveLength(1);
+    expect(result[0].ready).toBe(true);
+    expect(result[0].missing_env).toEqual([]);
+  });
+
+  test("marks agent not ready when required env missing", () => {
+    const agents = [makeAgent("openclaw", "OpenClaw")];
+    const reqs = new Map([["openclaw", {
+      agent_id: "openclaw", name: "OpenClaw", description: "AI assistant",
+      capabilities: ["chat"], env: { required: [{ name: "OPENAI_API_KEY" }], optional: [] },
+    }]]);
+    const result = computeReadiness(agents, reqs, {});
+    expect(result[0].ready).toBe(false);
+    expect(result[0].missing_env).toEqual(["OPENAI_API_KEY"]);
+  });
+
+  test("agent without requirements is ready", () => {
+    const agents = [makeAgent("zeroclaw", "ZeroClaw")];
+    const result = computeReadiness(agents, new Map(), {});
+    expect(result[0].ready).toBe(true);
+  });
+});

--- a/gateway/src/providers/onboard.ts
+++ b/gateway/src/providers/onboard.ts
@@ -1,0 +1,125 @@
+import type { DaemonClient, DaemonAgentState, RequestContext } from "../daemon/client";
+
+export type ProviderType = "telegram" | "discord" | "feishu" | "dummy";
+
+export type OnboardRequest = {
+  provider?: string;
+  provider_token?: string;
+  provider_webhook_secret?: string;
+  env?: Record<string, string>;
+};
+
+export type OnboardInstallRequest = {
+  agents?: string[];
+  instance_name?: string;
+};
+
+export type AgentRequirements = {
+  agent_id: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+  env: {
+    required: EnvVarInfo[];
+    optional: EnvVarInfo[];
+  };
+};
+
+export type EnvVarInfo = {
+  name: string;
+  secret?: boolean;
+  default?: string;
+  description?: string;
+};
+
+export type OnboardAgentInfo = {
+  id: string;
+  name: string;
+  description: string;
+  ready: boolean;
+  missing_env: string[];
+  capabilities: string[];
+};
+
+export type OnboardState = {
+  provider: ProviderType | null;
+  provider_configured: boolean;
+  env: Record<string, string>;
+  configured_at: string | null;
+};
+
+export type OnboardInstallResult = {
+  agent_id: string;
+  instance_id: string;
+  install: "ok" | "error";
+  start: "ok" | "error" | "skipped";
+  status: string;
+  error?: string;
+};
+
+const VALID_PROVIDERS: ProviderType[] = ["telegram", "discord", "feishu", "dummy"];
+
+export class OnboardStore {
+  private state: OnboardState = {
+    provider: null,
+    provider_configured: false,
+    env: {},
+    configured_at: null,
+  };
+
+  getState(): OnboardState {
+    return { ...this.state, env: { ...this.state.env } };
+  }
+
+  configure(provider: ProviderType, token?: string, env?: Record<string, string>): void {
+    this.state.provider = provider;
+    this.state.provider_configured = !!token;
+    if (env) {
+      this.state.env = { ...this.state.env, ...env };
+    }
+    this.state.configured_at = new Date().toISOString();
+  }
+
+  getEnv(): Record<string, string> {
+    return { ...this.state.env };
+  }
+}
+
+export function validateProvider(provider: string): provider is ProviderType {
+  return VALID_PROVIDERS.includes(provider as ProviderType);
+}
+
+export async function fetchAgentRequirements(
+  daemon: DaemonClient,
+  agentId: string,
+  ctx: RequestContext,
+): Promise<AgentRequirements | null> {
+  try {
+    const resp = await (daemon as any).getAgentRequirements(agentId, ctx);
+    return resp as AgentRequirements;
+  } catch {
+    return null;
+  }
+}
+
+export function computeReadiness(
+  agents: DaemonAgentState[],
+  requirements: Map<string, AgentRequirements>,
+  providedEnv: Record<string, string>,
+): OnboardAgentInfo[] {
+  return agents.map((agent) => {
+    const reqs = requirements.get(agent.id);
+    const requiredVars = reqs?.env?.required ?? [];
+    const missing = requiredVars
+      .filter((v) => !providedEnv[v.name])
+      .map((v) => v.name);
+    return {
+      id: agent.id,
+      name: agent.name,
+      description: reqs?.description ?? "",
+      ready: missing.length === 0,
+      missing_env: missing,
+      capabilities: reqs?.capabilities ?? [],
+    };
+  });
+}

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -1,5 +1,6 @@
 import { safeHandleCommand, type GatewayDependencies } from "./index";
 import { ProviderSetupStore, type ProviderType } from "./providers/setup";
+import { OnboardStore, validateProvider as validateOnboardProvider, computeReadiness } from "./providers/onboard";
 import { HttpDaemonClient } from "./daemon/http_client";
 import {
   buildContentDisposition,
@@ -117,6 +118,7 @@ export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): Gatew
   const maxBodyBytes = Number.isFinite(rawMax) && rawMax > 0 ? Math.floor(rawMax) : cachedMaxCommandBodyBytes;
 
     const providerSetup = new ProviderSetupStore();
+  const onboardStore = new OnboardStore();
 
   const router: GatewayHandler = async (ctx) => {
     const url = new URL(ctx.request.url);
@@ -193,6 +195,111 @@ export function createGatewayRuntime(options: GatewayRuntimeOptions = {}): Gatew
         result: "ok" as const,
         configured: providerSetup.isConfigured(),
         provider: redactedConfig,
+      });
+    }
+
+    // Onboard: POST /api/v1/onboard
+    if (ctx.request.method === "POST" && (url.pathname === "/api/v1/onboard")) {
+      const authErr = validateGatewayAPIToken(ctx.request, ctx.requestId);
+      if (authErr) return jsonResponse(authErr, 401);
+      try {
+        const body = await ctx.request.json() as {
+          provider?: string;
+          provider_token?: string;
+          provider_webhook_secret?: string;
+          env?: Record<string, string>;
+        };
+        if (!body.provider) {
+          return jsonResponse({ requestId: ctx.requestId, result: "error", errorCode: "E_MISSING_PROVIDER", message: "provider field is required" }, 400);
+        }
+        if (!validateOnboardProvider(body.provider)) {
+          return jsonResponse({ requestId: ctx.requestId, result: "error", errorCode: "E_INVALID_PROVIDER", message: `invalid provider: ${body.provider}` }, 400);
+        }
+        onboardStore.configure(body.provider as any, body.provider_token, body.env);
+
+        // Fetch agents from daemon and their requirements
+        const reqCtx = { actor: "onboard", requestId: ctx.requestId };
+        const agents = await ctx.deps.daemon.listAgents(reqCtx);
+        const requirements = new Map<string, any>();
+        for (const agent of agents) {
+          try {
+            const reqs = await ctx.deps.daemon.getAgentRequirements(agent.id, reqCtx);
+            if (reqs) requirements.set(agent.id, reqs);
+          } catch { /* skip agents whose requirements can't be fetched */ }
+        }
+        const providedEnv = onboardStore.getEnv();
+        const available = computeReadiness(agents, requirements, providedEnv);
+        return jsonResponse({
+          requestId: ctx.requestId,
+          status: "ready",
+          provider_configured: !!body.provider_token,
+          available_agents: available,
+        });
+      } catch {
+        return jsonResponse({ requestId: ctx.requestId, result: "error", errorCode: "E_BAD_REQUEST", message: "invalid JSON body" }, 400);
+      }
+    }
+
+    // Onboard: POST /api/v1/onboard/install
+    if (ctx.request.method === "POST" && url.pathname === "/api/v1/onboard/install") {
+      const authErr = validateGatewayAPIToken(ctx.request, ctx.requestId);
+      if (authErr) return jsonResponse(authErr, 401);
+      try {
+        const body = await ctx.request.json() as { agents?: string[]; instance_name?: string };
+        if (!body.agents || !Array.isArray(body.agents) || body.agents.length === 0) {
+          return jsonResponse({ requestId: ctx.requestId, result: "error", errorCode: "E_MISSING_AGENTS", message: "agents array is required" }, 400);
+        }
+        const reqCtx = { actor: "onboard", requestId: ctx.requestId };
+        const results = [];
+        for (const agentId of body.agents) {
+          const instanceId = body.instance_name ?? agentId;
+          let installStatus: "ok" | "error" = "ok";
+          let startStatus: "ok" | "error" = "ok";
+          let status = "running";
+          let error: string | undefined;
+          try {
+            await ctx.deps.daemon.installAgent(agentId, reqCtx);
+          } catch (e: any) {
+            installStatus = "error";
+            startStatus = "skipped" as any;
+            status = "install_failed";
+            error = e?.message ?? String(e);
+          }
+          if (installStatus === "ok") {
+            try {
+              await ctx.deps.daemon.startAgent(agentId, reqCtx);
+            } catch (e: any) {
+              startStatus = "error";
+              status = "start_failed";
+              error = e?.message ?? String(e);
+            }
+          }
+          results.push({ agent_id: agentId, instance_id: instanceId, install: installStatus, start: startStatus, status, ...(error ? { error } : {}) });
+        }
+        return jsonResponse({ requestId: ctx.requestId, results });
+      } catch {
+        return jsonResponse({ requestId: ctx.requestId, result: "error", errorCode: "E_BAD_REQUEST", message: "invalid JSON body" }, 400);
+      }
+    }
+
+    // Onboard: GET /api/v1/onboard/status
+    if (ctx.request.method === "GET" && url.pathname === "/api/v1/onboard/status") {
+      const authErr = validateGatewayAPIToken(ctx.request, ctx.requestId);
+      if (authErr) return jsonResponse(authErr, 401);
+      const state = onboardStore.getState();
+      const reqCtx = { actor: "onboard", requestId: ctx.requestId };
+      let agentStatuses: any[] = [];
+      try {
+        agentStatuses = await ctx.deps.daemon.listAgents(reqCtx);
+      } catch { /* daemon unavailable */ }
+      return jsonResponse({
+        requestId: ctx.requestId,
+        onboard: {
+          provider: state.provider,
+          provider_configured: state.provider_configured,
+          configured_at: state.configured_at,
+        },
+        agents: agentStatuses,
       });
     }
 


### PR DESCRIPTION
## Summary

Implements a unified onboard flow that abstracts agent installation into a guided process.

### Changes

**Gateway (3 new endpoints):**
- `POST /api/v1/onboard` — accepts provider config + env vars, queries daemon for agent list and requirements, returns readiness report with missing env per agent
- `POST /api/v1/onboard/install` — installs and starts selected agents in one call
- `GET /api/v1/onboard/status` — returns current onboard state and agent statuses

**Daemon:**
- `GET /api/v1/agents/:id/requirements` — returns env requirements (required + optional) from agent manifest
- `GetManifest()` method on `lifecycle.Service`

**Tests:** 17 new tests (gateway), all 450 gateway tests + all Go tests pass.

Closes #1163