### PR TITLE
refactor(onboard): interactive step-by-step flow replacing subcommands

### DIFF
--- a/gateway/src/providers/onboard.test.ts
+++ b/gateway/src/providers/onboard.test.ts
@@ -21,62 +21,105 @@ function makeDeps() {
   };
 }
 
-describe("handleOnboardCommand", () => {
-  test("no args shows welcome with agent list", async () => {
+describe("handleOnboardCommand — interactive flow", () => {
+  test("no args shows welcome with agent list and starts session", async () => {
     const deps = makeDeps();
     const res = await handleOnboardCommand(makeCmd(), deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("Welcome to Carrier");
     expect(res.message).toContain("OpenClaw");
+    expect(res.message).toContain("Reply with the agent name");
   });
 
-  test("env sets a variable", async () => {
+  test("full interactive flow: select agent → env → confirm → install", async () => {
     const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["env", "OPENAI_API_KEY=sk-xxx"]), deps);
-    expect(res.result).toBe("ok");
-    expect(res.message).toContain("OPENAI_API_KEY set");
-    expect(deps.onboardStore.getEnv("telegram:chat-1").get("OPENAI_API_KEY")).toBe("sk-xxx");
+
+    // Step 1: Start session
+    const r1 = await handleOnboardCommand(makeCmd(), deps);
+    expect(r1.result).toBe("ok");
+    expect(r1.message).toContain("Welcome");
+
+    // Step 2: Select agent
+    const r2 = await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    expect(r2.result).toBe("ok");
+    expect(r2.message).toContain("Selected agent");
+    expect(r2.message).toContain("openclaw");
+
+    // Step 3: Provide env var
+    const r3 = await handleOnboardCommand(makeCmd(["OPENAI_API_KEY=sk-xxx"]), deps);
+    expect(r3.result).toBe("ok");
+    expect(r3.message).toContain("OPENAI_API_KEY set");
+
+    // Step 4: Done with env vars
+    const r4 = await handleOnboardCommand(makeCmd(["done"]), deps);
+    expect(r4.result).toBe("ok");
+    expect(r4.message).toContain("Ready to install");
+    expect(r4.message).toContain("OPENAI_API_KEY");
+
+    // Step 5: Confirm
+    const r5 = await handleOnboardCommand(makeCmd(["yes"]), deps);
+    expect(r5.result).toBe("ok");
+    expect(r5.message).toContain("openclaw installed and running");
   });
 
-  test("env without value returns usage error", async () => {
+  test("select agent then skip env vars", async () => {
     const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["env"]), deps);
-    expect(res.result).toBe("error");
-    expect(res.errorCode).toBe("E_USAGE");
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    const r = await handleOnboardCommand(makeCmd(["done"]), deps);
+    expect(r.result).toBe("ok");
+    expect(r.message).toContain("No environment variables set");
   });
 
-  test("install installs and starts agent", async () => {
+  test("select unknown agent returns error", async () => {
     const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["install", "openclaw"]), deps);
-    expect(res.result).toBe("ok");
-    expect(res.message).toContain("openclaw installed and running (healthy)");
-  });
-
-  test("install unknown agent returns error", async () => {
-    const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["install", "nonexistent"]), deps);
+    await handleOnboardCommand(makeCmd(), deps);
+    const res = await handleOnboardCommand(makeCmd(["nonexistent"]), deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_AGENT_NOT_FOUND");
   });
 
-  test("install without agent_id returns usage error", async () => {
+  test("cancel aborts active session", async () => {
     const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["install"]), deps);
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    const res = await handleOnboardCommand(makeCmd(["cancel"]), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("cancelled");
+  });
+
+  test("cancel with no active session is a no-op", async () => {
+    const deps = makeDeps();
+    const res = await handleOnboardCommand(makeCmd(["cancel"]), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("No active");
+  });
+
+  test("confirmation 'no' goes back to env step", async () => {
+    const deps = makeDeps();
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    await handleOnboardCommand(makeCmd(["done"]), deps);
+    const res = await handleOnboardCommand(makeCmd(["no"]), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("Going back");
+  });
+
+  test("invalid confirmation returns usage error", async () => {
+    const deps = makeDeps();
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    await handleOnboardCommand(makeCmd(["done"]), deps);
+    const res = await handleOnboardCommand(makeCmd(["maybe"]), deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
 
-  test("status shows agent states", async () => {
+  test("invalid env var format returns usage error", async () => {
     const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["status"]), deps);
-    expect(res.result).toBe("ok");
-    expect(res.message).toContain("Agent status:");
-    expect(res.message).toContain("OpenClaw");
-  });
-
-  test("unknown subcommand returns usage error", async () => {
-    const deps = makeDeps();
-    const res = await handleOnboardCommand(makeCmd(["unknown"]), deps);
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    const res = await handleOnboardCommand(makeCmd(["not-a-keyvalue"]), deps);
     expect(res.result).toBe("error");
     expect(res.errorCode).toBe("E_USAGE");
   });
@@ -84,9 +127,39 @@ describe("handleOnboardCommand", () => {
   test("install reports partial success when start fails", async () => {
     const deps = makeDeps();
     deps.daemon.simulateStartProbeFailure("openclaw");
-    const res = await handleOnboardCommand(makeCmd(["install", "openclaw"]), deps);
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    await handleOnboardCommand(makeCmd(["done"]), deps);
+    const res = await handleOnboardCommand(makeCmd(["yes"]), deps);
     expect(res.result).toBe("ok");
     expect(res.message).toContain("installed but failed to start");
+  });
+
+  test("status works anytime as standalone command", async () => {
+    const deps = makeDeps();
+    const res = await handleOnboardCommand(makeCmd(["status"]), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("Agent status:");
+    expect(res.message).toContain("OpenClaw");
+  });
+
+  test("agent shortcut without starting session first", async () => {
+    const deps = makeDeps();
+    // Directly provide agent name without `/onboard` first
+    const res = await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    expect(res.result).toBe("ok");
+    expect(res.message).toContain("Selected agent");
+  });
+
+  test("multiple env vars accumulate", async () => {
+    const deps = makeDeps();
+    await handleOnboardCommand(makeCmd(), deps);
+    await handleOnboardCommand(makeCmd(["openclaw"]), deps);
+    await handleOnboardCommand(makeCmd(["FOO=bar"]), deps);
+    await handleOnboardCommand(makeCmd(["BAZ=qux"]), deps);
+    const r = await handleOnboardCommand(makeCmd(["done"]), deps);
+    expect(r.message).toContain("FOO");
+    expect(r.message).toContain("BAZ");
   });
 });
 
@@ -110,5 +183,21 @@ describe("OnboardStore", () => {
   test("getEnv returns empty map for unknown key", () => {
     const store = new OnboardStore();
     expect(store.getEnv("unknown").size).toBe(0);
+  });
+
+  test("session lifecycle", () => {
+    const store = new OnboardStore();
+    expect(store.hasActiveSession("k1")).toBe(false);
+    store.startSession("k1");
+    expect(store.hasActiveSession("k1")).toBe(false); // idle is not active
+    store.updateSession("k1", { step: "agent_selected", selectedAgent: "openclaw" });
+    expect(store.hasActiveSession("k1")).toBe(true);
+    store.clearSession("k1");
+    expect(store.hasActiveSession("k1")).toBe(false);
+  });
+
+  test("getSession returns undefined for unknown key", () => {
+    const store = new OnboardStore();
+    expect(store.getSession("unknown")).toBeUndefined();
   });
 });

--- a/gateway/src/providers/onboard.ts
+++ b/gateway/src/providers/onboard.ts
@@ -3,27 +3,69 @@ import type { DaemonClient, DaemonAgentState, RequestContext } from "../daemon/c
 import { DaemonClientError } from "../daemon/client";
 
 /**
- * In-memory store for onboard session env vars.
+ * Session states for the interactive onboard flow.
+ */
+export type OnboardStep = "idle" | "agent_selected" | "env_configured" | "installing" | "done";
+
+export type OnboardSession = {
+  step: OnboardStep;
+  selectedAgent?: string;
+  envVars: Map<string, string>;
+};
+
+/**
+ * In-memory store for onboard session state.
  * Keyed by `${provider}:${chatId}`.
  */
 export class OnboardStore {
-  private envVars = new Map<string, Map<string, string>>();
+  private sessions = new Map<string, OnboardSession>();
 
-  setEnv(key: string, envName: string, envValue: string): void {
-    let vars = this.envVars.get(key);
-    if (!vars) {
-      vars = new Map();
-      this.envVars.set(key, vars);
+  getSession(key: string): OnboardSession | undefined {
+    return this.sessions.get(key);
+  }
+
+  startSession(key: string): OnboardSession {
+    const session: OnboardSession = { step: "idle", envVars: new Map() };
+    this.sessions.set(key, session);
+    return session;
+  }
+
+  updateSession(key: string, update: Partial<OnboardSession>): OnboardSession {
+    const session = this.sessions.get(key);
+    if (!session) {
+      throw new Error("no active session");
     }
-    vars.set(envName, envValue);
+    Object.assign(session, update);
+    return session;
+  }
+
+  clearSession(key: string): void {
+    this.sessions.delete(key);
+  }
+
+  hasActiveSession(key: string): boolean {
+    const session = this.sessions.get(key);
+    return !!session && session.step !== "idle" && session.step !== "done";
+  }
+
+  // Legacy compat helpers
+  setEnv(key: string, envName: string, envValue: string): void {
+    let session = this.sessions.get(key);
+    if (!session) {
+      session = this.startSession(key);
+    }
+    session.envVars.set(envName, envValue);
   }
 
   getEnv(key: string): Map<string, string> {
-    return this.envVars.get(key) ?? new Map();
+    return this.sessions.get(key)?.envVars ?? new Map();
   }
 
   clearEnv(key: string): void {
-    this.envVars.delete(key);
+    const session = this.sessions.get(key);
+    if (session) {
+      session.envVars = new Map();
+    }
   }
 }
 
@@ -32,6 +74,14 @@ export type OnboardDependencies = {
   onboardStore: OnboardStore;
 };
 
+/**
+ * Handle `/onboard` as an interactive step-by-step flow.
+ *
+ * - `/onboard` with no args: starts/continues the interactive session
+ * - `/onboard status`: standalone status check (works anytime)
+ * - `/onboard cancel`: abort the current session
+ * - `/onboard <text>`: routed as user reply in active session
+ */
 export async function handleOnboardCommand(
   cmd: GatewayCommand,
   deps: OnboardDependencies,
@@ -41,28 +91,35 @@ export async function handleOnboardCommand(
     requestId: cmd.requestId,
   };
   const sessionKey = `${cmd.provider}:${cmd.chatId}`;
-  const [subcommand, ...subArgs] = cmd.args;
+  const [firstArg, ...restArgs] = cmd.args;
 
   try {
-    if (!subcommand) {
-      return await showWelcome(cmd.requestId, deps.daemon, ctx);
+    // `/onboard status` always works regardless of session state
+    if (firstArg === "status") {
+      return await handleStatus(cmd.requestId, deps.daemon, ctx);
     }
 
-    switch (subcommand) {
-      case "env":
-        return handleEnv(cmd.requestId, subArgs, sessionKey, deps.onboardStore);
-      case "install":
-        return await handleInstall(cmd.requestId, subArgs, sessionKey, deps);
-      case "status":
-        return await handleStatus(cmd.requestId, deps.daemon, ctx);
-      default:
-        return {
-          requestId: cmd.requestId,
-          result: "error",
-          errorCode: "E_USAGE",
-          message: "usage: /onboard [env KEY=VALUE | install <agent_id> | status]",
-        };
+    // `/onboard cancel` aborts an active session
+    if (firstArg === "cancel") {
+      return handleCancel(cmd.requestId, sessionKey, deps.onboardStore);
     }
+
+    // No args → start a new session (show welcome, transition to awaiting agent selection)
+    if (!firstArg) {
+      return await startInteractiveSession(cmd.requestId, sessionKey, deps);
+    }
+
+    // If there's an active session, route the input as a reply
+    const session = deps.onboardStore.getSession(sessionKey);
+    if (session && session.step !== "idle" && session.step !== "done") {
+      return await handleSessionReply(cmd.requestId, sessionKey, cmd.args, deps, ctx);
+    }
+
+    // No active session and unrecognized arg → treat as agent selection shortcut
+    // Start session and immediately select the agent
+    deps.onboardStore.startSession(sessionKey);
+    deps.onboardStore.updateSession(sessionKey, { step: "idle" });
+    return await handleSessionReply(cmd.requestId, sessionKey, cmd.args, deps, ctx);
   } catch (error) {
     if (error instanceof DaemonClientError) {
       return {
@@ -81,12 +138,17 @@ export async function handleOnboardCommand(
   }
 }
 
-async function showWelcome(
+async function startInteractiveSession(
   requestId: string,
-  daemon: DaemonClient,
-  ctx: RequestContext,
+  sessionKey: string,
+  deps: OnboardDependencies,
 ): Promise<GatewayResponse> {
-  const agents = await daemon.listAgents(ctx);
+  const ctx: RequestContext = { actor: sessionKey, requestId };
+  const agents = await deps.daemon.listAgents(ctx);
+
+  // Start a fresh session
+  deps.onboardStore.startSession(sessionKey);
+
   const lines = ["🚀 Welcome to Carrier! Let's set up your agents.", ""];
   lines.push("Available agents:");
   for (let i = 0; i < agents.length; i++) {
@@ -95,10 +157,7 @@ async function showWelcome(
     lines.push(`${i + 1}. ${a.name} (${a.id})${stateTag}`);
   }
   lines.push("");
-  lines.push("Reply with:");
-  lines.push("/onboard install <agent_id> — install and start an agent");
-  lines.push("/onboard env <KEY>=<VALUE> — set environment variables");
-  lines.push("/onboard status — check agent states");
+  lines.push("Reply with the agent name to install (e.g. `/onboard openclaw`), or `/onboard cancel` to abort.");
 
   return {
     requestId,
@@ -107,60 +166,195 @@ async function showWelcome(
   };
 }
 
-function handleEnv(
+async function handleSessionReply(
   requestId: string,
-  args: string[],
   sessionKey: string,
-  store: OnboardStore,
-): GatewayResponse {
-  const pair = args.join(" ");
-  const eqIdx = pair.indexOf("=");
-  if (eqIdx <= 0) {
-    return {
-      requestId,
-      result: "error",
-      errorCode: "E_USAGE",
-      message: "usage: /onboard env <KEY>=<VALUE>",
-    };
+  args: string[],
+  deps: OnboardDependencies,
+  ctx: RequestContext,
+): Promise<GatewayResponse> {
+  const session = deps.onboardStore.getSession(sessionKey);
+  if (!session) {
+    // No session, start one
+    return await startInteractiveSession(requestId, sessionKey, deps);
   }
-  const envName = pair.slice(0, eqIdx).trim();
-  const envValue = pair.slice(eqIdx + 1).trim();
-  if (!envName || !envValue) {
-    return {
-      requestId,
-      result: "error",
-      errorCode: "E_USAGE",
-      message: "usage: /onboard env <KEY>=<VALUE>",
-    };
+
+  const input = args.join(" ").trim();
+
+  switch (session.step) {
+    case "idle":
+      // User is selecting an agent
+      return await handleAgentSelection(requestId, sessionKey, input, deps, ctx);
+
+    case "agent_selected":
+      // User is providing env vars
+      return handleEnvInput(requestId, sessionKey, input, deps.onboardStore);
+
+    case "env_configured":
+      // User is confirming install
+      return await handleConfirmation(requestId, sessionKey, input, deps, ctx);
+
+    case "installing":
+      return {
+        requestId,
+        result: "ok",
+        message: "⏳ Installation is in progress. Please wait...",
+      };
+
+    case "done":
+      return {
+        requestId,
+        result: "ok",
+        message: "✅ Onboarding is complete! Run `/onboard` to set up another agent, or `/onboard status` to check.",
+      };
+
+    default:
+      return {
+        requestId,
+        result: "error",
+        errorCode: "E_USAGE",
+        message: "Unexpected state. Run `/onboard` to start over.",
+      };
   }
-  store.setEnv(sessionKey, envName, envValue);
-  return {
-    requestId,
-    result: "ok",
-    message: `${envName} set. Ready to install agents.`,
-  };
 }
 
-async function handleInstall(
+async function handleAgentSelection(
   requestId: string,
-  args: string[],
   sessionKey: string,
+  agentId: string,
   deps: OnboardDependencies,
+  ctx: RequestContext,
 ): Promise<GatewayResponse> {
-  const [agentId] = args;
   if (!agentId) {
     return {
       requestId,
       result: "error",
       errorCode: "E_USAGE",
-      message: "usage: /onboard install <agent_id>",
+      message: "Please provide an agent name. Run `/onboard` to see available agents.",
     };
   }
 
-  const ctx: RequestContext = {
-    actor: sessionKey,
+  // Verify the agent exists
+  const agents = await deps.daemon.listAgents(ctx);
+  const agent = agents.find((a) => a.id === agentId);
+  if (!agent) {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_AGENT_NOT_FOUND",
+      message: `Agent "${agentId}" not found. Run \`/onboard\` to see available agents.`,
+    };
+  }
+
+  deps.onboardStore.updateSession(sessionKey, {
+    step: "agent_selected",
+    selectedAgent: agentId,
+  });
+
+  const lines = [
+    `Selected agent: **${agent.name}** (${agent.id})`,
+    "",
+    "Provide any environment variables as KEY=VALUE pairs (one per message).",
+    "When done, reply with `/onboard done`.",
+    "To skip env vars, reply `/onboard done` now.",
+  ];
+
+  return {
     requestId,
+    result: "ok",
+    message: lines.join("\n"),
   };
+}
+
+function handleEnvInput(
+  requestId: string,
+  sessionKey: string,
+  input: string,
+  store: OnboardStore,
+): GatewayResponse {
+  // "done" transitions to confirmation
+  if (input.toLowerCase() === "done") {
+    store.updateSession(sessionKey, { step: "env_configured" });
+    const session = store.getSession(sessionKey)!;
+    const envCount = session.envVars.size;
+    const envSummary = envCount > 0
+      ? `\nEnvironment variables: ${[...session.envVars.keys()].join(", ")}`
+      : "\nNo environment variables set.";
+
+    const lines = [
+      `Ready to install **${session.selectedAgent}**?${envSummary}`,
+      "",
+      "Reply `/onboard yes` to proceed or `/onboard no` to go back.",
+    ];
+
+    return {
+      requestId,
+      result: "ok",
+      message: lines.join("\n"),
+    };
+  }
+
+  // Parse KEY=VALUE
+  const eqIdx = input.indexOf("=");
+  if (eqIdx <= 0) {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_USAGE",
+      message: 'Please provide env vars as KEY=VALUE, or reply `/onboard done` to continue.',
+    };
+  }
+
+  const envName = input.slice(0, eqIdx).trim();
+  const envValue = input.slice(eqIdx + 1).trim();
+  if (!envName || !envValue) {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_USAGE",
+      message: 'Please provide env vars as KEY=VALUE, or reply `/onboard done` to continue.',
+    };
+  }
+
+  store.setEnv(sessionKey, envName, envValue);
+  return {
+    requestId,
+    result: "ok",
+    message: `✅ ${envName} set. Add more variables or reply \`/onboard done\` to continue.`,
+  };
+}
+
+async function handleConfirmation(
+  requestId: string,
+  sessionKey: string,
+  input: string,
+  deps: OnboardDependencies,
+  ctx: RequestContext,
+): Promise<GatewayResponse> {
+  const normalized = input.toLowerCase().trim();
+
+  if (normalized === "no" || normalized === "back") {
+    deps.onboardStore.updateSession(sessionKey, { step: "agent_selected" });
+    return {
+      requestId,
+      result: "ok",
+      message: "Going back. Provide env vars as KEY=VALUE, or reply `/onboard done` to continue.",
+    };
+  }
+
+  if (normalized !== "yes" && normalized !== "y") {
+    return {
+      requestId,
+      result: "error",
+      errorCode: "E_USAGE",
+      message: "Reply `/onboard yes` to install or `/onboard no` to go back.",
+    };
+  }
+
+  const session = deps.onboardStore.getSession(sessionKey)!;
+  const agentId = session.selectedAgent!;
+
+  deps.onboardStore.updateSession(sessionKey, { step: "installing" });
 
   // Install the agent
   await deps.daemon.installAgent(agentId, ctx);
@@ -169,7 +363,7 @@ async function handleInstall(
   try {
     await deps.daemon.startAgent(agentId, ctx);
   } catch (error) {
-    // If start fails, still report install success
+    deps.onboardStore.updateSession(sessionKey, { step: "done" });
     if (error instanceof DaemonClientError) {
       return {
         requestId,
@@ -180,15 +374,39 @@ async function handleInstall(
     throw error;
   }
 
-  // Get status to report health
+  // Get status
   const statuses = await deps.daemon.getStatus(agentId, ctx);
   const status = statuses[0];
   const health = status ? status.health : "unknown";
 
+  deps.onboardStore.updateSession(sessionKey, { step: "done" });
+
   return {
     requestId,
     result: "ok",
-    message: `${agentId} installed and running (${health})`,
+    message: `🎉 ${agentId} installed and running (${health}). Onboarding complete!`,
+  };
+}
+
+function handleCancel(
+  requestId: string,
+  sessionKey: string,
+  store: OnboardStore,
+): GatewayResponse {
+  const session = store.getSession(sessionKey);
+  if (!session || session.step === "idle" || session.step === "done") {
+    return {
+      requestId,
+      result: "ok",
+      message: "No active onboarding session to cancel.",
+    };
+  }
+
+  store.clearSession(sessionKey);
+  return {
+    requestId,
+    result: "ok",
+    message: "🚫 Onboarding cancelled. Run `/onboard` to start again.",
   };
 }
 


### PR DESCRIPTION
## Summary

Replace `/onboard` subcommands (env, install, welcome) with an interactive guided flow using a session state machine.

### State machine
`idle → agent_selected → env_configured → installing → done`

### Interactive flow
1. `/onboard` → Welcome message + agent list, asks user to pick one
2. `/onboard <agent>` → Selects agent, asks for env vars as KEY=VALUE
3. `/onboard done` → Confirms settings, asks yes/no
4. `/onboard yes` → Installs and starts agent, reports status
5. `/onboard cancel` → Aborts at any point

### Changes
- **OnboardStore** now tracks full session state (step, selected agent, env vars) with `hasActiveSession()`
- `/onboard status` remains a standalone command
- Legacy `setEnv/getEnv/clearEnv` helpers preserved for compatibility
- 14 new tests covering the interactive flow
- All 451 tests pass, Go daemon builds clean