### PR TITLE
ci: keep coverage report as single sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,9 +307,17 @@ jobs:
           marker='<!-- carrier-pr-coverage-report -->'
           pr='${{ github.event.pull_request.number }}'
           body=$(cat coverage-comment.md)
-          existing_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate             | jq -r --arg m "$marker" '.[] | select(.user.type=="Bot" and (.body | contains($m))) | .id'             | head -n1)
+          ids=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
+            | jq -r --arg m "$marker" '.[] | select(.body | contains($m)) | .id')
+          existing_id=$(printf '%s
+' "$ids" | sed '/^$/d' | head -n1)
           if [ -n "${existing_id:-}" ]; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -f body="$body" >/dev/null
+            # clean up accidental duplicates, keep only the first marker comment
+            printf '%s
+' "$ids" | sed '/^$/d' | tail -n +2 | while read -r extra_id; do
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${extra_id}" >/dev/null || true
+            done
           else
             gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" -f body="$body" >/dev/null
           fi


### PR DESCRIPTION
Ensures coverage report updates the same marker comment and removes accidental duplicates, so PR synchronize events do not create extra coverage comments.