### PR TITLE
feat: add desktop (carrier-gui) build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,31 +46,37 @@ jobs:
             label: linux-x64
             ext: ""
             archive_ext: zip
+            desktop_build: true
           - goos: linux
             goarch: arm64
             label: linux-arm64
             ext: ""
             archive_ext: zip
+            desktop_build: false
           - goos: darwin
             goarch: amd64
             label: darwin-x64
             ext: ""
             archive_ext: zip
+            desktop_build: false
           - goos: darwin
             goarch: arm64
             label: darwin-arm64
             ext: ""
             archive_ext: zip
+            desktop_build: false
           - goos: windows
             goarch: amd64
             label: windows-x64
             ext: ".exe"
             archive_ext: zip
+            desktop_build: false
           - goos: windows
             goarch: arm64
             label: windows-arm64
             ext: ".exe"
             archive_ext: zip
+            desktop_build: false
 
     steps:
       - name: Checkout
@@ -81,20 +87,49 @@ jobs:
         with:
           go-version-file: daemon/go.mod
 
+      - name: Install desktop (Gio) build dependencies
+        if: matrix.desktop_build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwayland-dev \
+            libx11-dev \
+            libx11-xcb-dev \
+            libxkbcommon-x11-dev \
+            libxkbcommon-dev \
+            libgles2-mesa-dev \
+            libegl1-mesa-dev \
+            libffi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxi-dev \
+            libxxf86vm-dev \
+            pkg-config
+
       - name: Build release package
         shell: bash
         run: |
           set -euo pipefail
           archive_name="carrier-${GITHUB_SHA}-${{ matrix.label }}"
           binary_name="agentd${{ matrix.ext }}"
+          gui_binary_name="carrier-gui${{ matrix.ext }}"
           release_dir="dist/${archive_name}"
           package_file="${archive_name}.${{ matrix.archive_ext }}"
 
           mkdir -p "${release_dir}"
 
+          # Build daemon (agentd) — pure Go, no CGO needed
           (cd daemon && \
             CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
               go build -trimpath -ldflags="-s -w" -o "../${release_dir}/${binary_name}" ./cmd/agentd)
+
+          # Build desktop GUI (carrier-gui) — requires CGO for Gio
+          if [[ "${{ matrix.desktop_build }}" == "true" ]]; then
+            (cd desktop && \
+              CGO_ENABLED=1 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+                go build -trimpath -ldflags="-s -w" -o "../${release_dir}/${gui_binary_name}" ./cmd/carrier-gui)
+          fi
 
           cp -R daemon catalog gateway docs README.md "${release_dir}/"
 


### PR DESCRIPTION
## Summary

Add Gio-based desktop GUI binary (`carrier-gui`) packaging to the release workflow, so release archives include both `agentd` and `carrier-gui`.

## Changes

- **Matrix flag**: Added `desktop_build` boolean to each matrix entry
- **System deps**: New step installs Gio/Wayland/X11 dev libraries (`libwayland-dev`, `libx11-dev`, `libxkbcommon-dev`, `libgles2-mesa-dev`, etc.) when `desktop_build` is true
- **Desktop build**: Builds `carrier-gui` from `desktop/cmd/carrier-gui/` with `CGO_ENABLED=1`
- **Archive**: `carrier-gui` is included alongside `agentd` in the release zip

## Platform Support

| Platform | agentd | carrier-gui | Notes |
|----------|--------|-------------|-------|
| linux-x64 | ✅ | ✅ | Native CGO on ubuntu runner |
| linux-arm64 | ✅ | ❌ | CGO cross-compile for arm64 needs cross-toolchain (`gcc-aarch64-linux-gnu` + arm64 sysroot). Can be added later. |
| darwin-x64 | ✅ | ❌ | Requires macOS SDK for CGO cross-compile (or macOS runner). |
| darwin-arm64 | ✅ | ❌ | Same — needs macOS runner or osxcross toolchain. |
| windows-x64 | ✅ | ❌ | Requires MinGW cross-compiler (`x86_64-w64-mingw32-gcc`). Can be added. |
| windows-arm64 | ✅ | ❌ | Very limited cross-compile support for Windows arm64 + CGO. |

## Future Work

- Add `windows-x64` desktop build using MinGW cross-compiler
- Add `linux-arm64` desktop build using `gcc-aarch64-linux-gnu`
- Use macOS runners for darwin desktop builds
- Consider a separate `build-desktop` job using platform-native runners

## Testing

- YAML syntax validated
- No changes to daemon build logic — existing agentd builds unaffected
- Desktop build only runs for linux-x64 matrix entry