### PR TITLE
fix(ci): coverage report showing 0% — artifact download path missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: daemon-coverage
+          path: daemon
 
       - name: Collect base branch coverage
         run: |


### PR DESCRIPTION
## Problem

Coverage Comment job always reports 0.00% because `download-artifact@v4` strips the common directory prefix by default. The artifact contains `daemon/coverage-func.txt`, but after download it lands as `coverage-func.txt` at workspace root. The parser looks for `daemon/coverage-func.txt` → not found → returns 0.0.

## Fix

Add `path: daemon` to the download step so files extract into `daemon/` directory where the parser expects them.