### PR TITLE
security(memory): enforce shared memory as read-only until ACL exists

### DIFF
--- a/daemon/internal/memory/coverage_test.go
+++ b/daemon/internal/memory/coverage_test.go
@@ -1332,15 +1332,15 @@ func TestListFilesEmpty(t *testing.T) {
 
 // ── AttachMemory with explicit mode ──
 
-func TestAttachMemorySharedExplicitRW(t *testing.T) {
+func TestAttachMemorySharedExplicitRWFailClosed(t *testing.T) {
 	s := newTestStore()
 	_, _ = s.Create("m1", "A", "1.0.0", TypeShared, "")
 	att, err := s.AttachMemory("agent-1", "m1", AttachOptions{Mode: AccessReadWrite})
 	if err != nil {
 		t.Fatalf("attach: %v", err)
 	}
-	if att.Mode != AccessReadWrite {
-		t.Fatalf("expected rw, got %s", att.Mode)
+	if att.Mode != AccessReadOnly {
+		t.Fatalf("expected ro (fail-closed), got %s", att.Mode)
 	}
 }
 

--- a/daemon/internal/memory/policy.go
+++ b/daemon/internal/memory/policy.go
@@ -72,10 +72,8 @@ func (p Policy) ResolveAccessMode(t Type, requested AccessMode) AccessMode {
 		return AccessReadOnly
 	}
 	if t == TypeShared {
-		// Shared memory can be writable only with explicit authorization.
-		if requested == AccessReadWrite {
-			return AccessReadWrite
-		}
+		// Fail-closed: shared memory is read-only until explicit RW authorization
+		// is implemented and wired through policy checks.
 		return AccessReadOnly
 	}
 	// per_agent — always rw

--- a/daemon/internal/memory/policy_test.go
+++ b/daemon/internal/memory/policy_test.go
@@ -31,7 +31,7 @@ func TestPolicyResolveAccessMode(t *testing.T) {
 		{TypePerAgent, AccessReadOnly, AccessReadWrite}, // always rw
 		{TypePerAgent, AccessReadWrite, AccessReadWrite},
 		{TypeShared, AccessReadOnly, AccessReadOnly},
-		{TypeShared, AccessReadWrite, AccessReadWrite}, // explicit authorization
+		{TypeShared, AccessReadWrite, AccessReadOnly}, // fail-closed until ACL is implemented
 		{TypePublic, AccessReadOnly, AccessReadOnly},
 		{TypePublic, AccessReadWrite, AccessReadOnly}, // forced ro
 	}


### PR DESCRIPTION
Implements issue #1219 with fail-closed semantics for shared memory access.\n\n## Changes\n- : shared memory now always resolves to \n- Updated policy tests for shared RW requests to expect \n- Updated coverage test to assert fail-closed behavior\n\n## Why\nCurrent code path allowed shared RW without any authorization gate. This change removes that unsafe path until explicit ACL/writer authorization is implemented.\n\n## Validation\n- ok  	carrier/daemon/internal/memory	(cached)