### PR TITLE
docs(memory): add TODO linking future ACL implementation to #1219

### DIFF
--- a/daemon/internal/memory/policy.go
+++ b/daemon/internal/memory/policy.go
@@ -74,6 +74,7 @@ func (p Policy) ResolveAccessMode(t Type, requested AccessMode) AccessMode {
 	if t == TypeShared {
 		// Fail-closed: shared memory is read-only until explicit RW authorization
 		// is implemented and wired through policy checks.
+		// TODO(acl): implement ACL-based write grants for shared memory (see #1219).
 		return AccessReadOnly
 	}
 	// per_agent — always rw


### PR DESCRIPTION
Adds a TODO comment in policy.go linking to #1219 for future ACL-based write grants on shared memory.

Closes #1229