### PR TITLE
docs: mark diverged plan docs as superseded with implementation pointers

### DIFF
--- a/docs/plans/memory-attach-detach-policy.md
+++ b/docs/plans/memory-attach-detach-policy.md
@@ -1,5 +1,9 @@
 # OpenClaw Memory Attach/Detach and Mount Policy Enforcement
 
+> **Status:** ⚠️ Superseded (diverged from implementation)
+>
+> **Note:** This plan describes REST APIs (`POST /agents/{agentId}/memory/attach`). The current implementation uses direct Go method calls (`Store.AttachMemory` / `Store.DetachMemory` in `daemon/internal/memory/store.go`) with policy enforcement in `policy.go`. Refer to the code as the source of truth.
+
 ## Overview
 
 This design covers instance-level memory attach/detach lifecycle APIs and strict mount-policy enforcement for the OpenClaw daemon. The goal is to ensure agents can only access memory stores they are explicitly granted, with clear failure modes for invalid requests.

--- a/docs/plans/memory-import-export-pipeline.md
+++ b/docs/plans/memory-import-export-pipeline.md
@@ -1,6 +1,8 @@
 # Memory Import/Export Pipeline and Artifact Delivery
 
-> **Issue:** #78 · **Status:** Plan · **Track:** B2 · **Depends on:** #77 (B1)
+> **Issue:** #78 · **Status:** ⚠️ Superseded (diverged from implementation) · **Track:** B2 · **Depends on:** #77 (B1)
+>
+> **Note:** This plan describes HTTP endpoints (`POST /api/v1/memory/import` with multipart/form-data). The current implementation uses local file path–based `ImportMemory` / `ExportMemory` Go methods (see `daemon/internal/memory/store.go`). Refer to the code as the source of truth.
 
 ## Goals
 

--- a/docs/plans/memory-package-specification.md
+++ b/docs/plans/memory-package-specification.md
@@ -1,6 +1,8 @@
 # Memory Package Specification and Validator
 
-> **Issue:** #77 · **Status:** Plan · **Track:** B1
+> **Issue:** #77 · **Status:** ⚠️ Superseded (diverged from implementation) · **Track:** B1
+>
+> **Note:** The schema described here (`id`, `version`, `type`, `owner`, `checksum`, `artifacts`) has diverged from the implemented code. The current implementation uses `PackageManifest` with `schema_version`, `region`, `kind`, `provenance`, `collections`, `mount` (see `daemon/internal/memory/mempack_types.go`). Refer to the code as the source of truth.
 
 ## Goals
 


### PR DESCRIPTION
Adds ⚠️ Superseded status headers to three plan docs that have diverged from the implemented code:

- `memory-package-specification.md` — schema fields differ from `PackageManifest` struct
- `memory-import-export-pipeline.md` — describes HTTP endpoints but implementation uses local file paths
- `memory-attach-detach-policy.md` — describes REST APIs but implementation uses direct Go methods

Each header points to the actual source files as the source of truth.

Closes #1222