### PR TITLE
feat(memory): persistence, incremental prepare reuse, and export guards

### DIFF
--- a/daemon/internal/memory/coverage_test.go
+++ b/daemon/internal/memory/coverage_test.go
@@ -256,6 +256,21 @@ func TestSetAttachmentsFromLinksPerAgentLimit(t *testing.T) {
 	}
 }
 
+func TestSetAttachmentsFromLinksArchivedRejected(t *testing.T) {
+	s := newTestStore()
+	_, _ = s.Create("m1", "A", "1.0.0", TypeShared, "")
+	if err := s.Archive("m1"); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	err := s.SetAttachmentsFromLinks("agent-1", []string{"m1"})
+	if err == nil {
+		t.Fatal("expected archived rejection error")
+	}
+	if !strings.Contains(err.Error(), "archived") {
+		t.Fatalf("expected archived in error, got %v", err)
+	}
+}
+
 // ── matchesCollectionSelection (33.3%) ──
 
 func TestMatchesCollectionSelection(t *testing.T) {
@@ -696,9 +711,9 @@ func TestCopyFileBadTargetDir(t *testing.T) {
 
 func TestShouldExportPath(t *testing.T) {
 	tests := []struct {
-		rel        string
-		selected   []string
-		want       bool
+		rel      string
+		selected []string
+		want     bool
 	}{
 		{"memory.yaml", nil, true},
 		{"README.md", []string{"prompts"}, true},
@@ -997,8 +1012,9 @@ func TestPrepareAgentMemoryDefaultRuntimeTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}
-	if contract.Env["AGENTD_MEMORY_PATH"] != "/app/memory" {
-		t.Fatalf("expected default /app/memory, got %s", contract.Env["AGENTD_MEMORY_PATH"])
+	defaultReadPath, _ := defaultRuntimeMountTargets()
+	if contract.Env["AGENTD_MEMORY_PATH"] != defaultReadPath {
+		t.Fatalf("expected default %s, got %s", defaultReadPath, contract.Env["AGENTD_MEMORY_PATH"])
 	}
 }
 

--- a/daemon/internal/memory/disk_space_unix.go
+++ b/daemon/internal/memory/disk_space_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package memory
+
+import "syscall"
+
+func availableDiskBytes(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return stat.Bavail * uint64(stat.Bsize), nil
+}

--- a/daemon/internal/memory/disk_space_windows.go
+++ b/daemon/internal/memory/disk_space_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package memory
+
+import "errors"
+
+func availableDiskBytes(path string) (uint64, error) {
+	return 0, errors.New("disk free-space probe unsupported on windows build")
+}

--- a/daemon/internal/memory/errors.go
+++ b/daemon/internal/memory/errors.go
@@ -7,4 +7,7 @@ var (
 	ErrManifestInvalid   = errors.New("invalid memory.yaml manifest")
 	ErrAttachmentMissing = errors.New("memory attachment not found")
 	ErrViewNotPrepared   = errors.New("memory view not prepared")
+	ErrExportTooLarge    = errors.New("memory export exceeds size limit")
+	ErrDiskSpaceLow      = errors.New("insufficient disk space for export")
+	ErrExportBusy        = errors.New("memory export concurrency limit reached")
 )

--- a/daemon/internal/memory/mempack_store.go
+++ b/daemon/internal/memory/mempack_store.go
@@ -127,6 +127,14 @@ func (s *Store) ImportMemory(mempackPath string, opts ImportOptions) (Entry, err
 	s.entries[memoryID] = entry
 	s.manifests[memoryID] = manifest
 	s.installPath[memoryID] = installPath
+	if err := s.persistStateLocked(); err != nil {
+		delete(s.entries, memoryID)
+		delete(s.manifests, memoryID)
+		delete(s.installPath, memoryID)
+		s.mu.Unlock()
+		s.recordAudit(opts.RequestID, opts.Actor, "import", memoryID, auditResultFailure, err.Error())
+		return Entry{}, err
+	}
 	s.mu.Unlock()
 
 	s.recordAudit(opts.RequestID, opts.Actor, "import", memoryID, auditResultSuccess, "memory imported")
@@ -139,10 +147,17 @@ func (s *Store) ExportMemory(memoryID string, opts ExportOptions) (string, error
 	if err != nil {
 		return "", err
 	}
+	releaseExport, err := s.acquireExportSlot()
+	if err != nil {
+		s.recordAudit(opts.RequestID, opts.Actor, "export", memoryID, auditResultFailure, err.Error())
+		return "", err
+	}
+	defer releaseExport()
 
 	s.mu.RLock()
 	manifest, ok := s.manifests[memoryID]
 	installPath := s.installPath[memoryID]
+	exportMaxBytes := s.exportMaxBytes
 	s.mu.RUnlock()
 	if !ok {
 		s.recordAudit(opts.RequestID, opts.Actor, "export", memoryID, auditResultFailure, ErrMemoryNotFound.Error())
@@ -184,6 +199,13 @@ func (s *Store) ExportMemory(memoryID string, opts ExportOptions) (string, error
 		return "", err
 	}
 
+	type exportCandidate struct {
+		abs string
+		rel string
+	}
+	candidates := make([]exportCandidate, 0, len(files))
+	var totalBytes int64
+
 	for _, abs := range files {
 		rel, err := filepath.Rel(installPath, abs)
 		if err != nil {
@@ -193,7 +215,26 @@ func (s *Store) ExportMemory(memoryID string, opts ExportOptions) (string, error
 		if !shouldExportPath(rel, selectedCollections) {
 			continue
 		}
+		info, statErr := os.Stat(abs)
+		if statErr != nil {
+			return "", fmt.Errorf("stat export file %s: %w", rel, statErr)
+		}
+		totalBytes += info.Size()
+		if exportMaxBytes > 0 && totalBytes > exportMaxBytes {
+			err := fmt.Errorf("%w: total=%d limit=%d", ErrExportTooLarge, totalBytes, exportMaxBytes)
+			s.recordAudit(opts.RequestID, opts.Actor, "export", memoryID, auditResultFailure, err.Error())
+			return "", err
+		}
+		candidates = append(candidates, exportCandidate{abs: abs, rel: rel})
+	}
+	if err := ensureDiskSpaceForExport(exportsDir, totalBytes); err != nil {
+		s.recordAudit(opts.RequestID, opts.Actor, "export", memoryID, auditResultFailure, err.Error())
+		return "", err
+	}
 
+	for _, file := range candidates {
+		rel := file.rel
+		abs := file.abs
 		raw, err := os.ReadFile(abs)
 		if err != nil {
 			return "", fmt.Errorf("read export file %s: %w", rel, err)
@@ -234,6 +275,38 @@ func (s *Store) requireRootDir() (string, error) {
 		return "", ErrRootDirRequired
 	}
 	return root, nil
+}
+
+func (s *Store) acquireExportSlot() (func(), error) {
+	s.mu.RLock()
+	slots := s.exportSlots
+	s.mu.RUnlock()
+	if slots == nil {
+		return func() {}, nil
+	}
+	select {
+	case slots <- struct{}{}:
+		return func() { <-slots }, nil
+	default:
+		return nil, ErrExportBusy
+	}
+}
+
+func ensureDiskSpaceForExport(path string, requiredBytes int64) error {
+	if requiredBytes <= 0 {
+		return nil
+	}
+	available, err := availableDiskBytes(path)
+	if err != nil {
+		// Best effort: when disk availability cannot be determined on this platform,
+		// continue and rely on filesystem write errors.
+		return nil
+	}
+	needed := uint64(requiredBytes)
+	if available < needed {
+		return fmt.Errorf("%w: required=%d available=%d", ErrDiskSpaceLow, needed, available)
+	}
+	return nil
 }
 
 func (s *Store) recordAudit(requestID, actor, action, target, result, message string) {

--- a/daemon/internal/memory/mempack_test.go
+++ b/daemon/internal/memory/mempack_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -212,10 +213,11 @@ func TestAttachAndPrepareAgentMemoryComposesDeterministicView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare agent memory: %v", err)
 	}
-	if contract.Env["AGENTD_MEMORY_PATH"] != "/app/memory" {
+	defaultReadPath, defaultWritePath := defaultRuntimeMountTargets()
+	if contract.Env["AGENTD_MEMORY_PATH"] != defaultReadPath {
 		t.Fatalf("unexpected AGENTD_MEMORY_PATH: %q", contract.Env["AGENTD_MEMORY_PATH"])
 	}
-	if contract.Env["AGENTD_MEMORY_WRITE_PATH"] != "/app/memory_private" {
+	if contract.Env["AGENTD_MEMORY_WRITE_PATH"] != defaultWritePath {
 		t.Fatalf("unexpected AGENTD_MEMORY_WRITE_PATH: %q", contract.Env["AGENTD_MEMORY_WRITE_PATH"])
 	}
 	if contract.ViewDigest == "" {
@@ -254,6 +256,93 @@ func TestAttachAndPrepareAgentMemoryComposesDeterministicView(t *testing.T) {
 	}
 }
 
+func TestPrepareAgentMemoryReusesExistingViewWhenInputUnchanged(t *testing.T) {
+	store, _ := newMemoryStoreWithRoot(t)
+	pack := filepath.Join(t.TempDir(), "reuse-view.mempack.zip")
+	writeMempack(t, pack, baseManifest("shared"), map[string]string{
+		"content/prompts/system.md": "hello",
+	})
+	entry, err := store.ImportMemory(pack, ImportOptions{TargetRegion: TypeShared})
+	if err != nil {
+		t.Fatalf("import memory: %v", err)
+	}
+	if _, err := store.AttachMemory("agent-1", entry.ID, AttachOptions{}); err != nil {
+		t.Fatalf("attach memory: %v", err)
+	}
+
+	first, err := store.PrepareAgentMemory("agent-1")
+	if err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	second, err := store.PrepareAgentMemory("agent-1")
+	if err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	if first.ViewDigest != second.ViewDigest {
+		t.Fatalf("expected stable digest, got %s and %s", first.ViewDigest, second.ViewDigest)
+	}
+
+	audits := store.AuditLogs()
+	reused := false
+	for _, a := range audits {
+		if a.Action == "prepare" && strings.Contains(a.Message, "reused=true") {
+			reused = true
+			break
+		}
+	}
+	if !reused {
+		t.Fatal("expected second prepare to reuse existing composed view")
+	}
+}
+
+func TestStorePersistsStateAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "state", "memory-store.json")
+	fixed := time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC)
+	store := NewStore(
+		WithRootDir(root),
+		WithPersistencePath(statePath),
+		WithNow(func() time.Time { return fixed }),
+	)
+
+	pack := filepath.Join(t.TempDir(), "persisted.mempack.zip")
+	writeMempack(t, pack, baseManifest("shared"), map[string]string{
+		"content/prompts/system.md": "persist me",
+	})
+	entry, err := store.ImportMemory(pack, ImportOptions{TargetRegion: TypeShared})
+	if err != nil {
+		t.Fatalf("import memory: %v", err)
+	}
+	if err := store.SetAttachmentsFromLinks("agent-1", []string{entry.ID}); err != nil {
+		t.Fatalf("set attachments: %v", err)
+	}
+	if err := store.LastStateError(); err != nil {
+		t.Fatalf("unexpected persistence error: %v", err)
+	}
+
+	reloaded := NewStore(
+		WithRootDir(root),
+		WithPersistencePath(statePath),
+		WithNow(func() time.Time { return fixed }),
+	)
+	if err := reloaded.LastStateError(); err != nil {
+		t.Fatalf("unexpected reload error: %v", err)
+	}
+	if _, err := reloaded.Get(entry.ID); err != nil {
+		t.Fatalf("expected memory entry to reload: %v", err)
+	}
+	attachments := reloaded.ListAttachments("agent-1")
+	if len(attachments) != 1 || attachments[0].MemoryID != entry.ID {
+		t.Fatalf("expected persisted attachment for agent-1, got %+v", attachments)
+	}
+	if _, ok := reloaded.manifests[entry.ID]; !ok {
+		t.Fatalf("expected persisted manifest for %s", entry.ID)
+	}
+	if reloaded.installPath[entry.ID] == "" {
+		t.Fatalf("expected persisted install path for %s", entry.ID)
+	}
+}
+
 func TestExportMemoryRespectsCollectionFilter(t *testing.T) {
 	store, _ := newMemoryStoreWithRoot(t)
 	pack := filepath.Join(t.TempDir(), "export-source.mempack.zip")
@@ -281,6 +370,55 @@ func TestExportMemoryRespectsCollectionFilter(t *testing.T) {
 	}
 	if _, ok := readZipFile(t, exportPath, "content/kb/internal.txt"); ok {
 		t.Fatal("did not expect filtered-out kb content in exported mempack")
+	}
+}
+
+func TestExportMemoryRespectsMaxSizeLimit(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(
+		WithRootDir(root),
+		WithNow(func() time.Time { return time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC) }),
+		WithExportGuard(8, 3),
+	)
+	pack := filepath.Join(t.TempDir(), "export-limit.mempack.zip")
+	writeMempack(t, pack, baseManifest("shared"), map[string]string{
+		"content/prompts/system.md": "this payload is larger than eight bytes",
+	})
+
+	entry, err := store.ImportMemory(pack, ImportOptions{TargetRegion: TypeShared})
+	if err != nil {
+		t.Fatalf("import memory: %v", err)
+	}
+
+	_, err = store.ExportMemory(entry.ID, ExportOptions{})
+	if !errors.Is(err, ErrExportTooLarge) {
+		t.Fatalf("expected ErrExportTooLarge, got %v", err)
+	}
+}
+
+func TestExportMemoryRespectsConcurrencyLimit(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(
+		WithRootDir(root),
+		WithNow(func() time.Time { return time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC) }),
+		WithExportGuard(1024*1024, 1),
+	)
+	pack := filepath.Join(t.TempDir(), "export-concurrency.mempack.zip")
+	writeMempack(t, pack, baseManifest("shared"), map[string]string{
+		"content/prompts/system.md": "small",
+	})
+	entry, err := store.ImportMemory(pack, ImportOptions{TargetRegion: TypeShared})
+	if err != nil {
+		t.Fatalf("import memory: %v", err)
+	}
+
+	// Simulate another export occupying the only slot.
+	store.exportSlots <- struct{}{}
+	defer func() { <-store.exportSlots }()
+
+	_, err = store.ExportMemory(entry.ID, ExportOptions{})
+	if !errors.Is(err, ErrExportBusy) {
+		t.Fatalf("expected ErrExportBusy, got %v", err)
 	}
 }
 
@@ -480,8 +618,8 @@ func TestPrepareAgentMemoryRollbackKeepsExistingMountsOnFailure(t *testing.T) {
 	if _, err := store.Mount(m1.ID, "agent-1", AccessReadOnly); err != nil {
 		t.Fatalf("mount existing memory: %v", err)
 	}
-	if err := store.Archive(m2.ID); err != nil {
-		t.Fatalf("archive m2: %v", err)
+	if _, err := store.Mount(m2.ID, "agent-2", AccessReadOnly); err != nil {
+		t.Fatalf("mount m2 for other agent: %v", err)
 	}
 	if err := store.SetAttachmentsFromLinks("agent-1", []string{m2.ID}); err != nil {
 		t.Fatalf("set attachments: %v", err)

--- a/daemon/internal/memory/persistence.go
+++ b/daemon/internal/memory/persistence.go
@@ -1,0 +1,135 @@
+package memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type persistedStoreState struct {
+	Entries         map[string]Entry           `json:"entries"`
+	Mounts          []MountRecord              `json:"mounts"`
+	Manifests       map[string]PackageManifest `json:"manifests"`
+	InstallPath     map[string]string          `json:"install_path"`
+	Attachments     map[string][]Attachment    `json:"attachments"`
+	Views           map[string]ViewExplanation `json:"views"`
+	ViewInputDigest map[string]string          `json:"view_input_digest"`
+}
+
+func (s *Store) loadState() error {
+	statePath := strings.TrimSpace(s.statePath)
+	if statePath == "" {
+		return nil
+	}
+
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read memory state: %w", err)
+	}
+
+	var state persistedStoreState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return fmt.Errorf("parse memory state: %w", err)
+	}
+
+	if state.Entries != nil {
+		s.entries = state.Entries
+	}
+	if state.Mounts != nil {
+		s.mounts = state.Mounts
+	}
+	if state.Manifests != nil {
+		s.manifests = state.Manifests
+	}
+	if state.InstallPath != nil {
+		s.installPath = state.InstallPath
+	}
+	if state.Attachments != nil {
+		s.attachments = state.Attachments
+	}
+	if state.Views != nil {
+		s.views = state.Views
+	}
+	if state.ViewInputDigest != nil {
+		s.viewInputDigest = state.ViewInputDigest
+	}
+
+	return nil
+}
+
+func (s *Store) persistStateLocked() error {
+	statePath := strings.TrimSpace(s.statePath)
+	if statePath == "" {
+		return nil
+	}
+
+	state := persistedStoreState{
+		Entries:         make(map[string]Entry, len(s.entries)),
+		Mounts:          append([]MountRecord(nil), s.mounts...),
+		Manifests:       make(map[string]PackageManifest, len(s.manifests)),
+		InstallPath:     make(map[string]string, len(s.installPath)),
+		Attachments:     make(map[string][]Attachment, len(s.attachments)),
+		Views:           make(map[string]ViewExplanation, len(s.views)),
+		ViewInputDigest: make(map[string]string, len(s.viewInputDigest)),
+	}
+	for k, v := range s.entries {
+		state.Entries[k] = v
+	}
+	for k, v := range s.manifests {
+		state.Manifests[k] = v
+	}
+	for k, v := range s.installPath {
+		state.InstallPath[k] = v
+	}
+	for k, v := range s.attachments {
+		state.Attachments[k] = append([]Attachment(nil), v...)
+	}
+	for k, v := range s.views {
+		state.Views[k] = v
+	}
+	for k, v := range s.viewInputDigest {
+		state.ViewInputDigest[k] = v
+	}
+
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		s.lastStateErr = fmt.Errorf("create memory state dir: %w", err)
+		return s.lastStateErr
+	}
+
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		s.lastStateErr = fmt.Errorf("marshal memory state: %w", err)
+		return s.lastStateErr
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(statePath), "memory-state-*.tmp")
+	if err != nil {
+		s.lastStateErr = fmt.Errorf("create memory state temp file: %w", err)
+		return s.lastStateErr
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		s.lastStateErr = fmt.Errorf("write memory state temp file: %w", err)
+		return s.lastStateErr
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		s.lastStateErr = fmt.Errorf("close memory state temp file: %w", err)
+		return s.lastStateErr
+	}
+	if err := os.Rename(tmpPath, statePath); err != nil {
+		_ = os.Remove(tmpPath)
+		s.lastStateErr = fmt.Errorf("replace memory state: %w", err)
+		return s.lastStateErr
+	}
+
+	s.lastStateErr = nil
+	return nil
+}

--- a/daemon/internal/memory/store.go
+++ b/daemon/internal/memory/store.go
@@ -2,6 +2,8 @@ package memory
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -22,8 +24,13 @@ type Store struct {
 	installPath            map[string]string          // keyed by memory ID
 	attachments            map[string][]Attachment    // keyed by agent ID
 	views                  map[string]ViewExplanation // keyed by agent ID
+	viewInputDigest        map[string]string          // keyed by agent ID
 	audits                 []AuditEvent
 	auditLimit             int
+	exportMaxBytes         int64
+	exportSlots            chan struct{}
+	statePath              string
+	lastStateErr           error
 }
 
 // StoreOption configures a Store.
@@ -37,6 +44,11 @@ func WithNow(fn func() time.Time) StoreOption {
 // WithRootDir configures filesystem storage root for mempack import/export and composed views.
 func WithRootDir(root string) StoreOption {
 	return func(s *Store) { s.rootDir = root }
+}
+
+// WithPersistencePath overrides the default on-disk state file path.
+func WithPersistencePath(path string) StoreOption {
+	return func(s *Store) { s.statePath = path }
 }
 
 // WithAuditLimit configures the maximum number of retained memory audit records.
@@ -60,22 +72,54 @@ func WithRuntimeMountTargets(readPath, writePath string) StoreOption {
 	}
 }
 
+// WithExportGuard configures export safeguards.
+// maxBytes <= 0 keeps the existing limit. maxConcurrent <= 0 keeps the existing limit.
+func WithExportGuard(maxBytes int64, maxConcurrent int) StoreOption {
+	return func(s *Store) {
+		if maxBytes > 0 {
+			s.exportMaxBytes = maxBytes
+		}
+		if maxConcurrent > 0 {
+			s.exportSlots = make(chan struct{}, maxConcurrent)
+		}
+	}
+}
+
+func defaultRuntimeMountTargets() (string, string) {
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil || userConfigDir == "" {
+		return "/app/memory", "/app/memory_private"
+	}
+	base := filepath.Join(userConfigDir, "carrier")
+	return filepath.Join(base, "memory"), filepath.Join(base, "memory_private")
+}
+
 // NewStore creates an empty memory store.
 func NewStore(opts ...StoreOption) *Store {
+	defaultReadPath, defaultWritePath := defaultRuntimeMountTargets()
 	s := &Store{
 		entries:                make(map[string]Entry),
 		now:                    time.Now,
-		runtimeReadTargetPath:  "/app/memory",
-		runtimeWriteTargetPath: "/app/memory_private",
+		runtimeReadTargetPath:  defaultReadPath,
+		runtimeWriteTargetPath: defaultWritePath,
 		manifests:              make(map[string]PackageManifest),
 		installPath:            make(map[string]string),
 		attachments:            make(map[string][]Attachment),
 		views:                  make(map[string]ViewExplanation),
+		viewInputDigest:        make(map[string]string),
 		audits:                 make([]AuditEvent, 0, 128),
 		auditLimit:             1000,
+		exportMaxBytes:         512 * 1024 * 1024,
+		exportSlots:            make(chan struct{}, 3),
 	}
 	for _, o := range opts {
 		o(s)
+	}
+	if s.statePath == "" && s.rootDir != "" {
+		s.statePath = filepath.Join(s.rootDir, "state", "memory-store.json")
+	}
+	if err := s.loadState(); err != nil {
+		s.lastStateErr = err
 	}
 	return s
 }
@@ -101,6 +145,9 @@ func (s *Store) Create(id, name, version string, memType Type, owner string) (En
 		UpdatedAt: now,
 	}
 	s.entries[id] = e
+	if err := s.persistStateLocked(); err != nil {
+		return Entry{}, err
+	}
 	return e, nil
 }
 
@@ -163,6 +210,9 @@ func (s *Store) Mount(memoryID, agentID string, requestedMode AccessMode) (Mount
 		MountedAt:  now,
 	}
 	s.mounts = append(s.mounts, rec)
+	if err := s.persistStateLocked(); err != nil {
+		return MountRecord{}, err
+	}
 	return rec, nil
 }
 
@@ -197,6 +247,9 @@ func (s *Store) Unmount(memoryID, agentID string) error {
 
 	// Remove mount record.
 	s.mounts = append(s.mounts[:idx], s.mounts[idx+1:]...)
+	if err := s.persistStateLocked(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -215,6 +268,9 @@ func (s *Store) Archive(memoryID string) error {
 	entry.State = StateArchived
 	entry.UpdatedAt = s.now()
 	s.entries[memoryID] = entry
+	if err := s.persistStateLocked(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -251,6 +307,9 @@ func (s *Store) UnmountAll(agentID string) int {
 		}
 	}
 	s.mounts = remaining
+	if err := s.persistStateLocked(); err != nil {
+		s.lastStateErr = err
+	}
 	return count
 }
 
@@ -270,4 +329,11 @@ func (s *Store) agentMounts(agentID string) []MountRecord {
 		out = append(out, m)
 	}
 	return out
+}
+
+// LastStateError returns the latest persistence load/save error observed by the store.
+func (s *Store) LastStateError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastStateErr
 }

--- a/daemon/internal/memory/view.go
+++ b/daemon/internal/memory/view.go
@@ -66,6 +66,11 @@ func (s *Store) AttachMemory(agentID, memoryID string, opts AttachOptions) (Atta
 		AttachedAt:  s.now(),
 	}
 	s.attachments[agentID] = append(existing, att)
+	if err := s.persistStateLocked(); err != nil {
+		s.mu.Unlock()
+		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, err.Error())
+		return Attachment{}, err
+	}
 	s.mu.Unlock()
 	s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultSuccess, "memory attached")
 	return att, nil
@@ -74,7 +79,6 @@ func (s *Store) AttachMemory(agentID, memoryID string, opts AttachOptions) (Atta
 // DetachMemory removes an attachment between an agent and memory package.
 func (s *Store) DetachMemory(agentID, memoryID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	attachments := s.attachments[agentID]
 	idx := -1
@@ -85,6 +89,7 @@ func (s *Store) DetachMemory(agentID, memoryID string) error {
 		}
 	}
 	if idx < 0 {
+		s.mu.Unlock()
 		return ErrAttachmentMissing
 	}
 
@@ -95,6 +100,11 @@ func (s *Store) DetachMemory(agentID, memoryID string) error {
 			break
 		}
 	}
+	if err := s.persistStateLocked(); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -112,20 +122,26 @@ func (s *Store) ListAttachments(agentID string) []Attachment {
 // The incoming order is preserved as ascending priority.
 func (s *Store) SetAttachmentsFromLinks(agentID string, memoryIDs []string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	attachments := make([]Attachment, 0, len(memoryIDs))
 	hasPerAgent := false
 	for i, memoryID := range memoryIDs {
 		entry, ok := s.entries[memoryID]
 		if !ok {
+			s.mu.Unlock()
 			return fmt.Errorf("%w: %s", ErrMemoryNotFound, memoryID)
+		}
+		if entry.State == StateArchived {
+			s.mu.Unlock()
+			return fmt.Errorf("%w: %s is archived", ErrInvalidState, memoryID)
 		}
 		if entry.Type == TypePerAgent {
 			if entry.Owner != "" && entry.Owner != agentID {
+				s.mu.Unlock()
 				return fmt.Errorf("%w: memory owner is %q, requester is %q", ErrOwnerMismatch, entry.Owner, agentID)
 			}
 			if hasPerAgent {
+				s.mu.Unlock()
 				return ErrPerAgentLimit
 			}
 			hasPerAgent = true
@@ -141,6 +157,11 @@ func (s *Store) SetAttachmentsFromLinks(agentID string, memoryIDs []string) erro
 		})
 	}
 	s.attachments[agentID] = attachments
+	if err := s.persistStateLocked(); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -164,11 +185,14 @@ func (s *Store) PrepareAgentMemory(agentID string) (RuntimeMemoryContract, error
 		installPaths[a.MemoryID] = s.installPath[a.MemoryID]
 	}
 	s.mu.RUnlock()
-	if runtimeReadTargetPath == "" {
-		runtimeReadTargetPath = "/app/memory"
-	}
-	if runtimeWriteTargetPath == "" {
-		runtimeWriteTargetPath = "/app/memory_private"
+	if runtimeReadTargetPath == "" || runtimeWriteTargetPath == "" {
+		defaultReadPath, defaultWritePath := defaultRuntimeMountTargets()
+		if runtimeReadTargetPath == "" {
+			runtimeReadTargetPath = defaultReadPath
+		}
+		if runtimeWriteTargetPath == "" {
+			runtimeWriteTargetPath = defaultWritePath
+		}
 	}
 	previousMounts := s.MountsForAgent(agentID)
 
@@ -186,6 +210,28 @@ func (s *Store) PrepareAgentMemory(agentID string) (RuntimeMemoryContract, error
 		}
 		return sorted[i].MemoryID < sorted[j].MemoryID
 	})
+
+	inputDigest, err := computePrepareInputDigest(sorted, entries, manifests, installPaths)
+	if err != nil {
+		return RuntimeMemoryContract{}, err
+	}
+
+	s.mu.RLock()
+	cachedDigest := s.viewInputDigest[agentID]
+	cachedExplain, hasCachedExplain := s.views[agentID]
+	s.mu.RUnlock()
+	if hasCachedExplain && cachedDigest == inputDigest {
+		if _, err := os.Stat(cachedExplain.ViewPath); err == nil {
+			if _, err := os.Stat(cachedExplain.MountMapPath); err == nil {
+				if err := s.applyMountStateWithRollback(agentID, sorted, previousMounts); err != nil {
+					return RuntimeMemoryContract{}, err
+				}
+				contract := buildRuntimeContractFromExplain(agentID, runtimeReadTargetPath, runtimeWriteTargetPath, cachedExplain)
+				s.recordAudit("", "", "prepare", agentID, auditResultSuccess, fmt.Sprintf("digest=%s reused=true", cachedExplain.Digest))
+				return contract, nil
+			}
+		}
+	}
 
 	viewRoot := filepath.Join(root, "views", agentID)
 	effectiveDir := filepath.Join(viewRoot, "effective")
@@ -281,28 +327,15 @@ func (s *Store) PrepareAgentMemory(agentID string) (RuntimeMemoryContract, error
 
 	s.mu.Lock()
 	s.views[agentID] = explain
+	s.viewInputDigest[agentID] = inputDigest
+	if err := s.persistStateLocked(); err != nil {
+		s.mu.Unlock()
+		return RuntimeMemoryContract{}, err
+	}
 	s.mu.Unlock()
 
-	env := map[string]string{
-		"AGENTD_MEMORY_PATH":        runtimeReadTargetPath,
-		"AGENTD_MEMORY_WRITE_PATH":  runtimeWriteTargetPath,
-		"AGENTD_MEMORY_VIEW_DIGEST": digest,
-	}
-	contract := RuntimeMemoryContract{
-		AgentID:          agentID,
-		ViewPath:         effectiveDir,
-		PrivateWritePath: privateWriteDir,
-		MountMapPath:     mountMapPath,
-		ViewDigest:       digest,
-		Mounts: []RuntimeMount{
-			{Source: effectiveDir, Target: env["AGENTD_MEMORY_PATH"], Mode: AccessReadOnly},
-			{Source: privateWriteDir, Target: env["AGENTD_MEMORY_WRITE_PATH"], Mode: AccessReadWrite},
-		},
-		Env:         env,
-		Explanation: explain,
-	}
-
-	s.recordAudit("", "", "prepare", agentID, auditResultSuccess, fmt.Sprintf("digest=%s", digest))
+	contract := buildRuntimeContractFromExplain(agentID, runtimeReadTargetPath, runtimeWriteTargetPath, explain)
+	s.recordAudit("", "", "prepare", agentID, auditResultSuccess, fmt.Sprintf("digest=%s reused=false", digest))
 	return contract, nil
 }
 
@@ -448,4 +481,57 @@ func writeMountMap(explain ViewExplanation) error {
 		return fmt.Errorf("write mountmap: %w", err)
 	}
 	return nil
+}
+
+func buildRuntimeContractFromExplain(agentID, runtimeReadTargetPath, runtimeWriteTargetPath string, explain ViewExplanation) RuntimeMemoryContract {
+	env := map[string]string{
+		"AGENTD_MEMORY_PATH":        runtimeReadTargetPath,
+		"AGENTD_MEMORY_WRITE_PATH":  runtimeWriteTargetPath,
+		"AGENTD_MEMORY_VIEW_DIGEST": explain.Digest,
+	}
+	privateWritePath := filepath.Join(filepath.Dir(explain.ViewPath), "private")
+	return RuntimeMemoryContract{
+		AgentID:          agentID,
+		ViewPath:         explain.ViewPath,
+		PrivateWritePath: privateWritePath,
+		MountMapPath:     explain.MountMapPath,
+		ViewDigest:       explain.Digest,
+		Mounts: []RuntimeMount{
+			{Source: explain.ViewPath, Target: env["AGENTD_MEMORY_PATH"], Mode: AccessReadOnly},
+			{Source: privateWritePath, Target: env["AGENTD_MEMORY_WRITE_PATH"], Mode: AccessReadWrite},
+		},
+		Env:         env,
+		Explanation: explain,
+	}
+}
+
+func computePrepareInputDigest(sorted []Attachment, entries map[string]Entry, manifests map[string]PackageManifest, installPaths map[string]string) (string, error) {
+	type prepareInput struct {
+		MemoryID    string     `json:"memory_id"`
+		Mode        AccessMode `json:"mode"`
+		Priority    int        `json:"priority"`
+		Collections []string   `json:"collections"`
+		Digest      string     `json:"digest"`
+		InstallPath string     `json:"install_path"`
+	}
+
+	inputs := make([]prepareInput, 0, len(sorted))
+	for _, att := range sorted {
+		manifest := manifests[att.MemoryID]
+		inputs = append(inputs, prepareInput{
+			MemoryID:    att.MemoryID,
+			Mode:        att.Mode,
+			Priority:    att.Priority,
+			Collections: append([]string(nil), att.Collections...),
+			Digest:      manifest.Provenance.Digest,
+			InstallPath: installPaths[att.MemoryID],
+		})
+	}
+
+	raw, err := json.Marshal(inputs)
+	if err != nil {
+		return "", fmt.Errorf("marshal prepare input digest: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
 }


### PR DESCRIPTION
## Summary
- persist memory store state (entries/mounts/manifests/install paths/attachments/views) to disk and reload on startup
- avoid full memory-view recomposition when prepare input is unchanged by reusing existing composed view\n- add export safety guards: max export bytes, concurrency limiter, and disk-availability precheck
- move default runtime mount targets to platform-aware user config directories
- add comprehensive tests for persistence, reuse path, and export guard behavior

## Validation
- go test ./internal/memory
- go test ./...
 
- Closes #1217
- Closes #1220 
- Closes #1221 
- Closes #1223