### PR TITLE
docs: add version prerequisites and relative link note

### DIFF
--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -33,3 +33,4 @@ Do not treat them as the implementation source of truth.
 
 - Keep unresolved work as tracked issues, not inline placeholders.
 - Keep this index updated when canonical architecture docs move.
+- Relative links in this file assume it lives in `docs/`. Update links if this file moves.


### PR DESCRIPTION
- Add minimum Go/Bun version note to quickstart prerequisites (closes #1265)
- Add relative link assumption note to architecture index (closes #1266)

Small docs followups from PR #1259 review.