### PR TITLE
fix(memory): fsync temp file before rename for crash-safety

### DIFF
--- a/daemon/internal/memory/persistence.go
+++ b/daemon/internal/memory/persistence.go
@@ -122,7 +122,7 @@ func (s *Store) persistStateLocked() error {
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
-		s.lastStateErr = fmt.Errorf("sync memory state temp file: %w", err)
+		s.lastStateErr = fmt.Errorf("fsync memory state temp file: %w", err)
 		return s.lastStateErr
 	}
 	if err := tmp.Close(); err != nil {


### PR DESCRIPTION
Add `tmp.Sync()` before `os.Rename()` to ensure data is flushed to disk before replacing the state file. Prevents data loss on ext4 with `data=writeback` mount option.

Closes #1262

Followup from PR #1261 review.