### PR TITLE
chore: resolve Gemini follow-up suggestions

### DIFF
--- a/daemon/internal/memory/disk_space_windows.go
+++ b/daemon/internal/memory/disk_space_windows.go
@@ -2,8 +2,45 @@
 
 package memory
 
-import "errors"
+import (
+	"fmt"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32DLL            = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExProc = kernel32DLL.NewProc("GetDiskFreeSpaceExW")
+)
 
 func availableDiskBytes(path string) (uint64, error) {
-	return 0, errors.New("disk free-space probe unsupported on windows build")
+	if path == "" {
+		path = "."
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return 0, fmt.Errorf("resolve disk space path: %w", err)
+	}
+	ptr, err := syscall.UTF16PtrFromString(absPath)
+	if err != nil {
+		return 0, fmt.Errorf("encode path for GetDiskFreeSpaceExW: %w", err)
+	}
+
+	var freeBytes uint64
+	r1, _, callErr := getDiskFreeSpaceExProc.Call(
+		uintptr(unsafe.Pointer(ptr)),
+		uintptr(unsafe.Pointer(&freeBytes)),
+		0,
+		0,
+	)
+	if r1 == 0 {
+		if callErr != syscall.Errno(0) {
+			return 0, fmt.Errorf("GetDiskFreeSpaceExW %s: %w", absPath, callErr)
+		}
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %s failed", absPath)
+	}
+
+	return freeBytes, nil
 }

--- a/daemon/internal/memory/mempack_test.go
+++ b/daemon/internal/memory/mempack_test.go
@@ -401,6 +401,13 @@ func TestPrepareAgentMemoryConcurrentSameAgent(t *testing.T) {
 			t.Fatalf("expected stable digest across concurrent prepares, got %s and %s", first, d)
 		}
 	}
+
+	store.prepareLocksMu.Lock()
+	activePrepareLocks := len(store.prepareLocks)
+	store.prepareLocksMu.Unlock()
+	if activePrepareLocks != 0 {
+		t.Fatalf("expected prepare lock map to be cleaned, got %d active locks", activePrepareLocks)
+	}
 }
 
 func TestExportMemoryRespectsCollectionFilter(t *testing.T) {

--- a/daemon/internal/memory/persistence.go
+++ b/daemon/internal/memory/persistence.go
@@ -119,6 +119,12 @@ func (s *Store) persistStateLocked() error {
 		s.lastStateErr = fmt.Errorf("write memory state temp file: %w", err)
 		return s.lastStateErr
 	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		s.lastStateErr = fmt.Errorf("sync memory state temp file: %w", err)
+		return s.lastStateErr
+	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		s.lastStateErr = fmt.Errorf("close memory state temp file: %w", err)

--- a/daemon/internal/memory/store.go
+++ b/daemon/internal/memory/store.go
@@ -31,7 +31,13 @@ type Store struct {
 	exportSlots            chan struct{}
 	statePath              string
 	lastStateErr           error
-	prepareLocks           sync.Map // keyed by agent ID, values are *sync.Mutex
+	prepareLocksMu         sync.Mutex
+	prepareLocks           map[string]*prepareLockEntry // keyed by agent ID
+}
+
+type prepareLockEntry struct {
+	mu   sync.Mutex
+	refs int
 }
 
 // StoreOption configures a Store.
@@ -112,6 +118,7 @@ func NewStore(opts ...StoreOption) *Store {
 		auditLimit:             1000,
 		exportMaxBytes:         512 * 1024 * 1024,
 		exportSlots:            make(chan struct{}, 3),
+		prepareLocks:           make(map[string]*prepareLockEntry),
 	}
 	for _, o := range opts {
 		o(s)
@@ -339,10 +346,29 @@ func (s *Store) LastStateError() error {
 	return s.lastStateErr
 }
 
-func (s *Store) prepareLockForAgent(agentID string) *sync.Mutex {
+func (s *Store) lockPrepareForAgent(agentID string) func() {
 	if agentID == "" {
 		agentID = "__default__"
 	}
-	lock, _ := s.prepareLocks.LoadOrStore(agentID, &sync.Mutex{})
-	return lock.(*sync.Mutex)
+
+	s.prepareLocksMu.Lock()
+	entry := s.prepareLocks[agentID]
+	if entry == nil {
+		entry = &prepareLockEntry{}
+		s.prepareLocks[agentID] = entry
+	}
+	entry.refs++
+	s.prepareLocksMu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+
+		s.prepareLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(s.prepareLocks, agentID)
+		}
+		s.prepareLocksMu.Unlock()
+	}
 }

--- a/daemon/internal/memory/view.go
+++ b/daemon/internal/memory/view.go
@@ -15,41 +15,42 @@ import (
 // AttachMemory binds a memory package to an agent with explicit mode and priority.
 func (s *Store) AttachMemory(agentID, memoryID string, opts AttachOptions) (Attachment, error) {
 	s.mu.Lock()
+	att, auditMessage, err := s.attachMemoryLocked(agentID, memoryID, opts)
+	s.mu.Unlock()
 
+	if err != nil {
+		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, auditMessage)
+		return Attachment{}, err
+	}
+	s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultSuccess, auditMessage)
+	return att, nil
+}
+
+func (s *Store) attachMemoryLocked(agentID, memoryID string, opts AttachOptions) (Attachment, string, error) {
 	entry, ok := s.entries[memoryID]
 	if !ok {
-		s.mu.Unlock()
-		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, ErrMemoryNotFound.Error())
-		return Attachment{}, ErrMemoryNotFound
+		return Attachment{}, ErrMemoryNotFound.Error(), ErrMemoryNotFound
 	}
 	if entry.State == StateArchived {
 		err := fmt.Errorf("cannot attach archived memory %s", memoryID)
-		s.mu.Unlock()
-		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, err.Error())
-		return Attachment{}, err
+		return Attachment{}, err.Error(), err
 	}
 
 	existing := s.attachments[agentID]
 	for _, a := range existing {
 		if a.MemoryID == memoryID {
-			s.mu.Unlock()
-			s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, ErrAlreadyMounted.Error())
-			return Attachment{}, ErrAlreadyMounted
+			return Attachment{}, ErrAlreadyMounted.Error(), ErrAlreadyMounted
 		}
 		if entry.Type == TypePerAgent && a.MemoryID != memoryID {
 			if e, ok := s.entries[a.MemoryID]; ok && e.Type == TypePerAgent {
-				s.mu.Unlock()
-				s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, ErrPerAgentLimit.Error())
-				return Attachment{}, ErrPerAgentLimit
+				return Attachment{}, ErrPerAgentLimit.Error(), ErrPerAgentLimit
 			}
 		}
 	}
 
 	if entry.Type == TypePerAgent && entry.Owner != "" && entry.Owner != agentID {
 		err := fmt.Errorf("%w: memory owner is %q, requester is %q", ErrOwnerMismatch, entry.Owner, agentID)
-		s.mu.Unlock()
-		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, err.Error())
-		return Attachment{}, err
+		return Attachment{}, err.Error(), err
 	}
 
 	effectiveMode := s.policy.DefaultAccessMode(entry.Type)
@@ -67,18 +68,15 @@ func (s *Store) AttachMemory(agentID, memoryID string, opts AttachOptions) (Atta
 	}
 	s.attachments[agentID] = append(existing, att)
 	if err := s.persistStateLocked(); err != nil {
-		s.mu.Unlock()
-		s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultFailure, err.Error())
-		return Attachment{}, err
+		return Attachment{}, err.Error(), err
 	}
-	s.mu.Unlock()
-	s.recordAudit(opts.RequestID, opts.Actor, "attach", memoryID, auditResultSuccess, "memory attached")
-	return att, nil
+	return att, "memory attached", nil
 }
 
 // DetachMemory removes an attachment between an agent and memory package.
 func (s *Store) DetachMemory(agentID, memoryID string) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	attachments := s.attachments[agentID]
 	idx := -1
@@ -89,7 +87,6 @@ func (s *Store) DetachMemory(agentID, memoryID string) error {
 		}
 	}
 	if idx < 0 {
-		s.mu.Unlock()
 		return ErrAttachmentMissing
 	}
 
@@ -101,10 +98,8 @@ func (s *Store) DetachMemory(agentID, memoryID string) error {
 		}
 	}
 	if err := s.persistStateLocked(); err != nil {
-		s.mu.Unlock()
 		return err
 	}
-	s.mu.Unlock()
 	return nil
 }
 
@@ -122,26 +117,23 @@ func (s *Store) ListAttachments(agentID string) []Attachment {
 // The incoming order is preserved as ascending priority.
 func (s *Store) SetAttachmentsFromLinks(agentID string, memoryIDs []string) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	attachments := make([]Attachment, 0, len(memoryIDs))
 	hasPerAgent := false
 	for i, memoryID := range memoryIDs {
 		entry, ok := s.entries[memoryID]
 		if !ok {
-			s.mu.Unlock()
 			return fmt.Errorf("%w: %s", ErrMemoryNotFound, memoryID)
 		}
 		if entry.State == StateArchived {
-			s.mu.Unlock()
 			return fmt.Errorf("%w: %s is archived", ErrInvalidState, memoryID)
 		}
 		if entry.Type == TypePerAgent {
 			if entry.Owner != "" && entry.Owner != agentID {
-				s.mu.Unlock()
 				return fmt.Errorf("%w: memory owner is %q, requester is %q", ErrOwnerMismatch, entry.Owner, agentID)
 			}
 			if hasPerAgent {
-				s.mu.Unlock()
 				return ErrPerAgentLimit
 			}
 			hasPerAgent = true
@@ -158,10 +150,8 @@ func (s *Store) SetAttachmentsFromLinks(agentID string, memoryIDs []string) erro
 	}
 	s.attachments[agentID] = attachments
 	if err := s.persistStateLocked(); err != nil {
-		s.mu.Unlock()
 		return err
 	}
-	s.mu.Unlock()
 	return nil
 }
 
@@ -169,9 +159,8 @@ func (s *Store) SetAttachmentsFromLinks(agentID string, memoryIDs []string) erro
 func (s *Store) PrepareAgentMemory(agentID string) (RuntimeMemoryContract, error) {
 	// Serialize per-agent prepares so concurrent callers cannot race on
 	// effective view filesystem state or mount rollback bookkeeping.
-	prepareLock := s.prepareLockForAgent(agentID)
-	prepareLock.Lock()
-	defer prepareLock.Unlock()
+	releasePrepareLock := s.lockPrepareForAgent(agentID)
+	defer releasePrepareLock()
 
 	root, err := s.requireRootDir()
 	if err != nil {

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -24,7 +24,7 @@ Use this before reading historical planning notes.
 The documents below are retained for design history.
 Do not treat them as the implementation source of truth.
 
-- [`docs/plans/adr-runtime-model.md`](./plans/adr-runtime-model.md) -> use `docs/phase1-runtime-adr.md`
+- [`docs/plans/adr-runtime-model.md`](./plans/adr-runtime-model.md) -> use `docs/phase1-runtime-adr.md` (relative path assumes this index stays under `docs/`)
 - [`docs/plans/memory-package-specification.md`](./plans/memory-package-specification.md) -> use `daemon/internal/memory/`
 - [`docs/plans/memory-import-export-pipeline.md`](./plans/memory-import-export-pipeline.md) -> use `docs/command-contract.md` and `daemon/internal/memory/store.go`
 - [`docs/plans/memory-attach-detach-policy.md`](./plans/memory-attach-detach-policy.md) -> use `daemon/internal/memory/policy.go` and `daemon/internal/lifecycle/memory.go`

--- a/docs/task-first-quickstart.md
+++ b/docs/task-first-quickstart.md
@@ -6,7 +6,8 @@ It is the fastest path from clean machine to a working first session.
 ## Task 1: 5-Minute First Setup
 
 Prerequisites:
-- Go and Bun installed
+- Go 1.23+ (matches `daemon/go.mod` / `toolchain go1.23.0`)
+- Bun 1.0+ (required by gateway validation scripts)
 - Repository cloned
 
 Commands:


### PR DESCRIPTION
## Summary
- add temp-file fsync before memory state rename for stronger crash safety
- implement real Windows free-space probe via GetDiskFreeSpaceExW
- refactor attachment lock/unlock flow to reduce manual unlock maintenance risk
- replace unbounded prepare lock sync.Map with ref-counted lock map that self-cleans
- add minimum Go/Bun notes in task-first quickstart
- annotate relative-link assumption in current architecture index

## Validation
- cd daemon && go test ./internal/memory
- cd daemon && go test ./...
- cd daemon && GOOS=windows GOARCH=amd64 go test ./internal/memory -c -o /tmp/memory_windows.test.exe

Closes #1262
Closes #1263
Closes #1264
Closes #1265
Closes #1266
Closes #1267