### PR TITLE
ci: fix coverage report baseline and enforce 3% product regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version-file: daemon/go.mod
+          go-version-file: go.mod
 
       - name: Download daemon coverage artifact
         uses: actions/download-artifact@v4
@@ -205,51 +205,198 @@ jobs:
           name: daemon-coverage
           path: daemon
 
+      - name: Collect head branch coverage
+        run: |
+          set -euo pipefail
+          go test ./... -coverprofile=coverage-root.out
+          (cd webui && go test ./... -coverprofile=coverage-webui.out)
+
       - name: Collect base branch coverage
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
-          git worktree add ../_base_cov "origin/${{ github.event.pull_request.base.ref }}"
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "${base_sha}"
+          git worktree add ../_base_cov "${base_sha}"
           trap 'git worktree remove -f ../_base_cov || true' EXIT
 
-          if [ -d ../_base_cov/daemon ]; then
-            (cd ../_base_cov/daemon && go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out > coverage-func.txt)
-          fi
+          (cd ../_base_cov && go test ./... -coverprofile=coverage-root.out)
+          (cd ../_base_cov/webui && go test ./... -coverprofile=coverage-webui.out)
+          (cd ../_base_cov/daemon && go test ./... -coverprofile=coverage.out)
+
+          cp ../_base_cov/coverage-root.out coverage-base-root.out
+          cp ../_base_cov/webui/coverage-webui.out coverage-base-webui.out
+          cp ../_base_cov/daemon/coverage.out coverage-base-daemon.out
 
       - name: Build markdown summary
+        id: coverage_summary
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           python3 - <<'PY2'
-          import re, pathlib
+          import os
+          import pathlib
+          import subprocess
 
-          def parse_go_total(path):
-            """Parse the 'total' line from 'go tool cover -func' output."""
-            p = pathlib.Path(path)
-            if not p.exists():
-              return 0.0
-            txt = p.read_text()
-            m = re.search(r'total:\s*\(statements\)\s*([0-9.]+)%', txt)
-            return float(m.group(1)) if m else 0.0
+          MODULES = [
+              {
+                  "key": "daemon",
+                  "label": "Daemon (Go)",
+                  "head_profile": "daemon/coverage.out",
+                  "base_profile": "coverage-base-daemon.out",
+              },
+              {
+                  "key": "root",
+                  "label": "Carrier Core (Go)",
+                  "head_profile": "coverage-root.out",
+                  "base_profile": "coverage-base-root.out",
+              },
+              {
+                  "key": "webui",
+                  "label": "WebUI (Go)",
+                  "head_profile": "coverage-webui.out",
+                  "base_profile": "coverage-base-webui.out",
+              },
+          ]
 
-          daemon = parse_go_total('daemon/coverage-func.txt')
-          base_daemon = parse_go_total('../_base_cov/daemon/coverage-func.txt')
+          def parse_coverprofile(path):
+              p = pathlib.Path(path)
+              if not p.exists():
+                  return {"exists": False, "total": 0, "covered": 0}
+
+              total = 0
+              covered = 0
+              for raw in p.read_text().splitlines():
+                  line = raw.strip()
+                  if not line or line.startswith("mode:"):
+                      continue
+                  parts = line.rsplit(" ", 2)
+                  if len(parts) != 3:
+                      continue
+                  try:
+                      stmts = int(parts[1])
+                      count = int(parts[2])
+                  except ValueError:
+                      continue
+                  total += stmts
+                  if count > 0:
+                      covered += stmts
+
+              return {"exists": True, "total": total, "covered": covered}
+
+          def pct(stats):
+              if stats["total"] == 0:
+                  return 0.0
+              return (stats["covered"] * 100.0) / stats["total"]
+
+          def changed_modules():
+              base_sha = os.environ.get("BASE_SHA", "").strip()
+              head_sha = os.environ.get("HEAD_SHA", "").strip()
+              if not base_sha or not head_sha:
+                  return []
+
+              try:
+                  output = subprocess.check_output(
+                      ["git", "diff", "--name-only", base_sha, head_sha],
+                      text=True,
+                  )
+              except subprocess.CalledProcessError:
+                  return []
+              files = [f.strip() for f in output.splitlines() if f.strip()]
+              selected = set()
+
+              for path in files:
+                  if path.startswith("daemon/"):
+                      selected.add("daemon")
+                      continue
+                  if path.startswith("webui/"):
+                      selected.add("webui")
+                      continue
+                  if (
+                      path.endswith(".go")
+                      or path in {"go.mod", "go.sum"}
+                      or path.startswith(("cmd/", "internal/", "pkg/"))
+                  ):
+                      selected.add("root")
+
+              order = ["daemon", "root", "webui"]
+              return [m for m in order if m in selected]
+
+          module_data = {}
+          for mod in MODULES:
+              head_stats = parse_coverprofile(mod["head_profile"])
+              base_stats = parse_coverprofile(mod["base_profile"])
+              head_pct = pct(head_stats)
+              base_pct = pct(base_stats)
+              module_data[mod["key"]] = {
+                  "label": mod["label"],
+                  "head": head_stats,
+                  "base": base_stats,
+                  "head_pct": head_pct,
+                  "base_pct": base_pct,
+                  "delta": head_pct - base_pct,
+              }
+
+          changed = changed_modules()
+          visible_modules = changed if changed else [m["key"] for m in MODULES]
+
+          product_head_total = sum(module_data[m["key"]]["head"]["total"] for m in MODULES)
+          product_head_covered = sum(module_data[m["key"]]["head"]["covered"] for m in MODULES)
+          product_base_total = sum(module_data[m["key"]]["base"]["total"] for m in MODULES)
+          product_base_covered = sum(module_data[m["key"]]["base"]["covered"] for m in MODULES)
+
+          product_head_pct = (product_head_covered * 100.0 / product_head_total) if product_head_total else 0.0
+          product_base_pct = (product_base_covered * 100.0 / product_base_total) if product_base_total else 0.0
+          product_delta = product_head_pct - product_base_pct
+
+          gate_triggered = product_delta <= -3.0
 
           marker = '<!-- carrier-pr-coverage-report -->'
           lines = [
-            marker,
-            '### 📊 Coverage Report',
-            '',
-            '| Module | Line Coverage | Δ vs base |',
-            '|---|---:|---:|',
-            f'| Daemon (Go) | {daemon:.2f}% | {(daemon-base_daemon):+.2f}% |',
-            '',
-            f'**Line coverage:** {daemon:.2f}%',
-            f'**Δ vs base:** {(daemon-base_daemon):+.2f}%',
+              marker,
+              '### 📊 Coverage Report',
+              '',
+              '#### 1) Module Coverage (PR Scope)',
+              '',
+              '| Module | Line Coverage | Δ vs base |',
+              '|---|---:|---:|',
           ]
-          if not pathlib.Path('../_base_cov/daemon/coverage-func.txt').exists():
-            lines += ['', '_Note: base branch daemon coverage file not found; base daemon treated as 0.00%._']
+          for key in visible_modules:
+              row = module_data[key]
+              lines.append(f'| {row["label"]} | {row["head_pct"]:.2f}% | {row["delta"]:+.2f}% |')
+
+          if not changed:
+              lines.extend([
+                  '',
+                  '_Note: No Go module changes detected in this PR; module section shows all Go modules._',
+              ])
+
+          lines.extend([
+              '',
+              '#### 2) Full Product Coverage',
+              '',
+              '| Scope | Line Coverage | Δ vs base |',
+              '|---|---:|---:|',
+              f'| Full Product (Go modules) | {product_head_pct:.2f}% | {product_delta:+.2f}% |',
+              '',
+              '**Policy:** request changes when full product coverage drops by 3.00% or more.',
+          ])
+
+          if gate_triggered:
+              lines.extend([
+                  '',
+                  f'**Coverage Gate:** Triggered (full product delta {product_delta:+.2f}%).',
+              ])
 
           pathlib.Path('coverage-comment.md').write_text('\n'.join(lines))
+          pathlib.Path('coverage-request-changes.txt').write_text('true' if gate_triggered else 'false')
+          pathlib.Path('coverage-product-delta.txt').write_text(f'{product_delta:+.2f}')
+          pathlib.Path('coverage-product-current.txt').write_text(f'{product_head_pct:.2f}')
           PY2
+
+          echo "request_changes=$(cat coverage-request-changes.txt)" >> "$GITHUB_OUTPUT"
+          echo "product_delta=$(cat coverage-product-delta.txt)" >> "$GITHUB_OUTPUT"
+          echo "product_current=$(cat coverage-product-current.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Create or update PR comment
         env:
@@ -282,6 +429,41 @@ jobs:
             # No existing comment found — create a new one.
             gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" -f body="$body" >/dev/null
           fi
+
+      - name: Request changes on major coverage regression
+        if: steps.coverage_summary.outputs.request_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pr='${{ github.event.pull_request.number }}'
+          head_sha='${{ github.event.pull_request.head.sha }}'
+          marker='<!-- carrier-pr-coverage-gate -->'
+          delta='${{ steps.coverage_summary.outputs.product_delta }}'
+          current='${{ steps.coverage_summary.outputs.product_current }}'
+
+          existing_id=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews" --paginate \
+            | jq -r --arg m "$marker" --arg sha "$head_sha" \
+              '[.[] | select((.body // "") | contains($m)) | select(.commit_id == $sha) | .id] | .[0] // empty')
+
+          if [ -n "${existing_id:-}" ]; then
+            echo "Coverage gate review already exists for this commit: $existing_id"
+            exit 0
+          fi
+
+          body=$(cat <<EOF
+$marker
+Coverage gate triggered.
+
+Full product (Go modules) coverage: ${current}% (${delta}% vs base).
+
+Policy: request changes when full product coverage drops by 3.00% or more.
+EOF
+)
+
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews" \
+            -f event=REQUEST_CHANGES \
+            -f body="$body" >/dev/null
 
   e2e-webui:
     name: WebUI E2E Tests


### PR DESCRIPTION
## Summary
- fix PR coverage report baseline calculation by collecting base coverage from the exact `base.sha` and copying profiles before worktree cleanup
- report two sections on every PR: PR-scope module coverage delta and full-product (all Go modules) coverage delta
- add coverage gate: when full-product coverage drops by 3.00% or more, automatically submit a `REQUEST_CHANGES` review (deduped per commit)

## Test Plan
- [x] `node --test scripts/ci/*.test.cjs`
- [x] validated coverage summary script behavior with synthetic cover profiles for both gate-pass and gate-fail scenarios
