### PR TITLE
fix(release): preserve .zip extension for PR test package downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,8 @@ jobs:
         id: upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: ${{ steps.build.outputs.archive_name }}
+          # Include .zip suffix in the artifact filename downloaded from the web UI.
+          name: ${{ steps.build.outputs.package_file }}
           retention-days: ${{ env.RELEASE_ARTIFACT_RETENTION_DAYS }}
           path: |
             dist/${{ steps.build.outputs.package_file }}
@@ -343,6 +344,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
       - name: Download PR metadata
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -354,25 +358,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          {
-            echo "<!-- carrier-pr-test-packages -->"
-            echo "## Test Packages"
-            echo
-            echo "- Commit: \`${GITHUB_SHA}\`"
-            echo "- Workflow run: [${GITHUB_RUN_ID}](${run_url})"
-            echo
-            echo "Download:"
-          } > pr-comment.md
-
-          while IFS= read -r file; do
-            label="$(jq -r '.label' "${file}")"
-            package_file="$(jq -r '.package_file' "${file}")"
-            artifact_id="$(jq -r '.artifact_id' "${file}")"
-            artifact_url="${run_url}/artifacts/${artifact_id}"
-            echo "- ${label}: [\`${package_file}\`](${artifact_url})" >> pr-comment.md
-          done < <(find pr-meta -type f -name '*.json' | sort)
+          node scripts/ci/pr-package-comment.cjs \
+            --metadata-dir pr-meta \
+            --repository "${GITHUB_REPOSITORY}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --commit-sha "${GITHUB_SHA}" \
+            --output pr-comment.md
 
       - name: Upsert PR comment
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/scripts/ci/pr-package-comment.cjs
+++ b/scripts/ci/pr-package-comment.cjs
@@ -1,0 +1,128 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const COMMENT_MARKER = "<!-- carrier-pr-test-packages -->";
+
+function listMetadataFiles(metadataDir) {
+  if (!fs.existsSync(metadataDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(metadataDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.join(metadataDir, entry.name))
+    .sort();
+}
+
+function parseMetadataFile(filePath) {
+  const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const label = String(raw.label || "").trim();
+  const packageFile = String(raw.package_file || "").trim();
+  const artifactId = String(raw.artifact_id || "").trim();
+
+  if (!label) {
+    throw new Error(`Missing "label" in ${filePath}`);
+  }
+  if (!packageFile) {
+    throw new Error(`Missing "package_file" in ${filePath}`);
+  }
+  if (!packageFile.endsWith(".zip")) {
+    throw new Error(`Expected "package_file" to end with .zip in ${filePath}, got "${packageFile}"`);
+  }
+  if (!artifactId || !/^\d+$/.test(artifactId)) {
+    throw new Error(`Invalid "artifact_id" in ${filePath}: "${artifactId}"`);
+  }
+
+  return {
+    label,
+    packageFile,
+    artifactId,
+  };
+}
+
+function loadPackageMetadata(metadataDir) {
+  const files = listMetadataFiles(metadataDir);
+  return files.map((filePath) => parseMetadataFile(filePath));
+}
+
+function buildPrPackagesComment({ repository, runId, commitSha, packages }) {
+  const repo = String(repository || "").trim();
+  const run = String(runId || "").trim();
+  const sha = String(commitSha || "").trim();
+
+  if (!repo) {
+    throw new Error("repository is required");
+  }
+  if (!run || !/^\d+$/.test(run)) {
+    throw new Error(`runId must be numeric, got "${runId}"`);
+  }
+  if (!sha) {
+    throw new Error("commitSha is required");
+  }
+
+  const runUrl = `https://github.com/${repo}/actions/runs/${run}`;
+  const lines = [
+    COMMENT_MARKER,
+    "## Test Packages",
+    "",
+    `- Commit: \`${sha}\``,
+    `- Workflow run: [${run}](${runUrl})`,
+    "",
+    "Download:",
+  ];
+
+  for (const item of packages) {
+    lines.push(`- ${item.label}: [\`${item.packageFile}\`](${runUrl}/artifacts/${item.artifactId})`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let idx = 2; idx < argv.length; idx += 2) {
+    const key = argv[idx];
+    const value = argv[idx + 1];
+    if (!key || !key.startsWith("--")) {
+      throw new Error(`Unexpected argument "${key}"`);
+    }
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for argument "${key}"`);
+    }
+    out[key.slice(2)] = value;
+  }
+  return out;
+}
+
+function runCli() {
+  const args = parseArgs(process.argv);
+  const metadataDir = args["metadata-dir"] || "pr-meta";
+  const repository = args.repository || process.env.GITHUB_REPOSITORY;
+  const runId = args["run-id"] || process.env.GITHUB_RUN_ID;
+  const commitSha = args["commit-sha"] || process.env.GITHUB_SHA;
+  const outputPath = args.output || "pr-comment.md";
+
+  const packages = loadPackageMetadata(metadataDir);
+  const comment = buildPrPackagesComment({
+    repository,
+    runId,
+    commitSha,
+    packages,
+  });
+  fs.writeFileSync(outputPath, comment);
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  COMMENT_MARKER,
+  buildPrPackagesComment,
+  listMetadataFiles,
+  loadPackageMetadata,
+  parseMetadataFile,
+};

--- a/scripts/ci/pr-package-comment.test.cjs
+++ b/scripts/ci/pr-package-comment.test.cjs
@@ -1,0 +1,83 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  COMMENT_MARKER,
+  buildPrPackagesComment,
+  loadPackageMetadata,
+} = require("./pr-package-comment.cjs");
+
+function withTempDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "carrier-pr-comment-"));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("loadPackageMetadata reads sorted metadata and enforces zip package names", () => {
+  withTempDir((dir) => {
+    fs.writeFileSync(
+      path.join(dir, "b.json"),
+      JSON.stringify({
+        label: "darwin-arm64",
+        package_file: "carrier-darwin-arm64.zip",
+        artifact_id: "22",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(dir, "a.json"),
+      JSON.stringify({
+        label: "darwin-x64",
+        package_file: "carrier-darwin-x64.zip",
+        artifact_id: "11",
+      }),
+    );
+
+    const metadata = loadPackageMetadata(dir);
+    assert.equal(metadata.length, 2);
+    assert.equal(metadata[0].artifactId, "11");
+    assert.equal(metadata[1].artifactId, "22");
+  });
+});
+
+test("loadPackageMetadata fails when package_file does not end with .zip", () => {
+  withTempDir((dir) => {
+    fs.writeFileSync(
+      path.join(dir, "bad.json"),
+      JSON.stringify({
+        label: "linux-x64",
+        package_file: "carrier-linux-x64",
+        artifact_id: "9",
+      }),
+    );
+
+    assert.throws(() => loadPackageMetadata(dir), /end with \.zip/);
+  });
+});
+
+test("buildPrPackagesComment renders markdown body with artifact links", () => {
+  const body = buildPrPackagesComment({
+    repository: "Keith-CY/carrier",
+    runId: "22252074017",
+    commitSha: "38695c9610c2592d729cc566fa2b3619e0841905",
+    packages: [
+      { label: "darwin-arm64", packageFile: "carrier-darwin-arm64.zip", artifactId: "5600022400" },
+      { label: "linux-x64", packageFile: "carrier-linux-x64.zip", artifactId: "5600022428" },
+    ],
+  });
+
+  assert.match(body, new RegExp(COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(body, /- Commit: `38695c9610c2592d729cc566fa2b3619e0841905`/);
+  assert.match(body, /- Workflow run: \[22252074017\]\(https:\/\/github\.com\/Keith-CY\/carrier\/actions\/runs\/22252074017\)/);
+  assert.match(body, /carrier-darwin-arm64\.zip/);
+  assert.match(body, /actions\/runs\/22252074017\/artifacts\/5600022400/);
+  assert.match(body, /carrier-linux-x64\.zip/);
+  assert.match(body, /actions\/runs\/22252074017\/artifacts\/5600022428/);
+});


### PR DESCRIPTION
## Summary
- use the built package filename (with .zip) as the uploaded artifact name in release PR runs
- move PR test-package comment generation into scripts/ci/pr-package-comment.cjs
- add regression tests for comment generation and .zip package validation

## Why
Artifact links in PR comments point to GitHub Actions artifact downloads. When artifact names omit .zip, downloaded files can also lose the .zip suffix, causing extraction failures.

## Testing
- node --test scripts/ci/*.test.cjs
