### PR TITLE
ci: add debug log for git diff failure and recursive metadata discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,8 @@ jobs:
                       ["git", "diff", "--name-only", base_sha, head_sha],
                       text=True,
                   )
-              except subprocess.CalledProcessError:
+              except subprocess.CalledProcessError as exc:
+                  print(f"::debug::git diff failed ({exc}), falling back to all modules")
                   return []
               files = [f.strip() for f in output.splitlines() if f.strip()]
               selected = set()

--- a/scripts/ci/pr-package-comment.cjs
+++ b/scripts/ci/pr-package-comment.cjs
@@ -10,11 +10,19 @@ function listMetadataFiles(metadataDir) {
     return [];
   }
 
-  return fs
-    .readdirSync(metadataDir, { withFileTypes: true })
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-    .map((entry) => path.join(metadataDir, entry.name))
-    .sort();
+  const results = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith(".json")) {
+        results.push(full);
+      }
+    }
+  }
+  walk(metadataDir);
+  return results.sort();
 }
 
 function parseMetadataFile(filePath) {

--- a/scripts/ci/pr-package-comment.test.cjs
+++ b/scripts/ci/pr-package-comment.test.cjs
@@ -62,6 +62,32 @@ test("loadPackageMetadata fails when package_file does not end with .zip", () =>
   });
 });
 
+test("loadPackageMetadata discovers JSON files in nested directories", () => {
+  withTempDir((dir) => {
+    const sub = path.join(dir, "sub");
+    fs.mkdirSync(sub);
+    fs.writeFileSync(
+      path.join(sub, "nested.json"),
+      JSON.stringify({
+        label: "linux-arm64",
+        package_file: "carrier-linux-arm64.zip",
+        artifact_id: "33",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(dir, "top.json"),
+      JSON.stringify({
+        label: "linux-x64",
+        package_file: "carrier-linux-x64.zip",
+        artifact_id: "11",
+      }),
+    );
+
+    const metadata = loadPackageMetadata(dir);
+    assert.equal(metadata.length, 2);
+  });
+});
+
 test("buildPrPackagesComment renders markdown body with artifact links", () => {
   const body = buildPrPackagesComment({
     repository: "Keith-CY/carrier",


### PR DESCRIPTION
- Log debug message when `changed_modules()` git diff fails instead of silently returning empty (closes #1278)
- Make `listMetadataFiles` recursive to handle nested artifact extraction directories (closes #1275)
- Add test for nested directory discovery

Followups from PR #1271 and PR #1274 reviews.