### PR TITLE
feat: unify onboarding runtime and managed add-agent flows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,9 @@
 /daemon/internal/redact/** @Keith-CY @Akane-CN
 
 # Security-sensitive gateway paths
-/gateway/src/server.ts @Keith-CY @Akane-CN
-/gateway/src/index.ts @Keith-CY @Akane-CN
-/gateway/src/session/** @Keith-CY @Akane-CN
-/gateway/src/daemon/client.ts @Keith-CY @Akane-CN
+/daemon/internal/gateway/** @Keith-CY @Akane-CN
+/daemon/gateway/** @Keith-CY @Akane-CN
+/cmd/carrier/main.go @Keith-CY @Akane-CN
 
 # Release and CI workflow controls
 /.github/workflows/release.yml @Keith-CY @Akane-CN

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,13 +23,13 @@
 Local verification (run the checks relevant to your change type):
 
 - [ ] **Daemon changes:** `cd daemon && go test ./...`
-- [ ] **Gateway changes:** `cd gateway && bun install && bun run check && bun test`
+- [ ] **Gateway changes:** `cd daemon && go test ./internal/gateway/...`
 - [ ] **Docs-only:** Verified markdown links render correctly
 - [ ] **Full suite:** `./scripts/run-all-tests.sh` (recommended before final push)
 
 CI checks (must be green before merge):
 
 - [ ] Daemon Tests (`daemon-tests`)
-- [ ] Gateway Type Check (`gateway-check`)
+- [ ] Gateway Check (`gateway-check`)
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidance.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-Carrier is an agent lifecycle management system composed of two main components: a **daemon** (Go) that manages agents on the host, and a **gateway** (TypeScript/Bun) that provides a WebSocket API for remote control.
+Carrier is an agent lifecycle management system composed of two main components: a **daemon** (Go) that manages agents on the host, and a **gateway** (Go) that provides HTTP command/webhook ingress for remote control.
 
 ```
-┌─────────────┐       WebSocket        ┌─────────────┐      HTTP/exec      ┌──────────┐
-│   Client /   │ ◄──────────────────► │   Gateway    │ ◄────────────────► │  Daemon   │
-│   Browser    │   (commands/events)   │  (Bun/TS)   │   (JSON over WS)   │ (agentd)  │
+┌─────────────┐         HTTP           ┌─────────────┐        HTTP         ┌──────────┐
+│ Chat/Webhook │ ───────────────────► │   Gateway    │ ─────────────────► │  Daemon   │
+│   Clients    │   (commands/events)   │    (Go)      │   (JSON over API)  │ (agentd)  │
 └─────────────┘                        └─────────────┘                     └──────────┘
                                                                                 │
                                                                           ┌─────┴─────┐
@@ -35,19 +35,19 @@ The daemon (`agentd`) is the host-side process responsible for:
 - **Runtime Checks** (`internal/runtimecheck/`) — Pre-flight validation (env vars, ports, dependencies)
 - **Base Agent** (`internal/baseagent/`) — Repair action policies and risk classification
 
-### Gateway (`gateway/`)
+### Gateway (`daemon/internal/gateway/`)
 
-The gateway is a Bun/TypeScript WebSocket server that:
+The gateway is a Go HTTP server that:
 
-- Accepts client connections and routes commands to the daemon
-- Manages **sessions** (`session/`) with authentication
-- Issues **download tokens** (`downloads/`) for artifact retrieval
-- Enforces **rate limiting** (`ratelimit/`)
+- Accepts command requests (`/command`) and provider webhooks (`/webhook/{telegram|discord|feishu}`)
+- Manages **sessions** (`session.go`) with authentication
+- Issues **download tokens** (`downloads.go`) for artifact retrieval
+- Enforces **rate limiting** (`ratelimit.go`)
 - Translates between the client protocol and daemon API
 
-### Command Contract (`gateway/src/contracts/`)
+### Command Contract (`docs/command-contract.md`)
 
-Typed command definitions shared between gateway and clients, defining the request/response schema for each operation (`/pair`, `/agents`, `/install`, `/start`, `/stop`, `/status`, `/logs`, `/upgrade`, `/diagnose`).
+Command definitions used by gateway command parsing and response rendering, covering operations such as `/pair`, `/agents`, `/install`, `/start`, `/stop`, `/status`, `/logs`, `/upgrade`, `/diagnose`.
 
 ### Daemon API Contract (`docs/daemon-api-contract.md`)
 
@@ -55,7 +55,7 @@ Canonical endpoint/method matrix and error-envelope mapping for daemon HTTP APIs
 
 ## Data Flow
 
-1. Client connects to gateway via WebSocket
+1. Client sends command/webhook payload to gateway over HTTP
 2. Client sends a command (e.g., `/install agent-name`)
 3. Gateway validates session, applies rate limits, and forwards to daemon
 4. Daemon executes the operation (install agent, run pre-flight checks, etc.)
@@ -63,7 +63,7 @@ Canonical endpoint/method matrix and error-envelope mapping for daemon HTTP APIs
 
 ## Key Design Decisions
 
-- **Separation of concerns**: Gateway handles networking/auth; daemon handles host operations
+- **Separation of concerns**: Gateway handles transport/session/auth; daemon handles host operations
 - **Crash-loop protection**: Daemon tracks restart frequency and applies exponential cooldown
 - **Audit trail**: All lifecycle operations are logged with bounded audit buffers
 - **Redaction by default**: Sensitive environment variables and patterns are automatically redacted in diagnostics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,8 +198,8 @@ Example:
 ```text
 Fixes #425
 Validation:
-- cd gateway && bun run check
-- cd gateway && bun test src/server.test.ts
+- cd daemon && go test ./internal/gateway/... -count=1
+- cd daemon && go test ./... -count=1
 - bash scripts/ci/check-action-pinning.sh
 ```
 
@@ -260,8 +260,8 @@ Use these from repository root:
 # Daemon tests only
 cd daemon && go test ./...
 
-# Gateway check + tests only
-cd gateway && bun install --no-progress && bun run check && bun test
+# Gateway tests only
+cd daemon && go test ./internal/gateway/...
 
 # Full local validation (daemon + gateway + e2e hook)
 ./scripts/run-all-tests.sh
@@ -289,7 +289,7 @@ Typical local re-run commands after log review:
 
 ```bash
 cd daemon && go test ./...
-cd gateway && bun install --no-progress && bun run check && bun test
+cd daemon && go test ./internal/gateway/...
 ./scripts/run-e2e-tests.sh
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ test: test-daemon test-gateway test-openclaw-installer test-start-systemd ## Run
 test-daemon: ## Run daemon Go tests
 	cd daemon && go test ./...
 
-test-gateway: ## Run gateway TypeScript type check and tests
-	cd gateway && npx tsc --noEmit
-	cd gateway && npx bun test
+test-gateway: ## Run gateway Go tests
+	cd daemon && go test ./internal/gateway/...
 
 test-openclaw-installer: ## Run OpenClaw installer checksum regression test
 	cd daemon/internal/catalog && bash ./openclaw-installer_test.sh
@@ -18,9 +17,8 @@ test-openclaw-installer: ## Run OpenClaw installer checksum regression test
 test-start-systemd: ## Run start.sh systemd target regression test
 	bash scripts/start_systemd_test.sh
 
-lint: ## Run linters (go vet + tsc)
+lint: ## Run linters (go vet)
 	cd daemon && go vet ./...
-	cd gateway && npx tsc --noEmit
 
 build: ## Build daemon binary
 	cd daemon && go build -o ../bin/agentd ./cmd/agentd

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Key topics covered:
 | Path | Purpose |
 |------|---------|
 | [`daemon/`](./daemon/) | Go daemon — lifecycle management, catalog loading, Base Agent triage interfaces |
-| [`gateway/`](./gateway/) | TypeScript gateway — provider routing, session management, download tokens |
+| [`gateway/`](./gateway/) | Gateway docs entrypoint (runtime implementation is Go under `daemon/internal/gateway/`) |
 | [`catalog/`](./catalog/) | OpenClaw manifest and candidate agent list |
 | [`docs/`](./docs/) | Product requirements, implementation plan, and architecture docs |
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | System design overview and component interaction diagrams |
@@ -111,7 +111,7 @@ See `CONTRIBUTING.md` for command examples and required process. For security vu
 
 ### Prerequisites
 - Go toolchain (see `daemon/go.mod` for the required version)
-- Bun (for gateway TypeScript tasks)
+- Bun (optional; only needed for some utility scripts under `scripts/`)
 
 #### Toolchain quick check
 
@@ -120,43 +120,32 @@ Run the following to verify required tools are installed and print their version
 ```bash
 echo "gh:  $(gh --version | head -1)"
 echo "go:  $(go version)"
-echo "bun: $(bun --version)"
+bun --version >/dev/null 2>&1 && echo "bun: $(bun --version)" || echo "bun: (optional, not installed)"
 ```
 
 If any command fails, install the missing tool before running automation scripts. See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed CI troubleshooting.
 
 ### Install
-- Daemon (Go): Go modules are loaded automatically when building or testing; no additional install command needed.
-- Gateway (TypeScript):
-  - `cd gateway`
-  - `bun install --frozen-lockfile`
+- Carrier/Daemon/Gateway (Go): Go modules are loaded automatically when building or testing; no additional install command needed.
 
 ### Run tests / checks
 - Daemon tests:
   - `cd daemon`
   - `go test ./...`
   - `go test ./internal/manifest -run TestLoadFileAcceptsCatalogManifest -count=1`
-- Gateway checks:
-  - `cd gateway`
-  - `bun run check`
-  - `bun test`
+- Gateway tests:
+  - `cd daemon`
+  - `go test ./internal/gateway/...`
 - Full local flow from repo root (mandatory before pushing):
   - `./scripts/run-all-tests.sh`
 
 Optional local flow from repo root:
-  - `cd gateway && bun install --frozen-lockfile && bun run check && cd ../daemon && go test ./...`
+  - `cd daemon && go test ./...`
 
-### Frozen lockfile policy (CI and automation)
-- CI/release automation must use lockfile-enforced installs for gateway dependencies:
-  - `bun install --frozen-lockfile --no-progress`
-- This guarantees deterministic dependency resolution from committed `gateway/bun.lock`.
-- If `gateway/package.json` and `gateway/bun.lock` drift, install must fail until lockfile is updated and committed.
-
-### Gateway runtime server (Bun)
+### Gateway runtime server (Go)
 
 - Start gateway runtime HTTP server:
-  - `cd gateway`
-  - `bun run dev`
+  - `go run ./cmd/carrier gateway`
 - Health route:
   - `GET /healthz`
 - Command ingress route:

--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -2,33 +2,298 @@
 //
 // Usage:
 //
-//	carrier           Start the daemon HTTP API server (with WebUI)
-//	carrier daemon    Same as above
-//	carrier --help    Show usage
+//	carrier                 Bootstrap Carrier (onboard if needed, keep daemon+gateway running, then exit)
+//	carrier daemon          Start daemon HTTP API server (foreground)
+//	carrier gateway         Start gateway HTTP server
+//	carrier stop            Stop background daemon and gateway started by Carrier
+//	carrier stop <id>       Stop a managed agent instance
+//	carrier uninstall <id>  Uninstall and remove a managed agent instance
+//	carrier list            List managed agent instances
+//	carrier onboard         Interactive TUI onboarding (channel/provider -> keep gateway running in background)
+//	carrier onboard --webui Launch WebUI onboarding (start/reuse daemon+gateway)
+//	carrier add <agent_id>  Add/install an agent via TUI flow
+//	carrier add <agent_id> --webui
+//	                       Add/install an agent via WebUI flow
+//	carrier --help          Show usage
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	neturl "net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
 
+	"carrier/configv2"
+	gatewayruntime "carrier/daemon/gateway"
 	"carrier/daemon/server"
 )
+
+type choiceOption struct {
+	ID    string
+	Name  string
+	Setup string
+
+	AuthMode     providerAuthMode
+	ProviderEnv  string
+	ExampleModel string
+
+	TokenEnv     string
+	RequireToken bool
+	SecretEnv    string
+}
+
+type providerAuthMode string
+
+const (
+	authModeAPIKey          providerAuthMode = "api_key"
+	authModeOAuthDeviceCode providerAuthMode = "oauth_device_code"
+	authModeNone            providerAuthMode = "none"
+)
+
+type addCommandOptions struct {
+	AgentID string
+	WebUI   bool
+}
+
+type picoclawChannel struct {
+	ID         string
+	Name       string
+	TokenLabel string
+}
+
+type picoclawAddResult struct {
+	InstanceID    string
+	WorkspacePath string
+	ConfigPath    string
+	RecordPath    string
+	ChannelID     string
+	ProviderID    string
+}
+
+type managedAgentInstance struct {
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	AgentID      string `json:"agent_id"`
+	GatewayURL   string `json:"gateway_url"`
+	Workspace    string `json:"workspace_path,omitempty"`
+	ConfigPath   string `json:"config_path,omitempty"`
+	RecordPath   string `json:"record_path,omitempty"`
+	Channel      string `json:"channel,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	PairRequired bool   `json:"pair_required,omitempty"`
+	PairCode     string `json:"pair_code,omitempty"`
+	PairedChatID string `json:"paired_chat_id,omitempty"`
+	RuntimeState string `json:"runtime_state,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+type managedAgentInstanceFile struct {
+	Instances []managedAgentInstance `json:"instances"`
+}
+
+var (
+	errCredentialNotFound           = errors.New("credential not found")
+	errCredentialBackendUnavailable = errors.New("credential backend unavailable")
+)
+
+var picoclawPairCodePattern = regexp.MustCompile(`\bpair-[a-f0-9]{32}\b`)
+
+var picoclawChannels = []picoclawChannel{
+	{
+		ID:         "telegram",
+		Name:       "Telegram",
+		TokenLabel: "Telegram bot token for PicoClaw",
+	},
+}
+
+var channelOptions = []choiceOption{
+	{
+		ID: "telegram", Name: "Telegram", Setup: "Easy (bot token)",
+		TokenEnv: "CARRIER_TELEGRAM_BOT_TOKEN", RequireToken: true,
+		SecretEnv: "CARRIER_TELEGRAM_WEBHOOK_SECRET",
+	},
+	{
+		ID: "discord", Name: "Discord", Setup: "Easy (bot token + intents)",
+		TokenEnv:  "CARRIER_DISCORD_BOT_TOKEN",
+		SecretEnv: "CARRIER_DISCORD_PUBLIC_KEY",
+	},
+	{
+		ID: "feishu", Name: "Feishu", Setup: "Medium (app credentials + webhook)",
+		TokenEnv:  "CARRIER_FEISHU_APP_TOKEN",
+		SecretEnv: "CARRIER_FEISHU_VERIFICATION_TOKEN",
+	},
+	{ID: "qq", Name: "QQ", Setup: "Easy (AppID + AppSecret)", TokenEnv: "CARRIER_QQ_BOT_TOKEN"},
+	{ID: "dingtalk", Name: "DingTalk", Setup: "Medium (app credentials)", TokenEnv: "CARRIER_DINGTALK_BOT_TOKEN"},
+	{ID: "line", Name: "LINE", Setup: "Medium (credentials + webhook URL)", TokenEnv: "CARRIER_LINE_BOT_TOKEN"},
+	{ID: "wecom", Name: "WeCom", Setup: "Medium (CorpID + webhook setup)", TokenEnv: "CARRIER_WECOM_BOT_TOKEN"},
+}
+
+var providerOptions = []choiceOption{
+	{ID: "gemini", Name: "Google Gemini", Setup: "Gemini direct API key", AuthMode: authModeAPIKey, ProviderEnv: "GEMINI_API_KEY", ExampleModel: "gemini/gemini-2.0-flash-exp"},
+	{ID: "zhipu", Name: "Zhipu", Setup: "GLM direct API key", AuthMode: authModeAPIKey, ProviderEnv: "ZHIPU_API_KEY", ExampleModel: "zhipu/glm-4.7"},
+	{ID: "openrouter", Name: "OpenRouter", Setup: "Unified gateway API key", AuthMode: authModeAPIKey, ProviderEnv: "OPENROUTER_API_KEY", ExampleModel: "openrouter/auto"},
+	{ID: "anthropic", Name: "Anthropic", Setup: "Claude direct API key", AuthMode: authModeAPIKey, ProviderEnv: "ANTHROPIC_API_KEY", ExampleModel: "anthropic/claude-sonnet-4.6"},
+	{ID: "openai", Name: "OpenAI", Setup: "GPT direct API key", AuthMode: authModeAPIKey, ProviderEnv: "OPENAI_API_KEY", ExampleModel: "openai/gpt-5.2"},
+	{ID: "openai-codex", Name: "OpenAI Codex", Setup: "OAuth device-code login", AuthMode: authModeOAuthDeviceCode, ProviderEnv: "OPENAI_CODEX_TOKEN", ExampleModel: "openai-codex/gpt-5.3-codex"},
+	{ID: "deepseek", Name: "DeepSeek", Setup: "DeepSeek direct API key", AuthMode: authModeAPIKey, ProviderEnv: "DEEPSEEK_API_KEY", ExampleModel: "deepseek/deepseek-chat"},
+	{ID: "qwen", Name: "Qwen", Setup: "DashScope API key", AuthMode: authModeAPIKey, ProviderEnv: "QWEN_API_KEY", ExampleModel: "qwen/qwen-plus"},
+	{ID: "groq", Name: "Groq", Setup: "Groq API key", AuthMode: authModeAPIKey, ProviderEnv: "GROQ_API_KEY", ExampleModel: "groq/llama-3.3-70b-versatile"},
+	{ID: "cerebras", Name: "Cerebras", Setup: "Cerebras API key", AuthMode: authModeAPIKey, ProviderEnv: "CEREBRAS_API_KEY", ExampleModel: "cerebras/llama-3.3-70b"},
+	{ID: "ollama", Name: "Ollama", Setup: "Local runtime, no API key", AuthMode: authModeNone, ExampleModel: "ollama/llama3"},
+	{ID: "vllm", Name: "vLLM", Setup: "Local/OpenAI-compatible endpoint", AuthMode: authModeNone, ExampleModel: "vllm/auto"},
+}
+
+const (
+	openAICodexAuthBaseURL        = "https://auth.openai.com"
+	openAICodexClientID           = "app_EMoamEEZ73f0CkXaXp7hrann"
+	openAICodexVerificationURL    = openAICodexAuthBaseURL + "/codex/device"
+	openAICodexDeviceAuthTimeout  = 15 * time.Minute
+	openAICodexDefaultPollSeconds = 5
+	daemonBootTimeout             = 10 * time.Second
+	gatewayBootTimeout            = 10 * time.Second
+	daemonBootPollInterval        = 250 * time.Millisecond
+	defaultPairCodeTTLSeconds     = 300
+)
+
+var runOpenAICodexDeviceCodeFlow = performOpenAICodexDeviceCodeFlow
+var gatewayHealthProbe = checkGatewayHealth
+var daemonHealthProbe = checkDaemonHealth
+var daemonBackgroundStarter = startDaemonInBackground
+var gatewayBackgroundStarter = startGatewayInBackground
+var daemonPairCodeFetcher = fetchDaemonPairCode
+var openBrowserFunc = openBrowserURL
+var runOnboardFlow = runOnboard
+var ensureWebUIServicesFlow = ensureWebUIServices
 
 const usage = `Carrier — unified agent platform binary
 
 Usage:
-  carrier              Start the daemon HTTP API server (with WebUI)
-  carrier daemon       Same as above
-  carrier --help       Show this help message
+  carrier                Bootstrap Carrier (onboard if needed, keep daemon+gateway running, then exit)
+  carrier daemon         Start daemon HTTP API server (foreground)
+  carrier gateway        Start gateway HTTP server
+  carrier stop           Stop background daemon and gateway
+  carrier stop <id>      Stop a managed agent instance
+  carrier uninstall <id> Uninstall and remove a managed agent instance
+  carrier list           List managed agent instances
+  carrier onboard        Interactive onboarding (channel/provider -> keep gateway running in background)
+  carrier onboard --webui
+                        Launch WebUI onboarding (start/reuse daemon+gateway)
+  carrier add <agent_id>
+                        Add/install an agent via TUI flow
+  carrier add <agent_id> --webui
+                        Add/install an agent via WebUI flow
+  carrier --help         Show this help message
 
-The WebUI is served at http://localhost:<port>/ alongside the API.
+Notes:
+  - daemon API defaults to http://127.0.0.1:9090
+  - gateway API defaults to http://127.0.0.1:8787
+  - onboarding asks channel credentials and provider auth setup
+  - onboarding config path:
+      $CARRIER_CONFIG or ~/.carrier/config.v2.json
 `
 
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "daemon", "--daemon":
+			applyConfigV2Env(os.Stderr)
 			server.Run()
+			return
+		case "gateway", "--gateway":
+			applyConfigV2Env(os.Stderr)
+			if err := gatewayruntime.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "gateway error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "stop":
+			if len(os.Args) >= 3 {
+				if err := runStopInstance(os.Stdout, os.Args[2]); err != nil {
+					fmt.Fprintf(os.Stderr, "stop failed: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
+			if err := runStop(os.Stdout); err != nil {
+				fmt.Fprintf(os.Stderr, "stop failed: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "uninstall":
+			if len(os.Args) < 3 {
+				fmt.Fprintln(os.Stderr, "uninstall failed: instance id is required")
+				fmt.Fprint(os.Stderr, usage)
+				os.Exit(1)
+			}
+			if err := runUninstallInstance(os.Stdout, os.Args[2]); err != nil {
+				fmt.Fprintf(os.Stderr, "uninstall failed: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "list":
+			if err := runListInstances(os.Stdout); err != nil {
+				fmt.Fprintf(os.Stderr, "list failed: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "onboard":
+			if len(os.Args) >= 3 {
+				mode := strings.ToLower(strings.TrimSpace(os.Args[2]))
+				switch mode {
+				case "--webui", "--web", "webui":
+					if err := runOnboardWebUI(os.Stdout); err != nil {
+						fmt.Fprintf(os.Stderr, "onboard failed: %v\n", err)
+						os.Exit(1)
+					}
+					return
+				default:
+					fmt.Fprintf(os.Stderr, "unknown onboard option: %s\n\n", os.Args[2])
+					fmt.Fprint(os.Stderr, usage)
+					os.Exit(1)
+				}
+			}
+			if err := runOnboardFlow(os.Stdin, os.Stdout, startGatewayInBackgroundAndWait); err != nil {
+				fmt.Fprintf(os.Stderr, "onboard failed: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "add":
+			opts, err := parseAddCommandArgs(os.Args[2:])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "add failed: %v\n\n", err)
+				fmt.Fprint(os.Stderr, usage)
+				os.Exit(1)
+			}
+			if opts.WebUI {
+				if err := runAddWebUI(os.Stdout, opts.AgentID); err != nil {
+					fmt.Fprintf(os.Stderr, "add failed: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
+			if err := runAddTUI(os.Stdin, os.Stdout, opts.AgentID); err != nil {
+				fmt.Fprintf(os.Stderr, "add failed: %v\n", err)
+				os.Exit(1)
+			}
 			return
 		case "--help", "-h", "help":
 			fmt.Print(usage)
@@ -40,6 +305,2525 @@ func main() {
 		}
 	}
 
-	// Default: start daemon (which includes WebUI)
-	server.Run()
+	if err := runBootstrap(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "carrier bootstrap failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseAddCommandArgs(args []string) (addCommandOptions, error) {
+	if len(args) == 0 {
+		return addCommandOptions{}, errors.New("usage: carrier add <agent_id> [--webui]")
+	}
+	opts := addCommandOptions{
+		AgentID: strings.ToLower(strings.TrimSpace(args[0])),
+	}
+	if opts.AgentID == "" || strings.HasPrefix(opts.AgentID, "-") {
+		return addCommandOptions{}, errors.New("agent_id is required")
+	}
+	for _, raw := range args[1:] {
+		arg := strings.ToLower(strings.TrimSpace(raw))
+		switch arg {
+		case "--webui", "--web", "webui":
+			opts.WebUI = true
+		case "":
+			continue
+		default:
+			return addCommandOptions{}, fmt.Errorf("unknown add option: %s", raw)
+		}
+	}
+	return opts, nil
+}
+
+func needsInitialOnboard(loadFn func() (*configv2.Config, string, error)) bool {
+	cfg, _, err := loadFn()
+	if err != nil || cfg == nil {
+		return true
+	}
+	enabledChannels := 0
+	for _, ch := range cfg.Channels {
+		if ch.Enabled {
+			enabledChannels++
+		}
+	}
+	if enabledChannels == 0 {
+		return true
+	}
+	if len(cfg.ModelList) == 0 {
+		return true
+	}
+	return false
+}
+
+func runBootstrap(in io.Reader, out io.Writer) error {
+	_, _ = fmt.Fprintln(out, "Carrier Bootstrap")
+	_, _ = fmt.Fprintln(out, "-----------------")
+
+	if needsInitialOnboard(configv2.Load) {
+		_, _ = fmt.Fprintln(out, "Carrier is not onboarded. Starting onboarding...")
+		if err := runOnboardFlow(in, out, startGatewayInBackgroundAndWait); err != nil {
+			return err
+		}
+	} else {
+		_, _ = fmt.Fprintln(out, "Carrier is already onboarded. Ensuring runtime services...")
+		applyConfigV2Env(out)
+		if _, err := ensureWebUIServicesFlow(out); err != nil {
+			return err
+		}
+	}
+
+	printRuntimeSummary(out)
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Terminal is ready for the next command.")
+	_, _ = fmt.Fprintln(out, "Examples:")
+	_, _ = fmt.Fprintln(out, "  - carrier add picoclaw")
+	_, _ = fmt.Fprintln(out, "  - carrier add picoclaw --webui")
+	_, _ = fmt.Fprintln(out, "  - carrier list")
+	return nil
+}
+
+func runStop(out io.Writer) error {
+	_, _ = fmt.Fprintln(out, "Carrier Stop")
+	_, _ = fmt.Fprintln(out, "------------")
+
+	daemonStopped, daemonMsg := stopBackgroundService(
+		"daemon",
+		daemonProbeBaseURL(),
+		daemonHealthProbe,
+	)
+	gatewayStopped, gatewayMsg := stopBackgroundService(
+		"gateway",
+		gatewayProbeBaseURL(),
+		gatewayHealthProbe,
+	)
+
+	_, _ = fmt.Fprintf(out, "- daemon: %s\n", daemonMsg)
+	_, _ = fmt.Fprintf(out, "- gateway: %s\n", gatewayMsg)
+
+	if daemonStopped || gatewayStopped {
+		_, _ = fmt.Fprintln(out, "✅ stop complete")
+		return nil
+	}
+	_, _ = fmt.Fprintln(out, "No background daemon/gateway process was stopped.")
+	return nil
+}
+
+func runStopInstance(out io.Writer, instanceID string) error {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return errors.New("instance id is required")
+	}
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	idx := findManagedInstanceIndex(instances, instanceID)
+	if idx < 0 {
+		return fmt.Errorf("instance %s not found", instanceID)
+	}
+	inst := instances[idx]
+	if _, err := ensureDaemonRunning(out); err != nil {
+		return err
+	}
+	if err := daemonAgentAction(inst.AgentID, "stop"); err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	instances[idx].RuntimeState = "stopped"
+	instances[idx].UpdatedAt = now
+	if err := saveManagedInstances(path, instances); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "✅ stopped instance %s (%s)\n", inst.ID, inst.Type)
+	return nil
+}
+
+func runUninstallInstance(out io.Writer, instanceID string) error {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return errors.New("instance id is required")
+	}
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	idx := findManagedInstanceIndex(instances, instanceID)
+	if idx < 0 {
+		return fmt.Errorf("instance %s not found", instanceID)
+	}
+	inst := instances[idx]
+	if _, err := ensureDaemonRunning(out); err != nil {
+		return err
+	}
+	_ = daemonAgentAction(inst.AgentID, "stop")
+	if err := daemonAgentAction(inst.AgentID, "uninstall"); err != nil {
+		return err
+	}
+	if err := cleanupManagedInstanceFiles(inst); err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: instance file cleanup failed: %v\n", err)
+	}
+	instances = append(instances[:idx], instances[idx+1:]...)
+	if err := saveManagedInstances(path, instances); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "✅ uninstalled instance %s (%s)\n", inst.ID, inst.Type)
+	return nil
+}
+
+func runListInstances(out io.Writer) error {
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	running := make([]managedAgentInstance, 0, len(instances))
+	for _, inst := range instances {
+		if strings.EqualFold(strings.TrimSpace(inst.RuntimeState), "running") {
+			running = append(running, inst)
+		}
+	}
+	if len(running) == 0 {
+		_, _ = fmt.Fprintln(out, "No agent instances are running.")
+		return nil
+	}
+	_, _ = fmt.Fprintln(out, "Agent instances:")
+	for _, inst := range running {
+		runtimeState := strings.TrimSpace(inst.RuntimeState)
+		if runtimeState == "" {
+			runtimeState = "unknown"
+		}
+		_, _ = fmt.Fprintf(out, "- id=%s type=%s state=%s gateway=%s\n",
+			strings.TrimSpace(inst.ID),
+			strings.TrimSpace(inst.Type),
+			runtimeState,
+			strings.TrimSpace(inst.GatewayURL),
+		)
+	}
+	return nil
+}
+
+func stopBackgroundService(
+	name string,
+	baseURL string,
+	healthProbe func(string) bool,
+) (bool, string) {
+	stoppedByPID, pidErr := stopServiceByPIDFile(name)
+	if pidErr == nil && stoppedByPID {
+		return true, "stopped (pid file)"
+	}
+
+	if !healthProbe(baseURL) {
+		return false, "not running"
+	}
+
+	port := portFromBaseURL(baseURL)
+	if port <= 0 {
+		if pidErr != nil {
+			return false, fmt.Sprintf("running but unable to stop via pid file: %v", pidErr)
+		}
+		return false, "running but no pid file available"
+	}
+	stoppedByPort, portErr := stopServiceByPort(name, port)
+	if portErr == nil && stoppedByPort > 0 {
+		return true, fmt.Sprintf("stopped (%d process via port %d)", stoppedByPort, port)
+	}
+
+	if pidErr != nil {
+		return false, fmt.Sprintf("running but stop failed (pid file err=%v, port err=%v)", pidErr, portErr)
+	}
+	if portErr != nil {
+		return false, fmt.Sprintf("running but stop by port failed: %v", portErr)
+	}
+	return false, "running but no stoppable process found"
+}
+
+func stopServiceByPIDFile(name string) (bool, error) {
+	path, err := bootstrapPIDPath(name)
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read pid file %s: %w", path, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		_ = os.Remove(path)
+		return false, fmt.Errorf("invalid pid in %s", path)
+	}
+	stopped, stopErr := stopPID(pid)
+	_ = os.Remove(path)
+	return stopped, stopErr
+}
+
+func stopPID(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %d", pid)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	_ = proc.Signal(os.Interrupt)
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !processLikelyAlive(proc) {
+			return true, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err := proc.Kill(); err != nil && !isProcessAlreadyGone(err) {
+		return false, err
+	}
+	return true, nil
+}
+
+func processLikelyAlive(proc *os.Process) bool {
+	if proc == nil {
+		return false
+	}
+	err := proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+func isProcessAlreadyGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrProcessDone) {
+		return true
+	}
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(msg, "finished") || strings.Contains(msg, "no such process") || strings.Contains(msg, "process already done")
+}
+
+func stopServiceByPort(name string, port int) (int, error) {
+	if port <= 0 {
+		return 0, errors.New("invalid port")
+	}
+	if runtime.GOOS == "windows" {
+		return 0, errors.New("port-based stop is not supported on windows")
+	}
+	lsofPath, err := exec.LookPath("lsof")
+	if err != nil {
+		return 0, errors.New("lsof is not available")
+	}
+	cmd := exec.Command(lsofPath, "-nP", "-ti", fmt.Sprintf("tcp:%d", port))
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) == 0 {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("query pid by port %d: %w", port, err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	stopped := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		pid, convErr := strconv.Atoi(strings.TrimSpace(line))
+		if convErr != nil || pid <= 0 {
+			continue
+		}
+		ok, stopErr := stopPID(pid)
+		if stopErr == nil && ok {
+			stopped++
+		}
+	}
+	if stopped == 0 {
+		return 0, nil
+	}
+	if pidPath := mustBootstrapPIDPath(name); strings.TrimSpace(pidPath) != "" {
+		_ = os.Remove(pidPath)
+	}
+	return stopped, nil
+}
+
+func portFromBaseURL(baseURL string) int {
+	parsed, err := neturl.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return 0
+	}
+	if parsed.Port() == "" {
+		return 0
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port <= 0 {
+		return 0
+	}
+	return port
+}
+
+func managedInstancesPath() (string, error) {
+	if custom := strings.TrimSpace(os.Getenv("CARRIER_INSTANCE_STORE")); custom != "" {
+		return custom, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for instance store: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "instances.json"), nil
+}
+
+func generateManagedInstanceID(prefix string) (string, error) {
+	p := strings.ToLower(strings.TrimSpace(prefix))
+	if p == "" {
+		p = "agent"
+	}
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate random id: %w", err)
+	}
+	return fmt.Sprintf("%s-%s", p, hex.EncodeToString(buf)), nil
+}
+
+func loadManagedInstances() ([]managedAgentInstance, string, error) {
+	path, err := managedInstancesPath()
+	if err != nil {
+		return nil, "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []managedAgentInstance{}, path, nil
+		}
+		return nil, "", fmt.Errorf("read instance store: %w", err)
+	}
+	var file managedAgentInstanceFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, "", fmt.Errorf("parse instance store: %w", err)
+	}
+	if file.Instances == nil {
+		file.Instances = []managedAgentInstance{}
+	}
+	return file.Instances, path, nil
+}
+
+func saveManagedInstances(path string, instances []managedAgentInstance) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("instance store path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create instance store dir: %w", err)
+	}
+	payload := managedAgentInstanceFile{Instances: instances}
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal instance store: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write instance store: %w", err)
+	}
+	return nil
+}
+
+func findManagedInstanceIndex(instances []managedAgentInstance, instanceID string) int {
+	id := strings.TrimSpace(instanceID)
+	for i, inst := range instances {
+		if strings.EqualFold(strings.TrimSpace(inst.ID), id) {
+			return i
+		}
+	}
+	return -1
+}
+
+func upsertManagedInstance(inst managedAgentInstance) error {
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	idx := findManagedInstanceIndex(instances, inst.ID)
+	if idx >= 0 {
+		instances[idx] = inst
+	} else {
+		instances = append(instances, inst)
+	}
+	return saveManagedInstances(path, instances)
+}
+
+func cleanupManagedInstanceFiles(inst managedAgentInstance) error {
+	var firstErr error
+	removeFile := func(path string) {
+		if strings.TrimSpace(path) == "" {
+			return
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	removeDir := func(path string) {
+		p := strings.TrimSpace(path)
+		if p == "" {
+			return
+		}
+		if err := os.RemoveAll(p); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	removeFile(strings.TrimSpace(inst.RecordPath))
+	removeFile(strings.TrimSpace(inst.ConfigPath))
+	removeDir(strings.TrimSpace(inst.Workspace))
+	return firstErr
+}
+
+func startGatewayInBackgroundAndWait() error {
+	if err := gatewayBackgroundStarter(); err != nil {
+		return err
+	}
+	gatewayURL := gatewayProbeBaseURL()
+	if err := waitForGatewayHealthy(gatewayURL, gatewayBootTimeout); err != nil {
+		return fmt.Errorf("gateway failed to become healthy at %s within %s: %w", gatewayURL, gatewayBootTimeout, err)
+	}
+	return nil
+}
+
+func printRuntimeSummary(out io.Writer) {
+	daemonURL := daemonProbeBaseURL()
+	gatewayURL := gatewayProbeBaseURL()
+	daemonReady := daemonHealthProbe(daemonURL)
+	gatewayReady := gatewayHealthProbe(gatewayURL)
+	webUIReady := checkWebUIReady(gatewayURL)
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Runtime summary:")
+	_, _ = fmt.Fprintf(out, "- daemon: %s (%s)\n", statusText(daemonReady), daemonURL)
+	_, _ = fmt.Fprintf(out, "- gateway: %s (%s)\n", statusText(gatewayReady), gatewayURL)
+	if webUIReady {
+		_, _ = fmt.Fprintf(out, "- webui: ready (%s/)\n", strings.TrimRight(gatewayURL, "/"))
+	} else {
+		_, _ = fmt.Fprintf(out, "- webui: unavailable (%s/)\n", strings.TrimRight(gatewayURL, "/"))
+	}
+	if !bootstrapVerboseEnabled() {
+		if daemonLogPath, err := bootstrapLogPath("daemon"); err == nil {
+			if _, statErr := os.Stat(daemonLogPath); statErr == nil {
+				_, _ = fmt.Fprintf(out, "- daemon log: %s\n", daemonLogPath)
+			}
+		}
+		if gatewayLogPath, err := bootstrapLogPath("gateway"); err == nil {
+			if _, statErr := os.Stat(gatewayLogPath); statErr == nil {
+				_, _ = fmt.Fprintf(out, "- gateway log: %s\n", gatewayLogPath)
+			}
+		}
+	}
+
+	if cfg, cfgPath, err := configv2.Load(); err == nil && cfg != nil {
+		_, _ = fmt.Fprintf(out, "- config: %s\n", cfgPath)
+		if chatInfo := summarizeConfiguredChannels(cfg); chatInfo != "" {
+			_, _ = fmt.Fprintf(out, "- chat apps: %s\n", chatInfo)
+		}
+		if modelInfo := summarizeDefaultModel(cfg); modelInfo != "" {
+			_, _ = fmt.Fprintf(out, "- default model: %s\n", modelInfo)
+		}
+	}
+
+	if daemonReady {
+		pairCode, pairCodeExpiresAt, err := daemonPairCodeFetcher(daemonURL)
+		if err == nil && strings.TrimSpace(pairCode) != "" {
+			_, _ = fmt.Fprintf(out, "- pair code: %s\n", pairCode)
+			if expiry, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(pairCodeExpiresAt)); parseErr == nil {
+				remaining := time.Until(expiry)
+				if remaining < 0 {
+					remaining = 0
+				}
+				_, _ = fmt.Fprintf(out, "  expires in %s\n", remaining.Round(time.Second))
+			}
+		}
+	}
+}
+
+func statusText(ready bool) string {
+	if ready {
+		return "running"
+	}
+	return "not running"
+}
+
+func summarizeConfiguredChannels(cfg *configv2.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	items := make([]string, 0, len(cfg.Channels))
+	for _, ch := range cfg.Channels {
+		if !ch.Enabled {
+			continue
+		}
+		id := strings.ToLower(strings.TrimSpace(ch.ID))
+		if id == "" {
+			continue
+		}
+		details := []string{id}
+		if id == "telegram" {
+			mode := strings.ToLower(strings.TrimSpace(ch.TransportMode))
+			if mode == "" {
+				mode = "auto"
+			}
+			details = append(details, "mode="+mode)
+		}
+		if strings.TrimSpace(ch.BotToken) != "" {
+			details = append(details, "token=set")
+		}
+		if strings.TrimSpace(ch.WebhookURL) != "" {
+			details = append(details, "webhook=url-set")
+		}
+		items = append(items, strings.Join(details, ","))
+	}
+	if len(items) == 0 {
+		return ""
+	}
+	sort.Strings(items)
+	return strings.Join(items, " | ")
+}
+
+func summarizeDefaultModel(cfg *configv2.Config) string {
+	if cfg == nil || len(cfg.ModelList) == 0 {
+		return ""
+	}
+	pick := cfg.ModelList[0]
+	defaultName := strings.TrimSpace(cfg.DefaultModel)
+	if defaultName != "" {
+		for _, m := range cfg.ModelList {
+			if strings.EqualFold(strings.TrimSpace(m.ModelName), defaultName) {
+				pick = m
+				break
+			}
+		}
+	}
+	modelID := strings.TrimSpace(pick.Model)
+	if modelID == "" {
+		modelID = strings.TrimSpace(pick.ModelName)
+	}
+	if modelID == "" {
+		return ""
+	}
+	if providerID := strings.TrimSpace(pick.ProviderID); providerID != "" {
+		return fmt.Sprintf("%s (provider=%s)", modelID, providerID)
+	}
+	return modelID
+}
+
+func applyConfigV2Env(out io.Writer) {
+	cfg, _, err := configv2.Load()
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "warning: failed to load config.v2: %v\n", err)
+		return
+	}
+	if err := configv2.ApplyGatewayEnvironment(cfg); err != nil {
+		_, _ = fmt.Fprintf(out, "warning: failed to apply config.v2 environment: %v\n", err)
+	}
+}
+
+func runOnboard(in io.Reader, out io.Writer, startGateway func() error) error {
+	reader := bufio.NewReader(in)
+
+	_, _ = fmt.Fprintln(out, "Carrier TUI Onboard")
+	_, _ = fmt.Fprintln(out, "-------------------")
+	_, _ = fmt.Fprintln(out, "Tip: for browser onboarding, run `carrier onboard --webui` and open http://127.0.0.1:8787/")
+	_, _ = fmt.Fprintln(out, "Step 1/4: Configure chat channel")
+	channel, ok := resolveChoice("telegram", channelOptions)
+	if !ok {
+		return errors.New("telegram channel is unavailable")
+	}
+	_, _ = fmt.Fprintf(out, "Using channel: %s\n", channel.Name)
+	channelEnv, channelCfg, err := promptChannelCredentialsMinimal(reader, out, channel)
+	if err != nil {
+		return err
+	}
+	channelConfigs := []configv2.Channel{channelCfg}
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Step 2/4: Configure LLM provider")
+	provider, err := pickMinimalProvider()
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "Using provider: %s (%s)\n", provider.Name, provider.ID)
+	providerEnv, providerCredentialProvided, err := promptProviderAuthMinimal(reader, out, provider)
+	if err != nil {
+		return err
+	}
+	modelName := provider.ID + "-default"
+	modelID := strings.TrimSpace(provider.ExampleModel)
+	if modelID == "" {
+		modelID = provider.ID + "/default"
+	}
+	model := configv2.Model{
+		ModelName:  modelName,
+		Model:      modelID,
+		ProviderID: provider.ID,
+		AuthMode:   string(provider.AuthMode),
+		EnvVar:     provider.ProviderEnv,
+	}
+	if providerCredentialProvided {
+		model.CredentialRef = provider.ID
+	}
+	modelList := []configv2.Model{model}
+	defaultModel := modelName
+
+	cfg := &configv2.Config{
+		ConfigVersion: configv2.CurrentVersion,
+		Channels:      channelConfigs,
+		ModelList:     modelList,
+		DefaultModel:  defaultModel,
+		BaseAgent: configv2.BaseAgentSpec{
+			Enabled:           true,
+			PublicMemoryID:    "carrier.base.public.v1",
+			ActiveMemoryID:    "carrier.base.active.v1",
+			SelfHealBackupDir: "base-agent-memory-backups",
+		},
+		ConfiguredAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	cfgPath, err := configv2.Save(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := configv2.ApplyGatewayEnvironment(cfg); err != nil {
+		return err
+	}
+
+	combinedEnv := mergeEnvVars(channelEnv, providerEnv)
+	if err := applyEnvVars(combinedEnv); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "\nSaved onboarding config to %s\n", cfgPath)
+	if len(combinedEnv) > 0 {
+		envKeys := make([]string, 0, len(combinedEnv))
+		for k := range combinedEnv {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		_, _ = fmt.Fprintf(out, "Configured env vars for this process: %s\n", strings.Join(envKeys, ", "))
+	}
+	_, _ = fmt.Fprintln(out, "Step 3/4: Credential setup complete")
+	_, _ = fmt.Fprintln(out, "Step 4/4: Launch gateway")
+	_, _ = fmt.Fprintf(out, "Selected channel: %s\n", channel.Name)
+	_, _ = fmt.Fprintf(out, "Selected provider: %s\n", provider.Name)
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Ensuring daemon is running...")
+
+	daemonURL := daemonProbeBaseURL()
+	if daemonHealthProbe(daemonURL) {
+		_, _ = fmt.Fprintf(out, "Daemon already running at %s, reusing existing process.\n", daemonURL)
+	} else {
+		_, _ = fmt.Fprintf(out, "Daemon not detected at %s, starting in background...\n", daemonURL)
+		if err := daemonBackgroundStarter(); err != nil {
+			return fmt.Errorf("start daemon in background: %w", err)
+		}
+		if err := waitForDaemonHealthy(daemonURL, daemonBootTimeout); err != nil {
+			return fmt.Errorf("daemon failed to become healthy at %s within %s: %w", daemonURL, daemonBootTimeout, err)
+		}
+		_, _ = fmt.Fprintf(out, "Daemon started and healthy at %s.\n", daemonURL)
+	}
+
+	pairCode, pairCodeExpiresAt, err := daemonPairCodeFetcher(daemonURL)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: failed to fetch pair code from daemon: %v\n", err)
+	} else if strings.TrimSpace(pairCode) != "" {
+		_, _ = fmt.Fprintln(out, "")
+		_, _ = fmt.Fprintf(out, "PAIR_CODE: %s\n", pairCode)
+		if strings.TrimSpace(pairCodeExpiresAt) != "" {
+			if expiry, parseErr := time.Parse(time.RFC3339Nano, pairCodeExpiresAt); parseErr == nil {
+				remaining := time.Until(expiry)
+				if remaining < 0 {
+					remaining = 0
+				}
+				_, _ = fmt.Fprintf(out, "(expires in %s)\n", remaining.Round(time.Second))
+			} else {
+				_, _ = fmt.Fprintf(out, "(expiresAt: %s)\n", pairCodeExpiresAt)
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Starting gateway...")
+	_, _ = fmt.Fprintln(out, buildSlashCommandGuide(channel))
+
+	gatewayURL := gatewayProbeBaseURL()
+	if gatewayHealthProbe(gatewayURL) {
+		_, _ = fmt.Fprintf(out, "Gateway already running at %s, reusing existing process.\n", gatewayURL)
+		return nil
+	}
+
+	if err := startGateway(); err != nil {
+		if isAddressInUseError(err) && gatewayHealthProbe(gatewayURL) {
+			_, _ = fmt.Fprintf(out, "Gateway already running at %s, reusing existing process.\n", gatewayURL)
+			return nil
+		}
+		if isAddressInUseError(err) {
+			return fmt.Errorf("gateway port is already in use; stop the conflicting process or set CARRIER_GATEWAY_PORT (probe: %s): %w", gatewayURL, err)
+		}
+		return err
+	}
+	return nil
+}
+
+func runOnboardWebUI(out io.Writer) error {
+	_, _ = fmt.Fprintln(out, "Carrier WebUI Onboard")
+	_, _ = fmt.Fprintln(out, "--------------------")
+
+	gatewayURL, err := ensureWebUIServices(out)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "\nOpen WebUI: %s/\n", gatewayURL)
+	_, _ = fmt.Fprintln(out, "Use the browser flow to onboard Carrier and add agents.")
+	return nil
+}
+
+func runAddWebUI(out io.Writer, agentID string) error {
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	if agentID == "" {
+		return errors.New("agent_id is required")
+	}
+	_, _ = fmt.Fprintln(out, "Carrier Add (WebUI)")
+	_, _ = fmt.Fprintln(out, "-------------------")
+	_, _ = fmt.Fprintf(out, "Target agent: %s\n", agentID)
+
+	gatewayURL, err := ensureWebUIServices(out)
+	if err != nil {
+		return err
+	}
+	target := fmt.Sprintf("%s/#/add/%s", strings.TrimRight(gatewayURL, "/"), neturl.PathEscape(agentID))
+	_, _ = fmt.Fprintf(out, "\nOpening browser: %s\n", target)
+	if err := openBrowserFunc(target); err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: failed to open browser automatically: %v\n", err)
+		_, _ = fmt.Fprintln(out, "Please open the URL manually.")
+	}
+	return nil
+}
+
+func ensureWebUIServices(out io.Writer) (string, error) {
+
+	daemonURL := daemonProbeBaseURL()
+	if daemonHealthProbe(daemonURL) {
+		_, _ = fmt.Fprintf(out, "Daemon already running at %s, reusing existing process.\n", daemonURL)
+	} else {
+		_, _ = fmt.Fprintf(out, "Daemon not detected at %s, starting in background...\n", daemonURL)
+		if err := daemonBackgroundStarter(); err != nil {
+			return "", fmt.Errorf("start daemon in background: %w", err)
+		}
+		if err := waitForDaemonHealthy(daemonURL, daemonBootTimeout); err != nil {
+			return "", fmt.Errorf("daemon failed to become healthy at %s within %s: %w", daemonURL, daemonBootTimeout, err)
+		}
+		_, _ = fmt.Fprintf(out, "Daemon started and healthy at %s.\n", daemonURL)
+	}
+
+	pairCode, pairCodeExpiresAt, err := daemonPairCodeFetcher(daemonURL)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: failed to fetch pair code from daemon: %v\n", err)
+	} else if strings.TrimSpace(pairCode) != "" {
+		_, _ = fmt.Fprintln(out, "")
+		_, _ = fmt.Fprintf(out, "PAIR_CODE: %s\n", pairCode)
+		if strings.TrimSpace(pairCodeExpiresAt) != "" {
+			if expiry, parseErr := time.Parse(time.RFC3339Nano, pairCodeExpiresAt); parseErr == nil {
+				remaining := time.Until(expiry)
+				if remaining < 0 {
+					remaining = 0
+				}
+				_, _ = fmt.Fprintf(out, "(expires in %s)\n", remaining.Round(time.Second))
+			} else {
+				_, _ = fmt.Fprintf(out, "(expiresAt: %s)\n", pairCodeExpiresAt)
+			}
+		}
+	}
+
+	gatewayURL := gatewayProbeBaseURL()
+	if gatewayHealthProbe(gatewayURL) {
+		_, _ = fmt.Fprintf(out, "\nGateway already running at %s.\n", gatewayURL)
+	} else {
+		_, _ = fmt.Fprintf(out, "\nGateway not detected at %s, starting in background...\n", gatewayURL)
+		if err := gatewayBackgroundStarter(); err != nil {
+			return "", fmt.Errorf("start gateway in background: %w", err)
+		}
+		if err := waitForGatewayHealthy(gatewayURL, gatewayBootTimeout); err != nil {
+			return "", fmt.Errorf("gateway failed to become healthy at %s within %s: %w", gatewayURL, gatewayBootTimeout, err)
+		}
+	}
+
+	if !checkWebUIReady(gatewayURL) {
+		return "", fmt.Errorf("gateway is running at %s but WebUI is not embedded (root route returned 404); rebuild with `go build -tags webui`", gatewayURL)
+	}
+	return gatewayURL, nil
+}
+
+func runAddTUI(in io.Reader, out io.Writer, agentID string) error {
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	if agentID == "" {
+		return errors.New("agent_id is required")
+	}
+	if !strings.EqualFold(agentID, "picoclaw") {
+		_, _ = fmt.Fprintf(out, "Adding %s via direct install/start...\n", agentID)
+		if _, err := ensureDaemonRunning(out); err != nil {
+			return err
+		}
+		if err := daemonAgentAction(agentID, "install"); err != nil {
+			return err
+		}
+		if err := daemonAgentAction(agentID, "start"); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(out, "✅ %s installed and started.\n", agentID)
+		return nil
+	}
+
+	reader := bufio.NewReader(in)
+	_, _ = fmt.Fprintln(out, "Carrier Add (TUI)")
+	_, _ = fmt.Fprintln(out, "-----------------")
+	_, _ = fmt.Fprintln(out, "Agent: PicoClaw")
+	_, _ = fmt.Fprintln(out, "Tip: for browser flow, run `carrier add picoclaw --webui`.")
+	instanceID, err := generateManagedInstanceID("picoclaw")
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "Instance: %s\n", instanceID)
+	_, _ = fmt.Fprintln(out, "Step 1/4: Configure chat channel")
+	channel, ok := parsePicoclawChannel("telegram")
+	if !ok {
+		return errors.New("picoclaw telegram channel is unavailable")
+	}
+	_, _ = fmt.Fprintf(out, "Using channel: %s (fixed)\n", channel.Name)
+	token, err := promptInput(reader, out, "Telegram bot token for PicoClaw", true)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Step 2/4: Configure LLM provider")
+	provider, err := pickMinimalProvider()
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "Using provider: %s (%s)\n", provider.Name, provider.ID)
+	_, _ = fmt.Fprintln(out, "Saved provider credential will be reused automatically when available.")
+	providerEnv, _, err := promptProviderAuthMinimal(reader, out, provider)
+	if err != nil {
+		return err
+	}
+	envVars := mergeEnvVars(providerEnv, nil)
+	if err := applyEnvVars(envVars); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Step 3/4: Prepare PicoClaw configuration")
+	result, err := preparePicoclawAddArtifacts(instanceID, channel.ID, token, provider, envVars)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "PicoClaw workspace: %s\n", result.WorkspacePath)
+	_, _ = fmt.Fprintf(out, "PicoClaw config: %s\n", result.ConfigPath)
+	_, _ = fmt.Fprintf(out, "Carrier record: %s\n", result.RecordPath)
+
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Step 4/4: Install and start PicoClaw")
+	if _, err := ensureDaemonRunning(out); err != nil {
+		return err
+	}
+	if err := daemonAgentAction("picoclaw", "install"); err != nil {
+		return err
+	}
+	if err := daemonAgentAction("picoclaw", "start"); err != nil {
+		return err
+	}
+	if pairCode, _ := daemonExtractPairCodeFromLogs("picoclaw"); strings.TrimSpace(pairCode) != "" {
+		_, _ = fmt.Fprintf(out, "PicoClaw pair code: %s\n", pairCode)
+		_, _ = fmt.Fprintf(out, "Next: send `/pair %s` in your PicoClaw Telegram bot chat.\n", pairCode)
+	} else {
+		_, _ = fmt.Fprintln(out, "Pair code not detected yet. Open PicoClaw Telegram bot chat and follow `/start` -> `/pair` prompts.")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	inst := managedAgentInstance{
+		ID:           instanceID,
+		Type:         "picoclaw",
+		AgentID:      "picoclaw",
+		GatewayURL:   gatewayProbeBaseURL(),
+		Workspace:    result.WorkspacePath,
+		ConfigPath:   result.ConfigPath,
+		RecordPath:   result.RecordPath,
+		Channel:      result.ChannelID,
+		Provider:     result.ProviderID,
+		RuntimeState: "running",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := upsertManagedInstance(inst); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(out, "✅ PicoClaw installed and started.")
+	return nil
+}
+
+func parsePicoclawChannel(input string) (picoclawChannel, bool) {
+	id := strings.ToLower(strings.TrimSpace(input))
+	for _, ch := range picoclawChannels {
+		if id == ch.ID {
+			return ch, true
+		}
+	}
+	return picoclawChannel{}, false
+}
+
+func promptAdditionalEnvVars(reader *bufio.Reader, out io.Writer) (map[string]string, error) {
+	vars := map[string]string{}
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "Step 2.5/4: Additional environment variables (optional)")
+	_, _ = fmt.Fprintln(out, "Enter KEY=VALUE pairs; type `done` to continue.")
+	for {
+		line, err := promptInput(reader, out, "env", false)
+		if err != nil {
+			return nil, err
+		}
+		text := strings.TrimSpace(line)
+		if text == "" || strings.EqualFold(text, "done") || strings.EqualFold(text, "skip") {
+			return vars, nil
+		}
+		eq := strings.IndexByte(text, '=')
+		if eq <= 0 {
+			_, _ = fmt.Fprintln(out, "Invalid format. Please use KEY=VALUE or `done`.")
+			continue
+		}
+		key := strings.TrimSpace(text[:eq])
+		value := strings.TrimSpace(text[eq+1:])
+		if key == "" || value == "" {
+			_, _ = fmt.Fprintln(out, "Invalid format. Please use KEY=VALUE with non-empty key/value.")
+			continue
+		}
+		vars[key] = value
+	}
+}
+
+func ensureDaemonRunning(out io.Writer) (string, error) {
+	daemonURL := daemonProbeBaseURL()
+	if daemonHealthProbe(daemonURL) {
+		_, _ = fmt.Fprintf(out, "Daemon already running at %s, reusing existing process.\n", daemonURL)
+		return daemonURL, nil
+	}
+	_, _ = fmt.Fprintf(out, "Daemon not detected at %s, starting in background...\n", daemonURL)
+	if err := daemonBackgroundStarter(); err != nil {
+		return "", fmt.Errorf("start daemon in background: %w", err)
+	}
+	if err := waitForDaemonHealthy(daemonURL, daemonBootTimeout); err != nil {
+		return "", fmt.Errorf("daemon failed to become healthy at %s within %s: %w", daemonURL, daemonBootTimeout, err)
+	}
+	_, _ = fmt.Fprintf(out, "Daemon started and healthy at %s.\n", daemonURL)
+	return daemonURL, nil
+}
+
+func daemonAgentAction(agentID, action string) error {
+	agentID = strings.TrimSpace(agentID)
+	action = strings.TrimSpace(action)
+	if agentID == "" || action == "" {
+		return errors.New("agentID and action are required")
+	}
+	path := fmt.Sprintf("/api/v1/agents/%s/%s", neturl.PathEscape(agentID), neturl.PathEscape(action))
+	_, status, err := daemonRequest(http.MethodPost, path, map[string]string{})
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("daemon %s %s failed with status %d", action, agentID, status)
+	}
+	return nil
+}
+
+func daemonExtractPairCodeFromLogs(agentID string) (string, error) {
+	raw, status, err := daemonRequest(http.MethodGet, fmt.Sprintf("/api/v1/agents/%s/logs?tail=120", neturl.PathEscape(strings.TrimSpace(agentID))), nil)
+	if err != nil {
+		return "", err
+	}
+	if status < 200 || status >= 300 {
+		return "", fmt.Errorf("daemon logs request failed with status %d", status)
+	}
+	var payload struct {
+		Lines []string `json:"lines"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", fmt.Errorf("decode logs response: %w", err)
+	}
+	for _, line := range payload.Lines {
+		if code := strings.TrimSpace(picoclawPairCodePattern.FindString(line)); code != "" {
+			return code, nil
+		}
+	}
+	return "", nil
+}
+
+func daemonRequest(method, path string, body any) ([]byte, int, error) {
+	base := strings.TrimRight(strings.TrimSpace(daemonProbeBaseURL()), "/")
+	if base == "" {
+		return nil, 0, errors.New("daemon base url is empty")
+	}
+	target := base + "/" + strings.TrimLeft(strings.TrimSpace(path), "/")
+
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, target, reader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	addDaemonAuthHeader(req)
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return raw, resp.StatusCode, nil
+	}
+
+	var errBody struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(raw, &errBody) == nil && strings.TrimSpace(errBody.Error.Message) != "" {
+		return raw, resp.StatusCode, fmt.Errorf("daemon request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(errBody.Error.Message))
+	}
+	if msg := strings.TrimSpace(string(raw)); msg != "" {
+		return raw, resp.StatusCode, fmt.Errorf("daemon request failed with status %d: %s", resp.StatusCode, msg)
+	}
+	return raw, resp.StatusCode, fmt.Errorf("daemon request failed with status %d", resp.StatusCode)
+}
+
+func preparePicoclawAddArtifacts(instanceID, channelID, channelToken string, provider choiceOption, envVars map[string]string) (*picoclawAddResult, error) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return nil, errors.New("picoclaw instance id is required")
+	}
+	channelID = strings.TrimSpace(channelID)
+	channelToken = strings.TrimSpace(channelToken)
+	if channelID == "" {
+		return nil, errors.New("picoclaw channel is required")
+	}
+	if channelToken == "" {
+		return nil, errors.New("picoclaw channel token is required")
+	}
+	if strings.TrimSpace(provider.ID) == "" {
+		return nil, errors.New("picoclaw provider is required")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	workspacePath := filepath.Join(home, ".picoclaw", "instances", instanceID, "workspace")
+	configPath := filepath.Join(home, ".picoclaw", "config.json")
+	recordPath := filepath.Join(home, ".carrier", "agents", instanceID+".json")
+
+	if err := os.MkdirAll(workspacePath, 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(recordPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create record dir: %w", err)
+	}
+	if err := backupIfExists(configPath); err != nil {
+		return nil, fmt.Errorf("backup existing picoclaw config: %w", err)
+	}
+
+	modelID := strings.TrimSpace(provider.ExampleModel)
+	if modelID == "" {
+		modelID = provider.ID + "/default"
+	}
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		if _, name, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(name) != "" {
+			modelID = "openai/" + strings.TrimSpace(name)
+		} else {
+			modelID = "openai/gpt-5.3-codex"
+		}
+	}
+	modelName := modelID
+	if _, name, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(name) != "" {
+		modelName = strings.TrimSpace(name)
+	}
+
+	providerKey := provider.ID
+	if vendor, _, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(vendor) != "" {
+		providerKey = strings.TrimSpace(vendor)
+	}
+	providerKey = mapCarrierProviderToPicoclawProvider(providerKey)
+
+	modelItem := map[string]interface{}{
+		"model_name": modelName,
+		"model":      modelID,
+	}
+	providerItem := map[string]interface{}{}
+	token := pickProviderTokenForPicoclaw(provider, envVars)
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		modelItem["auth_method"] = "oauth"
+		providerItem["auth_method"] = "oauth"
+		if token != "" {
+			modelItem["api_key"] = token
+			providerItem["api_key"] = token
+		}
+		accountID := extractOpenAIAccountIDFromToken(token)
+		if err := savePicoclawAuthCredential(home, "openai", token, accountID); err != nil {
+			return nil, fmt.Errorf("write picoclaw auth store: %w", err)
+		}
+	} else if token != "" {
+		modelItem["api_key"] = token
+		providerItem["api_key"] = token
+	}
+
+	payload := map[string]interface{}{
+		"agents": map[string]interface{}{
+			"defaults": map[string]interface{}{
+				"workspace":             workspacePath,
+				"provider":              providerKey,
+				"model":                 modelName,
+				"max_tokens":            8192,
+				"temperature":           0.7,
+				"max_tool_iterations":   20,
+				"restrict_to_workspace": true,
+			},
+		},
+		"model_list": []interface{}{modelItem},
+		"providers": map[string]interface{}{
+			providerKey: providerItem,
+		},
+		"channels": map[string]interface{}{
+			channelID: map[string]interface{}{
+				"enabled":    true,
+				"token":      channelToken,
+				"allow_from": []string{},
+			},
+		},
+	}
+
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal picoclaw config: %w", err)
+	}
+	if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("write picoclaw config: %w", err)
+	}
+
+	record := map[string]interface{}{
+		"instance_id":    instanceID,
+		"agent_id":       "picoclaw",
+		"workspace_path": workspacePath,
+		"config_path":    configPath,
+		"channel":        channelID,
+		"provider":       provider.ID,
+		"updated_at":     time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	recordRaw, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal carrier record: %w", err)
+	}
+	if err := os.WriteFile(recordPath, append(recordRaw, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("write carrier record: %w", err)
+	}
+
+	return &picoclawAddResult{
+		InstanceID:    instanceID,
+		WorkspacePath: workspacePath,
+		ConfigPath:    configPath,
+		RecordPath:    recordPath,
+		ChannelID:     channelID,
+		ProviderID:    provider.ID,
+	}, nil
+}
+
+func backupIfExists(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	backupPath := fmt.Sprintf("%s.bak.%s", path, time.Now().UTC().Format("20060102T150405Z"))
+	return os.Rename(path, backupPath)
+}
+
+func mapCarrierProviderToPicoclawProvider(providerID string) string {
+	switch strings.ToLower(strings.TrimSpace(providerID)) {
+	case "openai-codex":
+		return "openai"
+	default:
+		return strings.TrimSpace(providerID)
+	}
+}
+
+func pickProviderTokenForPicoclaw(provider choiceOption, envVars map[string]string) string {
+	if envVars == nil {
+		return ""
+	}
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		for _, key := range []string{"OPENAI_CODEX_TOKEN", "OPENAI_API_KEY", provider.ProviderEnv} {
+			if token := strings.TrimSpace(envVars[key]); token != "" {
+				return token
+			}
+		}
+		return ""
+	}
+	if provider.ProviderEnv == "" {
+		return ""
+	}
+	return strings.TrimSpace(envVars[provider.ProviderEnv])
+}
+
+type picoclawAuthCredential struct {
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id,omitempty"`
+	Provider    string `json:"provider"`
+	AuthMethod  string `json:"auth_method"`
+}
+
+type picoclawAuthStore struct {
+	Credentials map[string]*picoclawAuthCredential `json:"credentials"`
+}
+
+func savePicoclawAuthCredential(home, providerID, accessToken, accountID string) error {
+	if strings.TrimSpace(accessToken) == "" {
+		return fmt.Errorf("empty access token")
+	}
+	path := filepath.Join(home, ".picoclaw", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create auth dir: %w", err)
+	}
+
+	store := picoclawAuthStore{Credentials: map[string]*picoclawAuthCredential{}}
+	if existing, err := os.ReadFile(path); err == nil && len(existing) > 0 {
+		if err := json.Unmarshal(existing, &store); err != nil {
+			return fmt.Errorf("parse existing auth store: %w", err)
+		}
+	}
+	if store.Credentials == nil {
+		store.Credentials = map[string]*picoclawAuthCredential{}
+	}
+	store.Credentials[strings.TrimSpace(providerID)] = &picoclawAuthCredential{
+		AccessToken: strings.TrimSpace(accessToken),
+		AccountID:   strings.TrimSpace(accountID),
+		Provider:    strings.TrimSpace(providerID),
+		AuthMethod:  "oauth",
+	}
+
+	raw, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal auth store: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write auth store: %w", err)
+	}
+	return nil
+}
+
+func extractOpenAIAccountIDFromToken(token string) string {
+	claims, err := parseJWTClaims(token)
+	if err != nil {
+		return ""
+	}
+	if accountID, ok := claims["chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		return strings.TrimSpace(accountID)
+	}
+	if accountID, ok := claims["https://api.openai.com/auth.chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		return strings.TrimSpace(accountID)
+	}
+	if authClaim, ok := claims["https://api.openai.com/auth"].(map[string]interface{}); ok {
+		if accountID, ok := authClaim["chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+			return strings.TrimSpace(accountID)
+		}
+	}
+	return ""
+}
+
+func parseJWTClaims(token string) (map[string]interface{}, error) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("token is not a JWT")
+	}
+	payload := parts[1]
+	decoded, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode jwt payload: %w", err)
+		}
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return nil, fmt.Errorf("decode jwt claims: %w", err)
+	}
+	return claims, nil
+}
+
+func openBrowserURL(targetURL string) error {
+	targetURL = strings.TrimSpace(targetURL)
+	if targetURL == "" {
+		return errors.New("url is empty")
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", targetURL).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", targetURL).Start()
+	default:
+		return exec.Command("xdg-open", targetURL).Start()
+	}
+}
+
+func pickMinimalProvider() (choiceOption, error) {
+	defaultID := strings.ToLower(strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_PROVIDER_ID")))
+	if defaultID != "" {
+		if p, ok := resolveChoice(defaultID, providerOptions); ok {
+			return p, nil
+		}
+	}
+	if p, ok := resolveChoice("openai-codex", providerOptions); ok {
+		return p, nil
+	}
+	if len(providerOptions) == 0 {
+		return choiceOption{}, errors.New("no provider available")
+	}
+	return providerOptions[0], nil
+}
+
+func promptChannelCredentialsMinimal(reader *bufio.Reader, out io.Writer, channel choiceOption) (map[string]string, configv2.Channel, error) {
+	env := make(map[string]string)
+	cfg := configv2.Channel{
+		ID:      channel.ID,
+		Enabled: true,
+	}
+	token, err := promptInput(reader, out, "Telegram bot token (required, from @BotFather)", true)
+	if err != nil {
+		return nil, configv2.Channel{}, err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, configv2.Channel{}, errors.New("telegram bot token is required")
+	}
+	cfg.BotToken = token
+	cfg.TransportMode = "auto"
+	env["CARRIER_TELEGRAM_BOT_TOKEN"] = token
+	env["CARRIER_TELEGRAM_TRANSPORT_MODE"] = "auto"
+	return env, cfg, nil
+}
+
+func promptProviderAuthMinimal(reader *bufio.Reader, out io.Writer, provider choiceOption) (map[string]string, bool, error) {
+	switch provider.AuthMode {
+	case authModeAPIKey:
+		value, backend, ok, err := loadProviderCredential(provider.ID)
+		if err == nil && ok && strings.TrimSpace(value) != "" && strings.TrimSpace(provider.ProviderEnv) != "" {
+			_, _ = fmt.Fprintf(out, "Reusing saved %s credential (%s).\n", provider.Name, backend)
+			return map[string]string{provider.ProviderEnv: strings.TrimSpace(value)}, true, nil
+		}
+		label := fmt.Sprintf("%s API key", provider.Name)
+		apiKey, err := promptInput(reader, out, label, true)
+		if err != nil {
+			return nil, false, err
+		}
+		apiKey = strings.TrimSpace(apiKey)
+		if apiKey == "" {
+			return nil, false, fmt.Errorf("%s API key is required", provider.Name)
+		}
+		if err := saveProviderCredentialAuto(out, provider, apiKey); err != nil {
+			return nil, false, err
+		}
+		return map[string]string{provider.ProviderEnv: apiKey}, true, nil
+	case authModeOAuthDeviceCode:
+		value, backend, ok, err := loadProviderCredential(provider.ID)
+		if err == nil && ok && strings.TrimSpace(value) != "" && strings.TrimSpace(provider.ProviderEnv) != "" {
+			_, _ = fmt.Fprintf(out, "Reusing saved %s credential (%s).\n", provider.Name, backend)
+			return map[string]string{provider.ProviderEnv: strings.TrimSpace(value)}, true, nil
+		}
+		if provider.ID == "openai-codex" {
+			token, err := runOpenAICodexDeviceCodeFlow(out)
+			if err != nil {
+				return nil, false, fmt.Errorf("openai-codex device-code login: %w", err)
+			}
+			token = strings.TrimSpace(token)
+			if token == "" {
+				return nil, false, errors.New("openai-codex token is empty")
+			}
+			if err := saveProviderCredentialAuto(out, provider, token); err != nil {
+				return nil, false, err
+			}
+			return map[string]string{provider.ProviderEnv: token}, true, nil
+		}
+		_, _ = fmt.Fprintln(out, "")
+		_, _ = fmt.Fprintf(out, "%s uses OAuth device-code authorization.\n", provider.Name)
+		_, _ = fmt.Fprintf(out, "Please complete the device-code flow in your auth tool, then paste %s.\n", provider.ProviderEnv)
+		token, err := promptInput(reader, out, fmt.Sprintf("%s token (%s)", provider.Name, provider.ProviderEnv), true)
+		if err != nil {
+			return nil, false, err
+		}
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return nil, false, fmt.Errorf("%s token is required", provider.Name)
+		}
+		if err := saveProviderCredentialAuto(out, provider, token); err != nil {
+			return nil, false, err
+		}
+		return map[string]string{provider.ProviderEnv: token}, true, nil
+	case authModeNone:
+		_, _ = fmt.Fprintf(out, "%s does not require provider auth.\n", provider.Name)
+		return nil, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported provider auth mode: %s", provider.AuthMode)
+	}
+}
+
+func promptChannelCredentials(reader *bufio.Reader, out io.Writer, channel choiceOption) (map[string]string, configv2.Channel, error) {
+	env := make(map[string]string)
+	cfg := configv2.Channel{
+		ID:      channel.ID,
+		Enabled: true,
+	}
+
+	if channel.TokenEnv != "" {
+		required := channel.RequireToken
+		tokenLabel := fmt.Sprintf("%s access token", channel.Name)
+		if channel.ID == "telegram" {
+			tokenLabel = "Telegram bot token (required, from @BotFather)"
+		}
+		token, err := promptInput(reader, out, tokenLabel, required)
+		if err != nil {
+			return nil, configv2.Channel{}, err
+		}
+		if strings.TrimSpace(token) != "" {
+			env[channel.TokenEnv] = strings.TrimSpace(token)
+			cfg.BotToken = strings.TrimSpace(token)
+		}
+	}
+
+	if channel.SecretEnv != "" {
+		secretLabel := fmt.Sprintf("%s webhook secret (optional, press Enter to skip)", channel.Name)
+		if channel.ID == "discord" {
+			secretLabel = "Discord public key (optional, press Enter to skip)"
+		}
+		secret, err := promptInput(reader, out, secretLabel, false)
+		if err != nil {
+			return nil, configv2.Channel{}, err
+		}
+		if strings.TrimSpace(secret) != "" {
+			env[channel.SecretEnv] = strings.TrimSpace(secret)
+			cfg.WebhookSecret = strings.TrimSpace(secret)
+		}
+	}
+
+	if channel.ID == "telegram" {
+		mode, webhookURL, err := promptTelegramTransport(reader, out)
+		if err != nil {
+			return nil, configv2.Channel{}, err
+		}
+		cfg.TransportMode = mode
+		cfg.WebhookURL = webhookURL
+		if strings.TrimSpace(mode) != "" {
+			env["CARRIER_TELEGRAM_TRANSPORT_MODE"] = mode
+		}
+		if strings.TrimSpace(webhookURL) != "" {
+			env["CARRIER_TELEGRAM_WEBHOOK_URL"] = webhookURL
+		}
+	}
+	return env, cfg, nil
+}
+
+func promptProviderAuth(reader *bufio.Reader, out io.Writer, provider choiceOption) (map[string]string, bool, error) {
+	switch provider.AuthMode {
+	case authModeAPIKey:
+		reused, ok, err := maybeReuseSavedProviderCredential(reader, out, provider)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return reused, true, nil
+		}
+
+		label := fmt.Sprintf("%s API key", provider.Name)
+		apiKey, err := promptInput(reader, out, label, true)
+		if err != nil {
+			return nil, false, err
+		}
+		cred := map[string]string{provider.ProviderEnv: apiKey}
+		if err := saveProviderCredentialFlow(reader, out, provider, apiKey); err != nil {
+			return nil, false, err
+		}
+		return cred, true, nil
+	case authModeOAuthDeviceCode:
+		reused, ok, err := maybeReuseSavedProviderCredential(reader, out, provider)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return reused, true, nil
+		}
+
+		if provider.ID == "openai-codex" {
+			token, err := runOpenAICodexDeviceCodeFlow(out)
+			if err != nil {
+				return nil, false, fmt.Errorf("openai-codex device-code login: %w", err)
+			}
+			cred := map[string]string{provider.ProviderEnv: token}
+			if err := saveProviderCredentialAuto(out, provider, token); err != nil {
+				return nil, false, err
+			}
+			return cred, true, nil
+		}
+
+		_, _ = fmt.Fprintln(out, "")
+		_, _ = fmt.Fprintf(out, "%s uses OAuth device-code authorization.\n", provider.Name)
+		_, _ = fmt.Fprintf(out, "Please complete the device-code flow in your auth tool, then paste %s.\n", provider.ProviderEnv)
+		token, err := promptInput(reader, out, fmt.Sprintf("%s token (%s)", provider.Name, provider.ProviderEnv), true)
+		if err != nil {
+			return nil, false, err
+		}
+		cred := map[string]string{provider.ProviderEnv: token}
+		if err := saveProviderCredentialAuto(out, provider, token); err != nil {
+			return nil, false, err
+		}
+		return cred, true, nil
+	case authModeNone:
+		_, _ = fmt.Fprintf(out, "%s does not require provider auth.\n", provider.Name)
+		return nil, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported provider auth mode: %s", provider.AuthMode)
+	}
+}
+
+func maybeReuseSavedProviderCredential(reader *bufio.Reader, out io.Writer, provider choiceOption) (map[string]string, bool, error) {
+	if strings.TrimSpace(provider.ProviderEnv) == "" {
+		return nil, false, nil
+	}
+	value, backend, ok, err := loadProviderCredential(provider.ID)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Warning: failed to read saved credential for %s: %v\n", provider.Name, err)
+		return nil, false, nil
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	reuse, err := promptYesNo(reader, out, fmt.Sprintf("Reuse saved %s credential from %s", provider.Name, backend), true)
+	if err != nil {
+		return nil, false, err
+	}
+	if !reuse {
+		return nil, false, nil
+	}
+	return map[string]string{provider.ProviderEnv: value}, true, nil
+}
+
+func saveProviderCredentialFlow(reader *bufio.Reader, out io.Writer, provider choiceOption, value string) error {
+	save, err := promptYesNo(reader, out, fmt.Sprintf("Save %s credential for future reuse", provider.Name), true)
+	if err != nil {
+		return err
+	}
+	if !save {
+		return nil
+	}
+	backend, err := saveProviderCredential(provider.ID, value)
+	if err != nil {
+		return fmt.Errorf("save credential: %w", err)
+	}
+	_, _ = fmt.Fprintf(out, "Credential saved (%s).\n", backend)
+	return nil
+}
+
+func saveProviderCredentialAuto(out io.Writer, provider choiceOption, value string) error {
+	backend, err := saveProviderCredential(provider.ID, value)
+	if err != nil {
+		return fmt.Errorf("save credential: %w", err)
+	}
+	_, _ = fmt.Fprintf(out, "Credential saved (%s).\n", backend)
+	return nil
+}
+
+func promptYesNo(reader *bufio.Reader, out io.Writer, label string, defaultYes bool) (bool, error) {
+	suffix := "[y/N]"
+	if defaultYes {
+		suffix = "[Y/n]"
+	}
+	for {
+		_, _ = fmt.Fprintf(out, "%s %s: ", label, suffix)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				text := strings.ToLower(strings.TrimSpace(line))
+				if text == "" {
+					return defaultYes, nil
+				}
+				switch text {
+				case "y", "yes":
+					return true, nil
+				case "n", "no":
+					return false, nil
+				default:
+					return false, errors.New("input interrupted")
+				}
+			}
+			return false, err
+		}
+		text := strings.ToLower(strings.TrimSpace(line))
+		if text == "" {
+			return defaultYes, nil
+		}
+		switch text {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			_, _ = fmt.Fprintln(out, "Please answer yes or no.")
+		}
+	}
+}
+
+func promptInput(reader *bufio.Reader, out io.Writer, label string, required bool) (string, error) {
+	for {
+		_, _ = fmt.Fprintf(out, "%s: ", label)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				value := strings.TrimSpace(line)
+				if value != "" || !required {
+					return value, nil
+				}
+				return "", errors.New("input interrupted")
+			}
+			return "", err
+		}
+		value := strings.TrimSpace(line)
+		if value == "" && required {
+			_, _ = fmt.Fprintln(out, "This field is required, please retry.")
+			continue
+		}
+		return value, nil
+	}
+}
+
+func performOpenAICodexDeviceCodeFlow(out io.Writer) (string, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	deviceAuthID, userCode, pollInterval, err := requestOpenAICodexUserCode(client)
+	if err != nil {
+		return "", err
+	}
+	_, _ = fmt.Fprintln(out, "")
+	_, _ = fmt.Fprintln(out, "OpenAI Codex device-code login")
+	_, _ = fmt.Fprintln(out, "1. Open this URL in your browser:")
+	_, _ = fmt.Fprintf(out, "   %s\n", openAICodexVerificationURL)
+	_, _ = fmt.Fprintln(out, "2. Enter this one-time code:")
+	_, _ = fmt.Fprintf(out, "   %s\n", userCode)
+	_, _ = fmt.Fprintln(out, "Waiting for authorization (up to 15 minutes)...")
+
+	authorizationCode, codeVerifier, err := pollOpenAICodexAuthorization(client, deviceAuthID, userCode, pollInterval, openAICodexDeviceAuthTimeout)
+	if err != nil {
+		return "", err
+	}
+	token, err := exchangeOpenAICodexToken(client, authorizationCode, codeVerifier)
+	if err != nil {
+		return "", err
+	}
+	_, _ = fmt.Fprintln(out, "OpenAI Codex authorization completed.")
+	return token, nil
+}
+
+func requestOpenAICodexUserCode(client *http.Client) (string, string, int, error) {
+	status, body, err := postJSON(
+		client,
+		openAICodexAuthBaseURL+"/api/accounts/deviceauth/usercode",
+		map[string]string{
+			"client_id": openAICodexClientID,
+		},
+	)
+	if err != nil {
+		return "", "", 0, err
+	}
+	if status < 200 || status >= 300 {
+		return "", "", 0, fmt.Errorf("request user code failed: status=%d body=%s", status, strings.TrimSpace(string(body)))
+	}
+	var resp struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+		Interval     string `json:"interval"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", "", 0, fmt.Errorf("decode user code response: %w", err)
+	}
+	deviceAuthID := strings.TrimSpace(resp.DeviceAuthID)
+	userCode := strings.TrimSpace(resp.UserCode)
+	if deviceAuthID == "" || userCode == "" {
+		return "", "", 0, errors.New("device-code response missing device_auth_id or user_code")
+	}
+	pollInterval := openAICodexDefaultPollSeconds
+	if n, err := strconv.Atoi(strings.TrimSpace(resp.Interval)); err == nil && n > 0 {
+		pollInterval = n
+	}
+	return deviceAuthID, userCode, pollInterval, nil
+}
+
+func pollOpenAICodexAuthorization(client *http.Client, deviceAuthID, userCode string, pollIntervalSeconds int, timeout time.Duration) (string, string, error) {
+	deadline := time.Now().Add(timeout)
+	first := true
+
+	for time.Now().Before(deadline) {
+		if !first {
+			time.Sleep(time.Duration(pollIntervalSeconds) * time.Second)
+		}
+		first = false
+
+		status, body, err := postJSON(
+			client,
+			openAICodexAuthBaseURL+"/api/accounts/deviceauth/token",
+			map[string]string{
+				"device_auth_id": deviceAuthID,
+				"user_code":      userCode,
+			},
+		)
+		if err != nil {
+			return "", "", err
+		}
+		if status >= 200 && status < 300 {
+			var resp struct {
+				AuthorizationCode string `json:"authorization_code"`
+				CodeVerifier      string `json:"code_verifier"`
+			}
+			if err := json.Unmarshal(body, &resp); err != nil {
+				return "", "", fmt.Errorf("decode deviceauth token response: %w", err)
+			}
+			authCode := strings.TrimSpace(resp.AuthorizationCode)
+			verifier := strings.TrimSpace(resp.CodeVerifier)
+			if authCode == "" || verifier == "" {
+				return "", "", errors.New("deviceauth token response missing authorization_code or code_verifier")
+			}
+			return authCode, verifier, nil
+		}
+		if status == http.StatusForbidden || status == http.StatusNotFound {
+			continue
+		}
+		return "", "", fmt.Errorf("deviceauth polling failed: status=%d body=%s", status, strings.TrimSpace(string(body)))
+	}
+	return "", "", errors.New("openai-codex device-code authorization timed out")
+}
+
+func exchangeOpenAICodexToken(client *http.Client, authorizationCode, codeVerifier string) (string, error) {
+	status, body, err := postJSON(
+		client,
+		openAICodexAuthBaseURL+"/oauth/token",
+		map[string]string{
+			"grant_type":    "authorization_code",
+			"client_id":     openAICodexClientID,
+			"code":          authorizationCode,
+			"code_verifier": codeVerifier,
+			"redirect_uri":  openAICodexAuthBaseURL + "/deviceauth/callback",
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if status < 200 || status >= 300 {
+		return "", fmt.Errorf("token exchange failed: status=%d body=%s", status, strings.TrimSpace(string(body)))
+	}
+	var resp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("decode oauth token response: %w", err)
+	}
+	token := strings.TrimSpace(resp.AccessToken)
+	if token == "" {
+		return "", errors.New("oauth token response missing access_token")
+	}
+	return token, nil
+}
+
+func postJSON(client *http.Client, url string, payload any) (int, []byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("marshal request payload: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return 0, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read response body: %w", err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+func gatewayProbeBaseURL() string {
+	host := strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_HOST"))
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	port := strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_PORT"))
+	if port == "" {
+		port = "8787"
+	}
+	return fmt.Sprintf("http://%s:%s", host, port)
+}
+
+func checkGatewayHealth(baseURL string) bool {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 1200 * time.Millisecond}
+	resp, err := client.Get(base + "/healthz")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func daemonProbeBaseURL() string {
+	host := strings.TrimSpace(os.Getenv("CARRIER_SERVER_HOST"))
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	port := strings.TrimSpace(os.Getenv("CARRIER_SERVER_PORT"))
+	if port == "" {
+		port = "9090"
+	}
+	return fmt.Sprintf("http://%s:%s", host, port)
+}
+
+func checkDaemonHealth(baseURL string) bool {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 1200 * time.Millisecond}
+	req, err := http.NewRequest(http.MethodGet, base+"/healthz", nil)
+	if err != nil {
+		return false
+	}
+	addDaemonAuthHeader(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func waitForDaemonHealthy(baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if daemonHealthProbe(baseURL) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("daemon health probe timed out")
+		}
+		time.Sleep(daemonBootPollInterval)
+	}
+}
+
+func waitForGatewayHealthy(baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if gatewayHealthProbe(baseURL) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("gateway health probe timed out")
+		}
+		time.Sleep(daemonBootPollInterval)
+	}
+}
+
+func startDaemonInBackground() error {
+	return startBackgroundSubprocess("daemon", "daemon")
+}
+
+func startGatewayInBackground() error {
+	return startBackgroundSubprocess("gateway", "gateway")
+}
+
+func startBackgroundSubprocess(subcommand, logName string) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current executable: %w", err)
+	}
+	cmd := exec.Command(exePath, subcommand)
+	cmd.Env = os.Environ()
+	if bootstrapVerboseEnabled() {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	} else {
+		logFile, _, err := openBootstrapLogFile(logName)
+		if err != nil {
+			return err
+		}
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+		if err := cmd.Start(); err != nil {
+			_ = logFile.Close()
+			return err
+		}
+		_ = logFile.Close()
+		if err := writeBootstrapPIDFile(logName, cmd.Process.Pid); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := writeBootstrapPIDFile(logName, cmd.Process.Pid); err != nil {
+		return err
+	}
+	return nil
+}
+
+func bootstrapVerboseEnabled() bool {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("CARRIER_BOOTSTRAP_VERBOSE")))
+	return raw == "1" || raw == "true" || raw == "yes" || raw == "on"
+}
+
+func bootstrapLogDir() (string, error) {
+	if customDir := strings.TrimSpace(os.Getenv("CARRIER_BOOTSTRAP_LOG_DIR")); customDir != "" {
+		if err := os.MkdirAll(customDir, 0o700); err != nil {
+			return "", fmt.Errorf("create bootstrap log dir %s: %w", customDir, err)
+		}
+		return customDir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for logs: %w", err)
+	}
+	dir := filepath.Join(home, ".carrier", "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create bootstrap log dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+func bootstrapRunDir() (string, error) {
+	if customDir := strings.TrimSpace(os.Getenv("CARRIER_BOOTSTRAP_RUN_DIR")); customDir != "" {
+		if err := os.MkdirAll(customDir, 0o700); err != nil {
+			return "", fmt.Errorf("create bootstrap run dir %s: %w", customDir, err)
+		}
+		return customDir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for run dir: %w", err)
+	}
+	dir := filepath.Join(home, ".carrier", "run")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create bootstrap run dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+func bootstrapPIDPath(name string) (string, error) {
+	dir, err := bootstrapRunDir()
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimSpace(name)
+	if base == "" {
+		base = "carrier"
+	}
+	return filepath.Join(dir, base+".pid"), nil
+}
+
+func mustBootstrapPIDPath(name string) string {
+	path, err := bootstrapPIDPath(name)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func writeBootstrapPIDFile(name string, pid int) error {
+	path, err := bootstrapPIDPath(name)
+	if err != nil {
+		return err
+	}
+	raw := []byte(fmt.Sprintf("%d\n", pid))
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return fmt.Errorf("write pid file %s: %w", path, err)
+	}
+	return nil
+}
+
+func bootstrapLogPath(logName string) (string, error) {
+	dir, err := bootstrapLogDir()
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimSpace(logName)
+	if base == "" {
+		base = "carrier"
+	}
+	return filepath.Join(dir, base+".log"), nil
+}
+
+func openBootstrapLogFile(logName string) (*os.File, string, error) {
+	path, err := bootstrapLogPath(logName)
+	if err != nil {
+		return nil, "", err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, "", fmt.Errorf("open log file %s: %w", path, err)
+	}
+	return file, path, nil
+}
+
+type daemonPairCodeRecord struct {
+	Code      string `json:"code"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+func fetchDaemonPairCode(baseURL string) (string, string, error) {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return "", "", errors.New("daemon probe url is empty")
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	req, err := http.NewRequest(http.MethodGet, base+"/api/v1/pairing/codes", nil)
+	if err != nil {
+		return "", "", err
+	}
+	addDaemonAuthHeader(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return "", "", readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", fmt.Errorf("list pairing codes failed with status %d", resp.StatusCode)
+	}
+
+	var listed struct {
+		Codes []daemonPairCodeRecord `json:"codes"`
+	}
+	if err := json.Unmarshal(body, &listed); err != nil {
+		return "", "", fmt.Errorf("decode pairing code list: %w", err)
+	}
+	for _, rec := range listed.Codes {
+		if strings.TrimSpace(rec.Code) != "" {
+			return strings.TrimSpace(rec.Code), strings.TrimSpace(rec.ExpiresAt), nil
+		}
+	}
+
+	issueReq, err := http.NewRequest(http.MethodPost, base+"/api/v1/pairing/codes", strings.NewReader(fmt.Sprintf(`{"ttlSeconds":%d}`, defaultPairCodeTTLSeconds)))
+	if err != nil {
+		return "", "", err
+	}
+	issueReq.Header.Set("Content-Type", "application/json")
+	addDaemonAuthHeader(issueReq)
+	issueResp, err := client.Do(issueReq)
+	if err != nil {
+		return "", "", err
+	}
+	issueBody, readIssueErr := io.ReadAll(issueResp.Body)
+	_ = issueResp.Body.Close()
+	if readIssueErr != nil {
+		return "", "", readIssueErr
+	}
+	if issueResp.StatusCode < 200 || issueResp.StatusCode >= 300 {
+		return "", "", fmt.Errorf("issue pairing code failed with status %d", issueResp.StatusCode)
+	}
+	var issued daemonPairCodeRecord
+	if err := json.Unmarshal(issueBody, &issued); err != nil {
+		return "", "", fmt.Errorf("decode issued pairing code: %w", err)
+	}
+	code := strings.TrimSpace(issued.Code)
+	if code == "" {
+		return "", "", errors.New("daemon returned empty pairing code")
+	}
+	return code, strings.TrimSpace(issued.ExpiresAt), nil
+}
+
+func addDaemonAuthHeader(req *http.Request) {
+	if req == nil {
+		return
+	}
+	if token := strings.TrimSpace(os.Getenv("CARRIER_SERVER_API_TOKEN")); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+func checkWebUIReady(gatewayBaseURL string) bool {
+	base := strings.TrimRight(strings.TrimSpace(gatewayBaseURL), "/")
+	if base == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 1500 * time.Millisecond}
+	resp, err := client.Get(base + "/")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func isAddressInUseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if strings.Contains(strings.ToLower(opErr.Error()), "address already in use") {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "address already in use")
+}
+
+func loadProviderCredential(providerID string) (string, string, bool, error) {
+	service := providerCredentialService(providerID)
+	if value, err := loadCredentialFromKeychain(service); err == nil {
+		return value, "macOS-keychain", true, nil
+	} else if !errors.Is(err, errCredentialNotFound) && !errors.Is(err, errCredentialBackendUnavailable) {
+		return "", "", false, err
+	}
+
+	value, err := loadCredentialFromFile(providerID)
+	if err == nil {
+		return value, "local-file", true, nil
+	}
+	if errors.Is(err, errCredentialNotFound) {
+		return "", "", false, nil
+	}
+	return "", "", false, err
+}
+
+func saveProviderCredential(providerID, value string) (string, error) {
+	service := providerCredentialService(providerID)
+	if err := saveCredentialToKeychain(service, value); err == nil {
+		return "macOS-keychain", nil
+	} else if !errors.Is(err, errCredentialBackendUnavailable) {
+		return "", err
+	}
+	if err := saveCredentialToFile(providerID, value); err != nil {
+		return "", err
+	}
+	return "local-file", nil
+}
+
+func providerCredentialService(providerID string) string {
+	return "carrier.provider." + strings.TrimSpace(providerID)
+}
+
+func keychainAvailable() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("CARRIER_DISABLE_KEYCHAIN")), "1") {
+		return false
+	}
+	_, err := exec.LookPath("security")
+	return err == nil
+}
+
+func loadCredentialFromKeychain(service string) (string, error) {
+	if !keychainAvailable() {
+		return "", errCredentialBackendUnavailable
+	}
+	cmd := exec.Command("security", "find-generic-password", "-a", "carrier", "-s", service, "-w")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.ToLower(strings.TrimSpace(stderr.String()))
+		if strings.Contains(msg, "could not be found") || strings.Contains(msg, "item not found") {
+			return "", errCredentialNotFound
+		}
+		return "", fmt.Errorf("read keychain credential for %s", service)
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", errCredentialNotFound
+	}
+	return value, nil
+}
+
+func saveCredentialToKeychain(service, value string) error {
+	if !keychainAvailable() {
+		return errCredentialBackendUnavailable
+	}
+	cmd := exec.Command("security", "add-generic-password", "-U", "-a", "carrier", "-s", service, "-w", value)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write keychain credential for %s", service)
+	}
+	return nil
+}
+
+func loadCredentialFromFile(providerID string) (string, error) {
+	path, err := credentialStorePath()
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", errCredentialNotFound
+		}
+		return "", fmt.Errorf("read credential file: %w", err)
+	}
+	var payload struct {
+		Providers map[string]string `json:"providers"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", fmt.Errorf("parse credential file: %w", err)
+	}
+	if payload.Providers == nil {
+		return "", errCredentialNotFound
+	}
+	value := strings.TrimSpace(payload.Providers[providerID])
+	if value == "" {
+		return "", errCredentialNotFound
+	}
+	return value, nil
+}
+
+func saveCredentialToFile(providerID, value string) error {
+	path, err := credentialStorePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create credential directory: %w", err)
+	}
+
+	payload := struct {
+		Providers map[string]string `json:"providers"`
+	}{
+		Providers: make(map[string]string),
+	}
+	if raw, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(raw, &payload)
+		if payload.Providers == nil {
+			payload.Providers = make(map[string]string)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read credential file: %w", err)
+	}
+
+	payload.Providers[providerID] = value
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credential file: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write credential file: %w", err)
+	}
+	return nil
+}
+
+func credentialStorePath() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("CARRIER_CREDENTIAL_STORE")); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "credentials.json"), nil
+}
+
+func mergeEnvVars(sets ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, set := range sets {
+		for k, v := range set {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+func applyEnvVars(vars map[string]string) error {
+	for k, v := range vars {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("set env %s: %w", k, err)
+		}
+	}
+	return nil
+}
+
+func promptChoice(reader *bufio.Reader, out io.Writer, options []choiceOption) (choiceOption, error) {
+	if len(options) == 0 {
+		return choiceOption{}, errors.New("no options available")
+	}
+
+	for {
+		for i, opt := range options {
+			_, _ = fmt.Fprintf(out, "  %d) %s (%s)\n", i+1, opt.Name, opt.Setup)
+		}
+		_, _ = fmt.Fprint(out, "Select by number or id: ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return choiceOption{}, errors.New("input interrupted")
+			}
+			return choiceOption{}, err
+		}
+
+		selection, ok := resolveChoice(strings.TrimSpace(line), options)
+		if ok {
+			return selection, nil
+		}
+		_, _ = fmt.Fprintln(out, "Invalid selection, please retry.")
+	}
+}
+
+func promptMultiChoice(reader *bufio.Reader, out io.Writer, options []choiceOption, label string) ([]choiceOption, error) {
+	selected := make([]choiceOption, 0, len(options))
+	selectedSet := make(map[string]struct{})
+	for {
+		for i, opt := range options {
+			_, _ = fmt.Fprintf(out, "  %d) %s (%s)\n", i+1, opt.Name, opt.Setup)
+		}
+		if len(selected) > 0 {
+			names := make([]string, 0, len(selected))
+			for _, s := range selected {
+				names = append(names, s.Name)
+			}
+			_, _ = fmt.Fprintf(out, "Selected %s(s): %s\n", label, strings.Join(names, ", "))
+		}
+		_, _ = fmt.Fprintf(out, "Select %s by number or id (`done` to finish): ", label)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if len(selected) == 0 {
+					return nil, fmt.Errorf("at least one %s is required", label)
+				}
+				return selected, nil
+			}
+			return nil, err
+		}
+		input := strings.ToLower(strings.TrimSpace(line))
+		if input == "done" {
+			if len(selected) == 0 {
+				_, _ = fmt.Fprintf(out, "Please select at least one %s.\n", label)
+				continue
+			}
+			return selected, nil
+		}
+		choice, ok := resolveChoice(input, options)
+		if !ok {
+			_, _ = fmt.Fprintln(out, "Invalid selection, please retry.")
+			continue
+		}
+		if _, exists := selectedSet[choice.ID]; exists {
+			_, _ = fmt.Fprintln(out, "Already selected, choose another or type `done`.")
+			continue
+		}
+		selected = append(selected, choice)
+		selectedSet[choice.ID] = struct{}{}
+	}
+}
+
+func promptTelegramTransport(reader *bufio.Reader, out io.Writer) (mode string, webhookURL string, err error) {
+	_, _ = fmt.Fprintln(out, "Telegram transport mode: auto (recommended), webhook, polling")
+	rawMode, err := promptInput(reader, out, "Transport mode [auto/webhook/polling] (default auto)", false)
+	if err != nil {
+		return "", "", err
+	}
+	mode = strings.ToLower(strings.TrimSpace(rawMode))
+	if mode == "" {
+		mode = "auto"
+	}
+	switch mode {
+	case "auto", "webhook", "polling":
+	default:
+		return "", "", fmt.Errorf("invalid transport mode %q", mode)
+	}
+
+	if mode == "auto" || mode == "webhook" {
+		urlLabel := "Public webhook URL (optional for auto; required for webhook)"
+		webhookURL, err = promptInput(reader, out, urlLabel, mode == "webhook")
+		if err != nil {
+			return "", "", err
+		}
+		webhookURL = strings.TrimSpace(webhookURL)
+	}
+	return mode, webhookURL, nil
+}
+
+func resolveChoice(input string, options []choiceOption) (choiceOption, bool) {
+	if input == "" {
+		return choiceOption{}, false
+	}
+
+	if n, err := strconv.Atoi(input); err == nil {
+		if n >= 1 && n <= len(options) {
+			return options[n-1], true
+		}
+		return choiceOption{}, false
+	}
+
+	for _, opt := range options {
+		if strings.EqualFold(opt.ID, input) {
+			return opt, true
+		}
+	}
+	return choiceOption{}, false
+}
+
+func onboardConfigPath(
+	getenv func(string) string,
+	userHomeDir func() (string, error),
+) (string, error) {
+	if path := strings.TrimSpace(getenv("CARRIER_CONFIG")); path != "" {
+		return path, nil
+	}
+	if path := strings.TrimSpace(getenv("CARRIER_ONBOARD_CONFIG")); path != "" {
+		return path, nil
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "config.v2.json"), nil
+}
+
+func buildSlashCommandGuide(channel choiceOption) string {
+	return fmt.Sprintf(
+		"Next step in %s:\n1. Open your bot chat and send `/pair <PAIR_CODE>`\n2. Then send `/agents`\n3. Open Carrier GUI to install/onboard additional agents\n4. Use `/start <agent_id>` to start installed agents",
+		channel.Name,
+	)
 }

--- a/configv2/config.go
+++ b/configv2/config.go
@@ -1,0 +1,279 @@
+package configv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	CurrentVersion = 2
+)
+
+type Config struct {
+	ConfigVersion int           `json:"config_version"`
+	Channels      []Channel     `json:"channels"`
+	ModelList     []Model       `json:"model_list"`
+	DefaultModel  string        `json:"default_model"`
+	BaseAgent     BaseAgentSpec `json:"base_agent"`
+	ConfiguredAt  string        `json:"configured_at"`
+}
+
+type BaseAgentSpec struct {
+	Enabled           bool   `json:"enabled"`
+	PublicMemoryID    string `json:"public_memory_id"`
+	ActiveMemoryID    string `json:"active_memory_id"`
+	SelfHealBackupDir string `json:"self_heal_backup_dir,omitempty"`
+}
+
+type Channel struct {
+	ID            string `json:"id"`
+	BotToken      string `json:"bot_token,omitempty"`
+	WebhookSecret string `json:"webhook_secret,omitempty"`
+	WebhookURL    string `json:"webhook_url,omitempty"`
+	TransportMode string `json:"transport_mode,omitempty"` // auto|webhook|polling
+	Enabled       bool   `json:"enabled"`
+}
+
+type Model struct {
+	ModelName     string `json:"model_name"`
+	Model         string `json:"model"`
+	ProviderID    string `json:"provider_id"`
+	AuthMode      string `json:"auth_mode,omitempty"`
+	EnvVar        string `json:"env_var,omitempty"`
+	CredentialRef string `json:"credential_ref,omitempty"` // provider credential key
+}
+
+func DefaultPath() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("CARRIER_CONFIG")); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "config.v2.json"), nil
+}
+
+func Load() (*Config, string, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return nil, "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Config{ConfigVersion: CurrentVersion}, path, nil
+		}
+		return nil, "", fmt.Errorf("read config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, "", fmt.Errorf("parse config: %w", err)
+	}
+	if cfg.ConfigVersion != CurrentVersion {
+		return nil, "", fmt.Errorf("unsupported config_version=%d (expected %d). Please run `carrier onboard` again", cfg.ConfigVersion, CurrentVersion)
+	}
+	return &cfg, path, nil
+}
+
+func Save(cfg *Config) (string, error) {
+	if cfg == nil {
+		return "", errors.New("nil config")
+	}
+	cfg.ConfigVersion = CurrentVersion
+	path, err := DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create config directory: %w", err)
+	}
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return "", fmt.Errorf("write config: %w", err)
+	}
+	return path, nil
+}
+
+func ApplyGatewayEnvironment(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	// Channel settings.
+	for _, ch := range cfg.Channels {
+		if !ch.Enabled {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(ch.ID)) {
+		case "telegram":
+			if ch.BotToken != "" {
+				if err := os.Setenv("CARRIER_TELEGRAM_BOT_TOKEN", ch.BotToken); err != nil {
+					return err
+				}
+			}
+			if ch.WebhookSecret != "" {
+				if err := os.Setenv("CARRIER_TELEGRAM_WEBHOOK_SECRET", ch.WebhookSecret); err != nil {
+					return err
+				}
+			}
+			if ch.WebhookURL != "" {
+				if err := os.Setenv("CARRIER_TELEGRAM_WEBHOOK_URL", ch.WebhookURL); err != nil {
+					return err
+				}
+			}
+			mode := strings.ToLower(strings.TrimSpace(ch.TransportMode))
+			if mode != "" {
+				if err := os.Setenv("CARRIER_TELEGRAM_TRANSPORT_MODE", mode); err != nil {
+					return err
+				}
+			}
+		case "discord":
+			if ch.BotToken != "" {
+				if err := os.Setenv("CARRIER_DISCORD_BOT_TOKEN", ch.BotToken); err != nil {
+					return err
+				}
+			}
+			if ch.WebhookSecret != "" {
+				if err := os.Setenv("CARRIER_DISCORD_PUBLIC_KEY", ch.WebhookSecret); err != nil {
+					return err
+				}
+			}
+		case "feishu":
+			if ch.BotToken != "" {
+				if err := os.Setenv("CARRIER_FEISHU_APP_TOKEN", ch.BotToken); err != nil {
+					return err
+				}
+			}
+			if ch.WebhookSecret != "" {
+				if err := os.Setenv("CARRIER_FEISHU_VERIFICATION_TOKEN", ch.WebhookSecret); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Provider credentials (by credential reference).
+	for _, m := range cfg.ModelList {
+		if strings.TrimSpace(m.EnvVar) == "" || strings.TrimSpace(m.CredentialRef) == "" {
+			continue
+		}
+		if value, ok := loadCredential(m.CredentialRef); ok {
+			if err := os.Setenv(m.EnvVar, value); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Expose default model context for components that need runtime inference.
+	defaultModel := pickDefaultModel(cfg)
+	if defaultModel != nil {
+		if strings.TrimSpace(defaultModel.ModelName) != "" {
+			if err := os.Setenv("CARRIER_DEFAULT_MODEL_NAME", strings.TrimSpace(defaultModel.ModelName)); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(defaultModel.Model) != "" {
+			if err := os.Setenv("CARRIER_DEFAULT_MODEL_ID", strings.TrimSpace(defaultModel.Model)); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(defaultModel.ProviderID) != "" {
+			if err := os.Setenv("CARRIER_DEFAULT_PROVIDER_ID", strings.TrimSpace(defaultModel.ProviderID)); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(defaultModel.EnvVar) != "" {
+			if err := os.Setenv("CARRIER_DEFAULT_PROVIDER_ENV", strings.TrimSpace(defaultModel.EnvVar)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func pickDefaultModel(cfg *Config) *Model {
+	if cfg == nil || len(cfg.ModelList) == 0 {
+		return nil
+	}
+	defaultName := strings.TrimSpace(cfg.DefaultModel)
+	if defaultName != "" {
+		for i := range cfg.ModelList {
+			if strings.EqualFold(strings.TrimSpace(cfg.ModelList[i].ModelName), defaultName) {
+				return &cfg.ModelList[i]
+			}
+		}
+	}
+	return &cfg.ModelList[0]
+}
+
+func loadCredential(providerID string) (string, bool) {
+	service := "carrier.provider." + strings.TrimSpace(providerID)
+	if v, ok := loadCredentialFromKeychain(service); ok {
+		return v, true
+	}
+	if v, ok := loadCredentialFromFile(providerID); ok {
+		return v, true
+	}
+	return "", false
+}
+
+func loadCredentialFromKeychain(service string) (string, bool) {
+	if runtime.GOOS != "darwin" {
+		return "", false
+	}
+	if strings.TrimSpace(os.Getenv("CARRIER_DISABLE_KEYCHAIN")) == "1" {
+		return "", false
+	}
+	if _, err := exec.LookPath("security"); err != nil {
+		return "", false
+	}
+	cmd := exec.Command("security", "find-generic-password", "-a", "carrier", "-s", service, "-w")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func loadCredentialFromFile(providerID string) (string, bool) {
+	path := strings.TrimSpace(os.Getenv("CARRIER_CREDENTIAL_STORE"))
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		path = filepath.Join(home, ".carrier", "credentials.json")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var payload struct {
+		Providers map[string]string `json:"providers"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", false
+	}
+	value := strings.TrimSpace(payload.Providers[providerID])
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}

--- a/daemon/gateway/gateway.go
+++ b/daemon/gateway/gateway.go
@@ -1,0 +1,12 @@
+// Package gateway exposes the daemon gateway runtime as a callable Run function.
+// This wrapper keeps cmd/carrier decoupled from internal package paths.
+package gateway
+
+import (
+	internalgateway "carrier/daemon/internal/gateway"
+)
+
+// Run starts the gateway HTTP server using environment-based configuration.
+func Run() error {
+	return internalgateway.StartGateway(nil)
+}

--- a/daemon/internal/baseagent/llm.go
+++ b/daemon/internal/baseagent/llm.go
@@ -1,0 +1,564 @@
+package baseagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultOpenAIBaseURL        = "https://api.openai.com/v1"
+	defaultOpenAICodexBaseURL   = "https://chatgpt.com/backend-api"
+	defaultOpenRouterBaseURL    = "https://openrouter.ai/api/v1"
+	defaultBaseAgentLLMTimeout  = 45 * time.Second
+	baseAgentMaxModelRespBytes  = 1 << 20
+	baseAgentMaxModelErrorBytes = 8 << 10
+)
+
+const openAICodexJWTClaimPath = "https://api.openai.com/auth"
+
+const baseAgentSystemPrompt = "You are Carrier's built-in base agent. " +
+	"Answer in the user's language. " +
+	"You can help with agent management. " +
+	"Onboarding and installation must be done in Carrier GUI, never via chat. Never ask users to paste secrets or tokens in chat. " +
+	"When relevant, include exact slash commands (for example: /agents, /uninstall <agent>, /start <agent>, /stop <agent>, /status <agent>). " +
+	"Keep responses concise and actionable."
+
+type llmRuntimeConfig struct {
+	ProviderID string
+	ModelID    string
+	Token      string
+	BaseURL    string
+}
+
+func (r *Runtime) replyWithLLM(ctx context.Context, userMessage string) (string, error) {
+	cfg, err := resolveLLMRuntimeConfig()
+	if err != nil {
+		return "", err
+	}
+	modelID := normalizeModelForProvider(cfg.ProviderID, cfg.ModelID)
+	if strings.TrimSpace(modelID) == "" {
+		return "", errors.New("empty model id")
+	}
+
+	path := "/chat/completions"
+	reqBody := buildOpenAICompatibleChatRequest(modelID, userMessage)
+	parseResponse := parseOpenAICompatibleChatResponse
+	if isOpenAICodexProvider(cfg.ProviderID) {
+		path = "/codex/responses"
+		reqBody = buildOpenAICodexResponsesRequest(modelID, userMessage)
+		parseResponse = parseOpenAICodexResponses
+	}
+
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal model request: %w", err)
+	}
+
+	llmCtx, cancel := context.WithTimeout(ctx, defaultBaseAgentLLMTimeout)
+	defer cancel()
+	url := strings.TrimRight(cfg.BaseURL, "/") + path
+	req, err := http.NewRequestWithContext(llmCtx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return "", fmt.Errorf("build model request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	if strings.EqualFold(cfg.ProviderID, "openrouter") {
+		req.Header.Set("HTTP-Referer", "https://carrier.local")
+		req.Header.Set("X-Title", "Carrier Base Agent")
+	}
+	if isOpenAICodexProvider(cfg.ProviderID) {
+		req.Header.Set("OpenAI-Beta", "responses=experimental")
+		req.Header.Set("originator", "carrier")
+		req.Header.Set("Accept", "text/event-stream")
+		if accountID := extractOpenAICodexAccountID(cfg.Token); accountID != "" {
+			req.Header.Set("chatgpt-account-id", accountID)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("model request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, baseAgentMaxModelErrorBytes))
+		if parsedErr := parseModelError(resp.StatusCode, body); parsedErr != nil {
+			return "", parsedErr
+		}
+
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			return "", fmt.Errorf("model request failed with status %d", resp.StatusCode)
+		}
+		return "", fmt.Errorf("model request failed with status %d: %s", resp.StatusCode, msg)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, baseAgentMaxModelRespBytes))
+	if err != nil {
+		return "", fmt.Errorf("read model response: %w", err)
+	}
+	text, err := parseResponse(body)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", errors.New("model returned empty content")
+	}
+	return text, nil
+}
+
+func buildOpenAICompatibleChatRequest(modelID, userMessage string) map[string]interface{} {
+	return map[string]interface{}{
+		"model": modelID,
+		"messages": []map[string]string{
+			{"role": "system", "content": baseAgentSystemPrompt},
+			{"role": "user", "content": userMessage},
+		},
+		"temperature": 0.2,
+	}
+}
+
+func buildOpenAICodexResponsesRequest(modelID, userMessage string) map[string]interface{} {
+	return map[string]interface{}{
+		"model":        modelID,
+		"store":        false,
+		"stream":       true,
+		"instructions": baseAgentSystemPrompt,
+		"input": []map[string]interface{}{
+			{
+				"role": "user",
+				"content": []map[string]string{
+					{
+						"type": "input_text",
+						"text": userMessage,
+					},
+				},
+			},
+		},
+		"text": map[string]string{
+			"verbosity": "medium",
+		},
+	}
+}
+
+func parseOpenAICompatibleChatResponse(body []byte) (string, error) {
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content interface{} `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("decode model response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", errors.New("model response has no choices")
+	}
+	return extractModelContent(parsed.Choices[0].Message.Content), nil
+}
+
+func parseOpenAICodexResponses(body []byte) (string, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "", errors.New("model response has no output")
+	}
+
+	if looksLikeSSEStream(trimmed) {
+		if text, err := parseOpenAICodexSSE(trimmed); err == nil && strings.TrimSpace(text) != "" {
+			return text, nil
+		}
+	}
+
+	var parsed struct {
+		OutputText string `json:"output_text"`
+		Output     []struct {
+			Content interface{} `json:"content"`
+			Text    string      `json:"text"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		// Fallback to stream parser for gateways that always return SSE.
+		if text, sseErr := parseOpenAICodexSSE(trimmed); sseErr == nil && strings.TrimSpace(text) != "" {
+			return text, nil
+		}
+		return "", fmt.Errorf("decode codex response: %w", err)
+	}
+	if text := strings.TrimSpace(parsed.OutputText); text != "" {
+		return text, nil
+	}
+
+	parts := make([]string, 0, len(parsed.Output))
+	for _, item := range parsed.Output {
+		if text := strings.TrimSpace(item.Text); text != "" {
+			parts = append(parts, text)
+		}
+		if text := extractModelContent(item.Content); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "\n"), nil
+	}
+
+	// Allow OpenAI-compatible proxies that still answer in chat/completions schema.
+	if text, err := parseOpenAICompatibleChatResponse(trimmed); err == nil {
+		return text, nil
+	}
+	return "", errors.New("model response has no output")
+}
+
+func looksLikeSSEStream(body []byte) bool {
+	return bytes.HasPrefix(body, []byte("data:")) ||
+		bytes.Contains(body, []byte("\nevent:")) ||
+		bytes.Contains(body, []byte("\ndata:"))
+}
+
+func parseOpenAICodexSSE(body []byte) (string, error) {
+	raw := strings.ReplaceAll(string(body), "\r\n", "\n")
+	events := strings.Split(raw, "\n\n")
+
+	deltaParts := make([]string, 0, 8)
+	completedText := ""
+
+	for _, block := range events {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+
+		lines := strings.Split(block, "\n")
+		dataLines := make([]string, 0, len(lines))
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "data:") {
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if len(dataLines) == 0 {
+			continue
+		}
+
+		payload := strings.TrimSpace(strings.Join(dataLines, "\n"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+
+		var evt map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+			continue
+		}
+
+		if t, _ := evt["type"].(string); t == "error" {
+			if msg := strings.TrimSpace(extractModelContent(evt)); msg != "" {
+				return "", fmt.Errorf("codex stream error: %s", msg)
+			}
+			return "", errors.New("codex stream error")
+		}
+
+		if d, ok := evt["delta"].(string); ok && strings.TrimSpace(d) != "" {
+			deltaParts = append(deltaParts, d)
+		}
+		if text, ok := evt["output_text"].(string); ok && strings.TrimSpace(text) != "" {
+			completedText = strings.TrimSpace(text)
+		}
+		if text, ok := evt["text"].(string); ok && strings.TrimSpace(text) != "" && completedText == "" {
+			completedText = strings.TrimSpace(text)
+		}
+		if response, ok := evt["response"].(map[string]interface{}); ok {
+			if text := strings.TrimSpace(extractModelContent(response)); text != "" {
+				completedText = text
+			}
+		}
+		if output, ok := evt["output"]; ok && completedText == "" {
+			if text := strings.TrimSpace(extractModelContent(output)); text != "" {
+				completedText = text
+			}
+		}
+	}
+
+	if len(deltaParts) > 0 {
+		return strings.TrimSpace(strings.Join(deltaParts, "")), nil
+	}
+	if completedText != "" {
+		return completedText, nil
+	}
+	return "", errors.New("model response has no output")
+}
+
+func parseModelError(statusCode int, body []byte) error {
+	type apiErrBody struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	}
+	var parsedErr apiErrBody
+	if err := json.Unmarshal(body, &parsedErr); err != nil {
+		return nil
+	}
+
+	detail := strings.TrimSpace(parsedErr.Error.Message)
+	if detail == "" {
+		detail = strings.TrimSpace(parsedErr.Message)
+	}
+	if detail == "" {
+		return nil
+	}
+
+	code := strings.TrimSpace(parsedErr.Error.Code)
+	if code == "" {
+		code = strings.TrimSpace(parsedErr.Code)
+	}
+	if code != "" {
+		return fmt.Errorf("model request failed with status %d: %s (%s)", statusCode, detail, code)
+	}
+	return fmt.Errorf("model request failed with status %d: %s", statusCode, detail)
+}
+
+func resolveLLMRuntimeConfig() (*llmRuntimeConfig, error) {
+	providerID := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_PROVIDER_ID"))
+	modelID := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_MODEL_ID"))
+	envVar := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_PROVIDER_ENV"))
+
+	if providerID == "" || modelID == "" {
+		if cfg, err := readDefaultModelFromConfigFile(); err == nil && cfg != nil {
+			if providerID == "" {
+				providerID = cfg.ProviderID
+			}
+			if modelID == "" {
+				modelID = cfg.ModelID
+			}
+			if envVar == "" {
+				envVar = cfg.EnvVar
+			}
+		}
+	}
+
+	if providerID == "" || modelID == "" {
+		return nil, errors.New("default model is not configured")
+	}
+	if envVar == "" {
+		envVar = inferProviderEnvVar(providerID)
+	}
+	if envVar == "" {
+		return nil, fmt.Errorf("no env var mapping for provider %s", providerID)
+	}
+
+	token := strings.TrimSpace(os.Getenv(envVar))
+	if token == "" {
+		return nil, fmt.Errorf("provider credential is missing (%s)", envVar)
+	}
+
+	baseURL := defaultOpenAIBaseURL
+	switch {
+	case strings.EqualFold(providerID, "openrouter"):
+		baseURL = strings.TrimSpace(os.Getenv("CARRIER_OPENROUTER_BASE_URL"))
+		if baseURL == "" {
+			baseURL = defaultOpenRouterBaseURL
+		}
+	case isOpenAICodexProvider(providerID):
+		baseURL = strings.TrimSpace(os.Getenv("CARRIER_OPENAI_CODEX_BASE_URL"))
+		if baseURL == "" {
+			baseURL = strings.TrimSpace(os.Getenv("CARRIER_OPENAI_BASE_URL"))
+		}
+		if baseURL == "" {
+			baseURL = defaultOpenAICodexBaseURL
+		}
+	default:
+		override := strings.TrimSpace(os.Getenv("CARRIER_OPENAI_BASE_URL"))
+		if override != "" {
+			baseURL = override
+		}
+	}
+
+	return &llmRuntimeConfig{
+		ProviderID: providerID,
+		ModelID:    modelID,
+		Token:      token,
+		BaseURL:    baseURL,
+	}, nil
+}
+
+type defaultModelConfig struct {
+	ProviderID string
+	ModelID    string
+	EnvVar     string
+}
+
+func readDefaultModelFromConfigFile() (*defaultModelConfig, error) {
+	path, err := resolveConfigV2Path()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg struct {
+		DefaultModel string `json:"default_model"`
+		ModelList    []struct {
+			ModelName  string `json:"model_name"`
+			Model      string `json:"model"`
+			ProviderID string `json:"provider_id"`
+			EnvVar     string `json:"env_var"`
+		} `json:"model_list"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	if len(cfg.ModelList) == 0 {
+		return nil, errors.New("empty model_list")
+	}
+	defaultName := strings.TrimSpace(cfg.DefaultModel)
+	if defaultName != "" {
+		for _, m := range cfg.ModelList {
+			if strings.EqualFold(strings.TrimSpace(m.ModelName), defaultName) {
+				return &defaultModelConfig{
+					ProviderID: strings.TrimSpace(m.ProviderID),
+					ModelID:    strings.TrimSpace(m.Model),
+					EnvVar:     strings.TrimSpace(m.EnvVar),
+				}, nil
+			}
+		}
+	}
+	m := cfg.ModelList[0]
+	return &defaultModelConfig{
+		ProviderID: strings.TrimSpace(m.ProviderID),
+		ModelID:    strings.TrimSpace(m.Model),
+		EnvVar:     strings.TrimSpace(m.EnvVar),
+	}, nil
+}
+
+func resolveConfigV2Path() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("CARRIER_CONFIG")); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".carrier", "config.v2.json"), nil
+}
+
+func inferProviderEnvVar(providerID string) string {
+	switch strings.ToLower(strings.TrimSpace(providerID)) {
+	case "openai-codex":
+		return "OPENAI_CODEX_TOKEN"
+	case "openai":
+		return "OPENAI_API_KEY"
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "google":
+		return "GEMINI_API_KEY"
+	case "groq":
+		return "GROQ_API_KEY"
+	case "deepseek":
+		return "DEEPSEEK_API_KEY"
+	case "mistral":
+		return "MISTRAL_API_KEY"
+	case "opencode":
+		return "OPENCODE_API_KEY"
+	case "zai":
+		return "ZAI_API_KEY"
+	case "cerebras":
+		return "CEREBRAS_API_KEY"
+	default:
+		return ""
+	}
+}
+
+func normalizeModelForProvider(providerID, modelID string) string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(providerID), "openrouter") {
+		return modelID
+	}
+	if slash := strings.Index(modelID, "/"); slash > 0 && slash < len(modelID)-1 {
+		return strings.TrimSpace(modelID[slash+1:])
+	}
+	return modelID
+}
+
+func extractModelContent(raw interface{}) string {
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []interface{}:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if text := extractModelContent(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]interface{}:
+		parts := make([]string, 0, 3)
+		if text, ok := v["output_text"].(string); ok && strings.TrimSpace(text) != "" {
+			parts = append(parts, strings.TrimSpace(text))
+		}
+		if text, ok := v["text"].(string); ok && strings.TrimSpace(text) != "" {
+			parts = append(parts, strings.TrimSpace(text))
+		}
+		for _, key := range []string{"content", "message", "output"} {
+			if nested, ok := v[key]; ok {
+				if text := extractModelContent(nested); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}
+
+func isOpenAICodexProvider(providerID string) bool {
+	return strings.EqualFold(strings.TrimSpace(providerID), "openai-codex")
+}
+
+func extractOpenAICodexAccountID(token string) string {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) != 3 {
+		return ""
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ""
+		}
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+
+	authClaim, ok := claims[openAICodexJWTClaimPath].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	accountID, _ := authClaim["chatgpt_account_id"].(string)
+	return strings.TrimSpace(accountID)
+}

--- a/daemon/internal/baseagent/llm_test.go
+++ b/daemon/internal/baseagent/llm_test.go
@@ -1,0 +1,255 @@
+package baseagent
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeModelForProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		want     string
+	}{
+		{
+			name:     "openai strips provider prefix",
+			provider: "openai-codex",
+			model:    "openai-codex/gpt-5.3-codex",
+			want:     "gpt-5.3-codex",
+		},
+		{
+			name:     "openrouter keeps full model id",
+			provider: "openrouter",
+			model:    "openai/gpt-5.3",
+			want:     "openai/gpt-5.3",
+		},
+		{
+			name:     "already plain model id",
+			provider: "openai",
+			model:    "gpt-5.3",
+			want:     "gpt-5.3",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeModelForProvider(tc.provider, tc.model)
+			if got != tc.want {
+				t.Fatalf("normalizeModelForProvider(%q, %q) = %q, want %q", tc.provider, tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractModelContent(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		got := extractModelContent("hello")
+		if got != "hello" {
+			t.Fatalf("extractModelContent(string) = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("array with text maps", func(t *testing.T) {
+		raw := []interface{}{
+			map[string]interface{}{"type": "output_text", "text": "hello"},
+			map[string]interface{}{"type": "output_text", "text": "world"},
+		}
+		got := extractModelContent(raw)
+		if got != "hello\nworld" {
+			t.Fatalf("extractModelContent(array) = %q, want %q", got, "hello\nworld")
+		}
+	})
+
+	t.Run("nested map content", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"content": []interface{}{
+				map[string]interface{}{"text": "nested"},
+			},
+		}
+		got := extractModelContent(raw)
+		if got != "nested" {
+			t.Fatalf("extractModelContent(nested map) = %q, want %q", got, "nested")
+		}
+	})
+}
+
+func TestResolveLLMRuntimeConfig_OpenAICodexBaseURL(t *testing.T) {
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai-codex")
+	t.Setenv("CARRIER_DEFAULT_MODEL_ID", "openai-codex/gpt-5.3-codex")
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ENV", "OPENAI_CODEX_TOKEN")
+	t.Setenv("OPENAI_CODEX_TOKEN", "test-token")
+	t.Setenv("CARRIER_OPENAI_CODEX_BASE_URL", "")
+	t.Setenv("CARRIER_OPENAI_BASE_URL", "")
+
+	cfg, err := resolveLLMRuntimeConfig()
+	if err != nil {
+		t.Fatalf("resolveLLMRuntimeConfig() error = %v", err)
+	}
+	if cfg.BaseURL != defaultOpenAICodexBaseURL {
+		t.Fatalf("BaseURL = %q, want %q", cfg.BaseURL, defaultOpenAICodexBaseURL)
+	}
+}
+
+func TestResolveLLMRuntimeConfig_OpenAICodexBaseURLOverride(t *testing.T) {
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai-codex")
+	t.Setenv("CARRIER_DEFAULT_MODEL_ID", "openai-codex/gpt-5.3-codex")
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ENV", "OPENAI_CODEX_TOKEN")
+	t.Setenv("OPENAI_CODEX_TOKEN", "test-token")
+	t.Setenv("CARRIER_OPENAI_CODEX_BASE_URL", "http://127.0.0.1:3001/backend-api")
+
+	cfg, err := resolveLLMRuntimeConfig()
+	if err != nil {
+		t.Fatalf("resolveLLMRuntimeConfig() error = %v", err)
+	}
+	if cfg.BaseURL != "http://127.0.0.1:3001/backend-api" {
+		t.Fatalf("BaseURL = %q, want custom codex base url", cfg.BaseURL)
+	}
+}
+
+func TestReplyWithLLM_OpenAICodexUsesResponsesEndpoint(t *testing.T) {
+	var gotPath string
+	var gotModel string
+	var gotInputText string
+	var gotStream bool
+	var gotChatGPTAccountID string
+	var gotOpenAIBeta string
+	var gotOriginator string
+	var gotAccept string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotChatGPTAccountID = strings.TrimSpace(r.Header.Get("chatgpt-account-id"))
+		gotOpenAIBeta = strings.TrimSpace(r.Header.Get("OpenAI-Beta"))
+		gotOriginator = strings.TrimSpace(r.Header.Get("originator"))
+		gotAccept = strings.TrimSpace(r.Header.Get("Accept"))
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		gotModel, _ = body["model"].(string)
+		gotStream, _ = body["stream"].(bool)
+		input, _ := body["input"].([]interface{})
+		if len(input) > 0 {
+			msg, _ := input[0].(map[string]interface{})
+			content, _ := msg["content"].([]interface{})
+			if len(content) > 0 {
+				block, _ := content[0].(map[string]interface{})
+				gotInputText, _ = block["text"].(string)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output":[{"content":[{"type":"output_text","text":"hello from codex"}]}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai-codex")
+	t.Setenv("CARRIER_DEFAULT_MODEL_ID", "openai-codex/gpt-5.3-codex")
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ENV", "OPENAI_CODEX_TOKEN")
+	t.Setenv("CARRIER_OPENAI_CODEX_BASE_URL", server.URL)
+	t.Setenv("OPENAI_CODEX_TOKEN", makeOpenAICodexJWT("acct-test-123"))
+
+	r := &Runtime{}
+	got, err := r.replyWithLLM(context.Background(), "hello codex")
+	if err != nil {
+		t.Fatalf("replyWithLLM() error = %v", err)
+	}
+	if got != "hello from codex" {
+		t.Fatalf("replyWithLLM() = %q, want %q", got, "hello from codex")
+	}
+	if gotPath != "/codex/responses" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/codex/responses")
+	}
+	if gotModel != "gpt-5.3-codex" {
+		t.Fatalf("model = %q, want %q", gotModel, "gpt-5.3-codex")
+	}
+	if gotInputText != "hello codex" {
+		t.Fatalf("input text = %q, want %q", gotInputText, "hello codex")
+	}
+	if !gotStream {
+		t.Fatalf("stream = %v, want true", gotStream)
+	}
+	if gotChatGPTAccountID != "acct-test-123" {
+		t.Fatalf("chatgpt-account-id header = %q, want %q", gotChatGPTAccountID, "acct-test-123")
+	}
+	if gotOpenAIBeta != "responses=experimental" {
+		t.Fatalf("OpenAI-Beta header = %q, want %q", gotOpenAIBeta, "responses=experimental")
+	}
+	if gotOriginator != "carrier" {
+		t.Fatalf("originator header = %q, want %q", gotOriginator, "carrier")
+	}
+	if gotAccept != "text/event-stream" {
+		t.Fatalf("Accept header = %q, want %q", gotAccept, "text/event-stream")
+	}
+}
+
+func TestParseOpenAICodexResponses_SSE(t *testing.T) {
+	raw := strings.Join([]string{
+		"event: response.output_text.delta",
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}",
+		"",
+		"event: response.output_text.delta",
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}",
+		"",
+		"event: response.completed",
+		"data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"Hello world\"}}",
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	got, err := parseOpenAICodexResponses([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseOpenAICodexResponses() error = %v", err)
+	}
+	if got != "Hello world" {
+		t.Fatalf("parseOpenAICodexResponses() = %q, want %q", got, "Hello world")
+	}
+}
+
+func TestReplyWithLLM_OpenAIUsesChatCompletionsEndpoint(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello from openai"}}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai")
+	t.Setenv("CARRIER_DEFAULT_MODEL_ID", "openai/gpt-5.3")
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ENV", "OPENAI_API_KEY")
+	t.Setenv("CARRIER_OPENAI_BASE_URL", server.URL)
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+
+	r := &Runtime{}
+	got, err := r.replyWithLLM(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("replyWithLLM() error = %v", err)
+	}
+	if got != "hello from openai" {
+		t.Fatalf("replyWithLLM() = %q, want %q", got, "hello from openai")
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/chat/completions")
+	}
+}
+
+func makeOpenAICodexJWT(accountID string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadStruct := map[string]interface{}{
+		openAICodexJWTClaimPath: map[string]string{
+			"chatgpt_account_id": accountID,
+		},
+	}
+	rawPayload, _ := json.Marshal(payloadStruct)
+	payload := base64.RawURLEncoding.EncodeToString(rawPayload)
+	return header + "." + payload + ".sig"
+}

--- a/daemon/internal/baseagent/runtime.go
+++ b/daemon/internal/baseagent/runtime.go
@@ -1,0 +1,317 @@
+package baseagent
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"carrier/daemon/internal/memory"
+)
+
+const (
+	baseAgentVirtualID          = "carrier.base.internal"
+	baseAgentPublicMemoryID     = "carrier.base.public.v1"
+	baseAgentActiveMemoryV1ID   = "carrier.base.active.v1"
+	baseAgentActiveMemoryPrefix = "carrier.base.active."
+)
+
+var agentActionPattern = regexp.MustCompile(`(?i)\b(install|uninstall|start|stop|status|logs|upgrade|diagnose)\s+([a-zA-Z0-9][a-zA-Z0-9._-]*)\b`)
+
+type ChatRequest struct {
+	Provider  string `json:"provider"`
+	ChatID    string `json:"chatId"`
+	RequestID string `json:"requestId"`
+	Message   string `json:"message"`
+}
+
+type ChatResponse struct {
+	Message    string `json:"message"`
+	Action     string `json:"action,omitempty"`
+	SelfHealed bool   `json:"selfHealed,omitempty"`
+	BackupRef  string `json:"backupRef,omitempty"`
+}
+
+type AgentState struct {
+	ID           string
+	Install      string
+	Runtime      string
+	Health       string
+	RestartCount int
+}
+
+type UpgradeResult struct {
+	AgentID     string
+	FromVersion string
+	ToVersion   string
+}
+
+type AgentService interface {
+	ListAgents() []AgentState
+	Install(ctx context.Context, agentID string) error
+	Uninstall(ctx context.Context, agentID string) error
+	Start(ctx context.Context, agentID string) error
+	Stop(ctx context.Context, agentID string) error
+	Status(agentID string) (AgentState, error)
+	Logs(agentID string, tail int) ([]string, error)
+	Upgrade(ctx context.Context, agentID string) (UpgradeResult, error)
+	Diagnose(agentID string) (string, error)
+}
+
+type Runtime struct {
+	svc    AgentService
+	memory *memory.Store
+
+	mu          sync.Mutex
+	initialized bool
+	activeID    string
+}
+
+func NewRuntime(svc AgentService, memStore *memory.Store) *Runtime {
+	return &Runtime{
+		svc:      svc,
+		memory:   memStore,
+		activeID: baseAgentActiveMemoryV1ID,
+	}
+}
+
+func (r *Runtime) Chat(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+	msg := strings.TrimSpace(req.Message)
+	if msg == "" {
+		return ChatResponse{Message: baseAgentHelpText()}, nil
+	}
+
+	healNote, healed, backupRef, err := r.ensureMemoryReady()
+	if err != nil {
+		healNote = "Base-agent memory check failed; continuing with safe mode."
+	}
+
+	lower := strings.ToLower(msg)
+	if wantsListAgents(lower) {
+		text := renderAgentList(r.svc.ListAgents())
+		return withMemoryNote(ChatResponse{Message: text, Action: "list_agents"}, healNote, healed, backupRef), nil
+	}
+
+	if matches := agentActionPattern.FindStringSubmatch(msg); len(matches) == 3 {
+		action := strings.ToLower(strings.TrimSpace(matches[1]))
+		agentID := strings.TrimSpace(matches[2])
+		resp, err := r.executeAgentAction(ctx, action, agentID)
+		if err != nil {
+			return withMemoryNote(ChatResponse{
+				Message: fmt.Sprintf("%s %s failed: %v", action, agentID, err),
+				Action:  action,
+			}, healNote, healed, backupRef), nil
+		}
+		return withMemoryNote(resp, healNote, healed, backupRef), nil
+	}
+
+	if strings.Contains(lower, "help") || strings.Contains(lower, "what can you do") {
+		return withMemoryNote(ChatResponse{Message: baseAgentHelpText(), Action: "help"}, healNote, healed, backupRef), nil
+	}
+
+	// Best-effort fallback: if user mentioned a known agent ID, return status.
+	for _, s := range r.svc.ListAgents() {
+		if strings.Contains(lower, strings.ToLower(s.ID)) {
+			resp, err := r.executeAgentAction(ctx, "status", s.ID)
+			if err == nil {
+				return withMemoryNote(resp, healNote, healed, backupRef), nil
+			}
+		}
+	}
+
+	if reply, err := r.replyWithLLM(ctx, msg); err == nil && strings.TrimSpace(reply) != "" {
+		return withMemoryNote(ChatResponse{
+			Message: reply,
+			Action:  "chat",
+		}, healNote, healed, backupRef), nil
+	} else if err != nil {
+		return withMemoryNote(ChatResponse{
+			Message: fmt.Sprintf("%s\n%s", explainLLMUnavailable(err), baseAgentHelpText()),
+			Action:  "help",
+		}, healNote, healed, backupRef), nil
+	}
+
+	return withMemoryNote(ChatResponse{
+		Message: "I can manage installed agents. Try: `uninstall openclaw`, `start openclaw`, `stop openclaw`, `status openclaw`, `logs openclaw`, `upgrade openclaw`, `diagnose openclaw`, or `list agents`. For install/onboard, use Carrier GUI.",
+		Action:  "help",
+	}, healNote, healed, backupRef), nil
+}
+
+func wantsListAgents(lower string) bool {
+	return strings.Contains(lower, "list agents") ||
+		strings.Contains(lower, "show agents") ||
+		strings.Contains(lower, "agents") && !strings.Contains(lower, "install ")
+}
+
+func renderAgentList(states []AgentState) string {
+	if len(states) == 0 {
+		return "No agents are registered."
+	}
+	lines := make([]string, 0, len(states)+1)
+	lines = append(lines, fmt.Sprintf("Found %d agents:", len(states)))
+	for _, s := range states {
+		lines = append(lines, fmt.Sprintf("- %s: install=%s runtime=%s health=%s", s.ID, s.Install, s.Runtime, s.Health))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (r *Runtime) executeAgentAction(ctx context.Context, action, agentID string) (ChatResponse, error) {
+	switch action {
+	case "install":
+		return ChatResponse{
+			Message: fmt.Sprintf("Install for %s is disabled in chat. Open Carrier GUI to install and onboard agents, then manage them here.", agentID),
+			Action:  "install",
+		}, nil
+	case "uninstall":
+		if err := r.svc.Uninstall(ctx, agentID); err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{Message: fmt.Sprintf("Uninstalled %s.", agentID), Action: "uninstall"}, nil
+	case "start":
+		if err := r.svc.Start(ctx, agentID); err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{Message: fmt.Sprintf("Started %s.", agentID), Action: "start"}, nil
+	case "stop":
+		if err := r.svc.Stop(ctx, agentID); err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{Message: fmt.Sprintf("Stopped %s.", agentID), Action: "stop"}, nil
+	case "status":
+		state, err := r.svc.Status(agentID)
+		if err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{
+			Message: fmt.Sprintf("%s: install=%s runtime=%s health=%s restarts=%d", state.ID, state.Install, state.Runtime, state.Health, state.RestartCount),
+			Action:  "status",
+		}, nil
+	case "logs":
+		lines, err := r.svc.Logs(agentID, 50)
+		if err != nil {
+			return ChatResponse{}, err
+		}
+		if len(lines) == 0 {
+			return ChatResponse{Message: fmt.Sprintf("No logs for %s.", agentID), Action: "logs"}, nil
+		}
+		return ChatResponse{Message: strings.Join(lines, "\n"), Action: "logs"}, nil
+	case "upgrade":
+		result, err := r.svc.Upgrade(ctx, agentID)
+		if err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{
+			Message: fmt.Sprintf("Upgraded %s from %s to %s.", result.AgentID, result.FromVersion, result.ToVersion),
+			Action:  "upgrade",
+		}, nil
+	case "diagnose":
+		ref, err := r.svc.Diagnose(agentID)
+		if err != nil {
+			return ChatResponse{}, err
+		}
+		return ChatResponse{
+			Message: fmt.Sprintf("Created diagnose artifact for %s: %s", agentID, ref),
+			Action:  "diagnose",
+		}, nil
+	default:
+		return ChatResponse{}, fmt.Errorf("unsupported action: %s", action)
+	}
+}
+
+func baseAgentHelpText() string {
+	return "Base agent manages local agents: `list agents`, `uninstall <agent>`, `start <agent>`, `stop <agent>`, `status <agent>`, `logs <agent>`, `upgrade <agent>`, `diagnose <agent>`. For install/onboard, open Carrier GUI."
+}
+
+func withMemoryNote(resp ChatResponse, note string, healed bool, backupRef string) ChatResponse {
+	if strings.TrimSpace(note) != "" {
+		resp.Message = note + "\n" + resp.Message
+	}
+	resp.SelfHealed = healed
+	resp.BackupRef = backupRef
+	return resp
+}
+
+func explainLLMUnavailable(err error) string {
+	if err == nil {
+		return "LLM chat is currently unavailable."
+	}
+	msg := strings.TrimSpace(strings.ReplaceAll(err.Error(), "\n", " "))
+	if len(msg) > 220 {
+		msg = msg[:220] + "..."
+	}
+	return fmt.Sprintf("LLM chat is currently unavailable (%s).", msg)
+}
+
+func (r *Runtime) ensureMemoryReady() (note string, healed bool, backupRef string, err error) {
+	if r.memory == nil {
+		return "", false, "", nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.initialized {
+		if err := r.ensureMemoryEntry(baseAgentPublicMemoryID, "Carrier Base Public Memory", "v1", memory.TypePublic, ""); err != nil {
+			return "", false, "", err
+		}
+		r.activeID = r.pickActiveMemoryID()
+		if err := r.ensureMemoryEntry(r.activeID, "Carrier Base Active Memory", "v1", memory.TypePerAgent, baseAgentVirtualID); err != nil {
+			return "", false, "", err
+		}
+		r.initialized = true
+	}
+
+	if err := r.memory.SetAttachmentsFromLinks(baseAgentVirtualID, []string{baseAgentPublicMemoryID, r.activeID}); err != nil {
+		return "", false, "", err
+	}
+	if _, err := r.memory.PrepareAgentMemory(baseAgentVirtualID); err == nil {
+		return "", false, "", nil
+	}
+
+	backupRef, _ = r.memory.ExportMemory(r.activeID, memory.ExportOptions{
+		Actor:     "carrier-base",
+		RequestID: fmt.Sprintf("base-self-heal-%d", time.Now().UTC().UnixNano()),
+	})
+	_ = r.memory.Archive(r.activeID)
+
+	r.activeID = fmt.Sprintf("%s%d", baseAgentActiveMemoryPrefix, time.Now().UTC().UnixNano())
+	if err := r.ensureMemoryEntry(r.activeID, "Carrier Base Active Memory", "v2", memory.TypePerAgent, baseAgentVirtualID); err != nil {
+		return "", false, backupRef, err
+	}
+	if err := r.memory.SetAttachmentsFromLinks(baseAgentVirtualID, []string{baseAgentPublicMemoryID, r.activeID}); err != nil {
+		return "", false, backupRef, err
+	}
+	if _, err := r.memory.PrepareAgentMemory(baseAgentVirtualID); err != nil {
+		return "", false, backupRef, err
+	}
+	msg := "Base-agent memory self-heal completed: active memory was reset from base public memory."
+	if backupRef != "" {
+		msg += " Backup: " + backupRef
+	}
+	return msg, true, backupRef, nil
+}
+
+func (r *Runtime) ensureMemoryEntry(id, name, version string, t memory.Type, owner string) error {
+	if _, err := r.memory.Get(id); err == nil {
+		return nil
+	}
+	_, err := r.memory.Create(id, name, version, t, owner)
+	return err
+}
+
+func (r *Runtime) pickActiveMemoryID() string {
+	entries := r.memory.List()
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if strings.HasPrefix(e.ID, baseAgentActiveMemoryPrefix) && e.State != memory.StateArchived {
+			ids = append(ids, e.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return baseAgentActiveMemoryV1ID
+	}
+	sort.Strings(ids)
+	return ids[len(ids)-1]
+}

--- a/daemon/internal/baseagent/runtime_test.go
+++ b/daemon/internal/baseagent/runtime_test.go
@@ -1,0 +1,68 @@
+package baseagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type stubAgentService struct {
+	installCalls []string
+}
+
+func (s *stubAgentService) ListAgents() []AgentState { return nil }
+
+func (s *stubAgentService) Install(_ context.Context, agentID string) error {
+	s.installCalls = append(s.installCalls, agentID)
+	return nil
+}
+
+func (s *stubAgentService) Uninstall(_ context.Context, _ string) error { return nil }
+
+func (s *stubAgentService) Start(_ context.Context, _ string) error { return nil }
+
+func (s *stubAgentService) Stop(_ context.Context, _ string) error { return nil }
+
+func (s *stubAgentService) Status(agentID string) (AgentState, error) {
+	return AgentState{ID: agentID}, nil
+}
+
+func (s *stubAgentService) Logs(_ string, _ int) ([]string, error) { return nil, nil }
+
+func (s *stubAgentService) Upgrade(_ context.Context, agentID string) (UpgradeResult, error) {
+	return UpgradeResult{AgentID: agentID}, nil
+}
+
+func (s *stubAgentService) Diagnose(agentID string) (string, error) { return agentID + "-diag", nil }
+
+func TestExecuteAgentAction_InstallPicoclawRequiresGUI(t *testing.T) {
+	svc := &stubAgentService{}
+	rt := NewRuntime(svc, nil)
+
+	resp, err := rt.executeAgentAction(context.Background(), "install", "picoclaw")
+	if err != nil {
+		t.Fatalf("executeAgentAction returned error: %v", err)
+	}
+	if !strings.Contains(resp.Message, "Carrier GUI") {
+		t.Fatalf("expected GUI guidance, got: %q", resp.Message)
+	}
+	if len(svc.installCalls) != 0 {
+		t.Fatalf("expected no install calls, got %v", svc.installCalls)
+	}
+}
+
+func TestExecuteAgentAction_InstallOtherAgentRequiresGUI(t *testing.T) {
+	svc := &stubAgentService{}
+	rt := NewRuntime(svc, nil)
+
+	resp, err := rt.executeAgentAction(context.Background(), "install", "openclaw")
+	if err != nil {
+		t.Fatalf("executeAgentAction returned error: %v", err)
+	}
+	if !strings.Contains(resp.Message, "disabled in chat") || !strings.Contains(resp.Message, "Carrier GUI") {
+		t.Fatalf("expected GUI-only install guidance, got: %q", resp.Message)
+	}
+	if len(svc.installCalls) != 0 {
+		t.Fatalf("expected no install call for openclaw, got %v", svc.installCalls)
+	}
+}

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -44,6 +44,7 @@ const (
 
 	// PicoClaw release URL pattern
 	picoClawReleaseBaseURL = "https://github.com/sipeed/picoclaw/releases/latest/download"
+	picoClawReleaseAPIURL  = "https://api.github.com/repos/sipeed/picoclaw/releases/latest"
 )
 
 // getInstallCommand returns the platform-appropriate install command.
@@ -234,18 +235,53 @@ func ZeroClawManifest() manifest.Manifest {
 	}
 }
 
-// picoClawBinaryName returns the platform-specific binary name for PicoClaw releases.
+// picoClawBinaryName returns the installed executable name.
 func picoClawBinaryName() string {
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
-	if goos == "windows" {
-		return fmt.Sprintf("picoclaw-%s-%s.exe", goos, goarch)
+	if runtime.GOOS == "windows" {
+		return "picoclaw.exe"
 	}
-	return fmt.Sprintf("picoclaw-%s-%s", goos, goarch)
+	return "picoclaw"
+}
+
+func picoClawReleaseOS() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "Darwin"
+	case "linux":
+		return "Linux"
+	case "freebsd":
+		return "Freebsd"
+	case "windows":
+		return "Windows"
+	default:
+		return strings.Title(runtime.GOOS)
+	}
+}
+
+func picoClawReleaseArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "arm64"
+	case "arm":
+		return "armv6"
+	default:
+		return runtime.GOARCH
+	}
+}
+
+// picoClawReleaseBundleName returns the release archive name in GitHub assets.
+func picoClawReleaseBundleName() string {
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("picoclaw_%s_%s%s", picoClawReleaseOS(), picoClawReleaseArch(), ext)
 }
 
 // getPicoClawInstallCommand returns the install command for PicoClaw.
-// It downloads the release binary and sha256sums.txt, verifies the checksum,
+// It downloads the release archive, verifies checksum when available,
 // and installs to ~/.local/bin/picoclaw.
 func getPicoClawInstallCommand() string {
 	if os.Getenv("CARRIER_DEV_MODE") == "1" {
@@ -253,6 +289,7 @@ func getPicoClawInstallCommand() string {
 	}
 
 	binary := picoClawBinaryName()
+	bundle := picoClawReleaseBundleName()
 	destName := "picoclaw"
 	if runtime.GOOS == "windows" {
 		destName = "picoclaw.exe"
@@ -262,28 +299,87 @@ func getPicoClawInstallCommand() string {
 	case "windows":
 		return fmt.Sprintf(`powershell -NoProfile -Command "
 $ErrorActionPreference = 'Stop'
-$bin = '%s'; $dest = \"$env:USERPROFILE\.local\bin\%s\"
+$bundle = '%s'; $bin = '%s'; $dest = \"$env:USERPROFILE\.local\bin\%s\"
 New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
-Invoke-WebRequest -Uri '%s/%s' -OutFile $dest
-Invoke-WebRequest -Uri '%s/sha256sums.txt' -OutFile \"$env:TEMP\sha256sums.txt\"
-$expected = (Get-Content \"$env:TEMP\sha256sums.txt\" | Select-String $bin).ToString().Split(' ')[0]
-$actual = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
-if ($actual -ne $expected) { Remove-Item $dest; throw \"checksum mismatch\" }
-"`, binary, destName, picoClawReleaseBaseURL, binary, picoClawReleaseBaseURL)
+$release = Invoke-RestMethod -Uri '%s'
+$asset = ($release.assets | Where-Object { $_.name -eq $bundle } | Select-Object -First 1)
+$url = if ($asset) { $asset.browser_download_url } else { '%s/' + $bundle }
+$archive = Join-Path $env:TEMP $bundle
+$tmp = Join-Path $env:TEMP ('picoclaw_extract_' + [guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+Invoke-WebRequest -Uri $url -OutFile $archive
+$checksumAsset = ($release.assets | Where-Object { $_.name -match 'checksums.*\.txt$' } | Select-Object -First 1)
+if ($checksumAsset) {
+  $sumsPath = Join-Path $env:TEMP 'picoclaw_checksums.txt'
+  Invoke-WebRequest -Uri $checksumAsset.browser_download_url -OutFile $sumsPath
+  $line = Get-Content $sumsPath | Select-String $bundle | Select-Object -First 1
+  if ($line) {
+    $expected = ($line.ToString().Trim() -split '\s+')[0].ToLower()
+    $actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) { Remove-Item $archive -ErrorAction SilentlyContinue; throw \"checksum mismatch\" }
+  }
+}
+Expand-Archive -Path $archive -DestinationPath $tmp -Force
+$extracted = Get-ChildItem -Path $tmp -Recurse -File | Where-Object { $_.Name -eq $bin } | Select-Object -First 1
+if (-not $extracted) { throw \"extracted binary not found: $bin\" }
+Copy-Item -Path $extracted.FullName -Destination $dest -Force
+"`, bundle, binary, destName, picoClawReleaseAPIURL, picoClawReleaseBaseURL)
 	default:
 		return fmt.Sprintf(`sh -c '
 set -e
+BUNDLE="%s"
 BINARY="%s"
 DEST="$HOME/.local/bin/%s"
+RELEASE_API_URL="%s"
 mkdir -p "$HOME/.local/bin"
-curl -fsSL -o "$DEST" "%s/%s"
-curl -fsSL -o /tmp/picoclaw-sha256sums.txt "%s/sha256sums.txt"
-EXPECTED=$(grep "$BINARY" /tmp/picoclaw-sha256sums.txt | cut -d" " -f1)
-ACTUAL=$(sha256sum "$DEST" | cut -d" " -f1)
-if [ "$EXPECTED" != "$ACTUAL" ]; then rm -f "$DEST"; echo "checksum mismatch" >&2; exit 1; fi
-chmod +x "$DEST"
-rm -f /tmp/picoclaw-sha256sums.txt
-'`, binary, destName, picoClawReleaseBaseURL, binary, picoClawReleaseBaseURL)
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+download() {
+  url="$1"
+  out="$2"
+  if ! curl -fsSL -o "$out" "$url"; then
+    echo "download failed: $url" >&2
+    exit 1
+  fi
+}
+
+RELEASE_JSON="$TMPDIR/release.json"
+download "$RELEASE_API_URL" "$RELEASE_JSON"
+
+ASSET_URL=$(grep -Eo "\"browser_download_url\":[[:space:]]*\"[^\"]*\"" "$RELEASE_JSON" | sed -E "s/.*\"([^\"]+)\"/\\1/" | grep "/$BUNDLE$" | head -n1)
+if [ -z "$ASSET_URL" ]; then ASSET_URL="%s/$BUNDLE"; fi
+
+CHECKSUM_URL=$(grep -Eo "\"browser_download_url\":[[:space:]]*\"[^\"]*checksums[^\"]*\.txt\"" "$RELEASE_JSON" | sed -E "s/.*\"([^\"]+)\"/\\1/" | head -n1)
+
+ARCHIVE="$TMPDIR/$BUNDLE"
+download "$ASSET_URL" "$ARCHIVE"
+
+if [ -n "$CHECKSUM_URL" ]; then
+  SUMS="$TMPDIR/checksums.txt"
+  download "$CHECKSUM_URL" "$SUMS"
+  EXPECTED=$(awk -v f="$BUNDLE" "\$2==f {print \$1; exit}" "$SUMS")
+  if [ -z "$EXPECTED" ]; then EXPECTED=$(grep -E "[ *]$BUNDLE$" "$SUMS" | head -n1 | awk "{print \$1}"); fi
+  if [ -n "$EXPECTED" ]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      ACTUAL=$(sha256sum "$ARCHIVE" | awk "{print \$1}")
+    elif command -v shasum >/dev/null 2>&1; then
+      ACTUAL=$(shasum -a 256 "$ARCHIVE" | awk "{print \$1}")
+    elif command -v openssl >/dev/null 2>&1; then
+      ACTUAL=$(openssl dgst -sha256 "$ARCHIVE" | awk "{print \$NF}")
+    else
+      echo "no sha256 tool available (need sha256sum, shasum, or openssl)" >&2
+      exit 1
+    fi
+    if [ "$EXPECTED" != "$ACTUAL" ]; then echo "checksum mismatch" >&2; exit 1; fi
+  fi
+fi
+
+tar -xzf "$ARCHIVE" -C "$TMPDIR"
+EXTRACTED=$(find "$TMPDIR" -type f -name "$BINARY" | head -n1)
+if [ -z "$EXTRACTED" ]; then echo "extracted binary not found: $BINARY" >&2; exit 1; fi
+install -m 0755 "$EXTRACTED" "$DEST"
+'`, bundle, binary, destName, picoClawReleaseAPIURL, picoClawReleaseBaseURL)
 	}
 }
 

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -4,6 +4,7 @@ import (
 	"carrier/daemon/internal/manifest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -80,6 +81,44 @@ func TestPicoClawBinaryName(t *testing.T) {
 	// Should contain picoclaw and current GOOS/GOARCH
 	if !contains(name, "picoclaw") {
 		t.Fatalf("binary name %q does not contain 'picoclaw'", name)
+	}
+}
+
+func TestPicoClawReleaseBundleName(t *testing.T) {
+	name := picoClawReleaseBundleName()
+	if !strings.HasPrefix(name, "picoclaw_") {
+		t.Fatalf("bundle name %q should start with picoclaw_", name)
+	}
+	if runtime.GOOS == "windows" {
+		if !strings.HasSuffix(name, ".zip") {
+			t.Fatalf("windows bundle should end with .zip, got %q", name)
+		}
+	} else {
+		if !strings.HasSuffix(name, ".tar.gz") {
+			t.Fatalf("unix bundle should end with .tar.gz, got %q", name)
+		}
+	}
+}
+
+func TestPicoClawInstallCommand_UnixUsesArchiveFlow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix install command test")
+	}
+	t.Setenv("CARRIER_DEV_MODE", "")
+
+	cmd := getPicoClawInstallCommand()
+	for _, want := range []string{
+		picoClawReleaseAPIURL,
+		"checksums",
+		"shasum -a 256",
+		"tar -xzf",
+		"find \"$TMPDIR\" -type f -name \"$BINARY\"",
+		"install -m 0755",
+		picoClawReleaseBundleName(),
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("install command missing %q\ngot: %s", want, cmd)
+		}
 	}
 }
 

--- a/daemon/internal/gateway/commands.go
+++ b/daemon/internal/gateway/commands.go
@@ -17,8 +17,10 @@ type CommandName string
 
 const (
 	CmdPair            CommandName = "/pair"
+	CmdChat            CommandName = "/chat"
 	CmdAgents          CommandName = "/agents"
 	CmdInstall         CommandName = "/install"
+	CmdUninstall       CommandName = "/uninstall"
 	CmdStart           CommandName = "/start"
 	CmdStop            CommandName = "/stop"
 	CmdStatus          CommandName = "/status"
@@ -31,8 +33,10 @@ const (
 
 var validCommands = map[CommandName]struct{}{
 	CmdPair:            {},
+	CmdChat:            {},
 	CmdAgents:          {},
 	CmdInstall:         {},
+	CmdUninstall:       {},
 	CmdStart:           {},
 	CmdStop:            {},
 	CmdStatus:          {},
@@ -160,11 +164,15 @@ func HandleCommand(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClien
 
 	switch cmd.Name {
 	case CmdOnboard:
-		return handleOnboard(ctx, cmd, daemon, onboard)
+		return onboardViaGUIOnlyResp(cmd.RequestID)
+	case CmdChat:
+		return handleChat(ctx, cmd, daemon, actor)
 	case CmdAgents:
 		return handleAgents(ctx, cmd, daemon, actor)
 	case CmdInstall:
-		return handleInstall(ctx, cmd, daemon, actor)
+		return handleInstall(ctx, cmd, daemon, actor, onboard)
+	case CmdUninstall:
+		return handleUninstall(ctx, cmd, daemon, actor)
 	case CmdStart:
 		return handleStart(ctx, cmd, daemon, actor)
 	case CmdStop:
@@ -238,10 +246,40 @@ func handlePair(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, 
 	}
 }
 
+func handleChat(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, actor string) GatewayResponse {
+	if len(cmd.Args) == 0 {
+		return usageResp(cmd.RequestID, "/chat <message>")
+	}
+	message := strings.TrimSpace(strings.Join(cmd.Args, " "))
+	if message == "" {
+		return usageResp(cmd.RequestID, "/chat <message>")
+	}
+	chatResult, err := daemon.ChatBaseAgent(ctx, cmd.Provider, cmd.ChatID, cmd.RequestID, message, actor)
+	if err != nil {
+		return daemonErrResp(cmd.RequestID, err)
+	}
+	respMessage := strings.TrimSpace(chatResult.Message)
+	if respMessage == "" {
+		respMessage = "base agent completed with no output"
+	}
+	return GatewayResponse{
+		RequestID: cmd.RequestID,
+		Result:    "ok",
+		Message:   respMessage,
+	}
+}
+
 func handleAgents(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, actor string) GatewayResponse {
 	agents, err := daemon.ListAgents(ctx, actor, cmd.RequestID)
 	if err != nil {
 		return daemonErrResp(cmd.RequestID, err)
+	}
+	if len(agents) == 0 {
+		return GatewayResponse{
+			RequestID: cmd.RequestID,
+			Result:    "ok",
+			Message:   "listed 0 agents (0 installed)",
+		}
 	}
 	installed := 0
 	for _, a := range agents {
@@ -249,25 +287,60 @@ func handleAgents(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient
 			installed++
 		}
 	}
+	lines := []string{fmt.Sprintf("listed %d agents (%d installed)", len(agents), installed)}
+	for _, a := range agents {
+		name := strings.TrimSpace(a.Name)
+		if name == "" {
+			name = a.ID
+		}
+		installState := strings.TrimSpace(a.InstallState)
+		if installState == "" {
+			installState = "unknown"
+		}
+		runtime := strings.TrimSpace(a.Runtime)
+		if runtime == "" {
+			runtime = "unknown"
+		}
+		health := strings.TrimSpace(a.Health)
+		if health == "" {
+			health = "unknown"
+		}
+		emoji := "⚪"
+		if installState != "installed" {
+			emoji = "🟡"
+		} else if runtime == "running" && health == "healthy" {
+			emoji = "🟢"
+		} else if runtime == "running" {
+			emoji = "🟠"
+		}
+		lines = append(lines, fmt.Sprintf("%s %s (%s): %s, %s, health=%s", emoji, name, a.ID, installState, runtime, health))
+	}
+	if installed < len(agents) {
+		lines = append(lines, "Tip: install/onboard in Carrier GUI. Chat supports management commands only.")
+	}
 	return GatewayResponse{
 		RequestID: cmd.RequestID,
 		Result:    "ok",
-		Message:   fmt.Sprintf("listed %d agents (%d installed)", len(agents), installed),
+		Message:   strings.Join(lines, "\n"),
 	}
 }
 
-func handleInstall(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, actor string) GatewayResponse {
+func handleInstall(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, actor string, onboard *OnboardStore) GatewayResponse {
+	return installViaGUIOnlyResp(cmd.RequestID)
+}
+
+func handleUninstall(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClient, actor string) GatewayResponse {
 	if len(cmd.Args) == 0 {
-		return usageResp(cmd.RequestID, "/install <agent_id>")
+		return usageResp(cmd.RequestID, "/uninstall <agent_id>")
 	}
 	agentID := cmd.Args[0]
-	if err := daemon.InstallAgent(ctx, agentID, actor, cmd.RequestID); err != nil {
+	if err := daemon.UninstallAgent(ctx, agentID, actor, cmd.RequestID); err != nil {
 		return daemonErrResp(cmd.RequestID, err)
 	}
 	return GatewayResponse{
 		RequestID: cmd.RequestID,
 		Result:    "ok",
-		Message:   fmt.Sprintf("install completed for %s", agentID),
+		Message:   fmt.Sprintf("uninstall completed for %s", agentID),
 	}
 }
 
@@ -498,6 +571,14 @@ func errResp(requestID, code, message string) GatewayResponse {
 
 func usageResp(requestID, usage string) GatewayResponse {
 	return errResp(requestID, "E_USAGE", "usage: "+usage)
+}
+
+func installViaGUIOnlyResp(requestID string) GatewayResponse {
+	return errResp(requestID, "E_INSTALL_GUI_ONLY", "Installation is disabled in chat to protect credentials. Open Carrier GUI to install/onboard agents. Chat is for management commands only.")
+}
+
+func onboardViaGUIOnlyResp(requestID string) GatewayResponse {
+	return errResp(requestID, "E_ONBOARD_GUI_ONLY", "Onboarding is disabled in chat to protect credentials. Open Carrier GUI to complete onboarding and credential setup.")
 }
 
 func daemonErrResp(requestID string, err error) GatewayResponse {

--- a/daemon/internal/gateway/commands_handlecommand_test.go
+++ b/daemon/internal/gateway/commands_handlecommand_test.go
@@ -157,6 +157,65 @@ func TestHandleCommand_InvalidSessionToken(t *testing.T) {
 	}
 }
 
+func TestHandleCommand_Chat_Success(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, map[string]http.HandlerFunc{
+		"POST /api/v1/base-agent/chat": func(w http.ResponseWriter, r *http.Request) {
+			var req map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if req["provider"] != "telegram" {
+				t.Fatalf("provider = %v, want telegram", req["provider"])
+			}
+			if req["chatId"] != "123" {
+				t.Fatalf("chatId = %v, want 123", req["chatId"])
+			}
+			if req["message"] != "hello from terminal" {
+				t.Fatalf("message = %v, want %q", req["message"], "hello from terminal")
+			}
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"message": "hello back",
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		},
+	})
+	defer srv.Close()
+
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r-chat",
+		Name: CmdChat, Args: []string{"hello", "from", "terminal"}, SessionToken: tok,
+	}
+	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
+	if resp.Result != "ok" {
+		t.Fatalf("expected ok, got %s: %s", resp.Result, resp.Message)
+	}
+	if resp.Message != "hello back" {
+		t.Fatalf("message = %q, want %q", resp.Message, "hello back")
+	}
+}
+
+func TestHandleCommand_Chat_NoArgs(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, nil)
+	defer srv.Close()
+
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r-chat",
+		Name: CmdChat, Args: []string{}, SessionToken: tok,
+	}
+	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
+	if resp.Result != "error" {
+		t.Fatalf("expected error, got %s", resp.Result)
+	}
+	if resp.ErrorCode != "E_USAGE" {
+		t.Fatalf("errorCode = %q, want %q", resp.ErrorCode, "E_USAGE")
+	}
+}
+
 func TestHandleCommand_Agents_Success(t *testing.T) {
 	srv, dc, sessions, downloads, onboard := setupTestEnv(t, map[string]http.HandlerFunc{
 		"GET /api/v1/agents": func(w http.ResponseWriter, r *http.Request) {
@@ -188,15 +247,13 @@ func TestHandleCommand_Agents_Success(t *testing.T) {
 	if !strings.Contains(resp.Message, "1 installed") {
 		t.Errorf("expected '1 installed' in message, got %q", resp.Message)
 	}
+	if !strings.Contains(resp.Message, "a1") || !strings.Contains(resp.Message, "a2") {
+		t.Errorf("expected detailed agent list in message, got %q", resp.Message)
+	}
 }
 
-func TestHandleCommand_Install_Success(t *testing.T) {
-	srv, dc, sessions, downloads, onboard := setupTestEnv(t, map[string]http.HandlerFunc{
-		"POST /api/v1/agents/myagent/install": func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"status":"installed"}`)
-		},
-	})
+func TestHandleCommand_Install_GuiOnly(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, nil)
 	defer srv.Close()
 
 	tok := pairAndGetSession(sessions, "telegram", "123")
@@ -205,8 +262,14 @@ func TestHandleCommand_Install_Success(t *testing.T) {
 		Name: CmdInstall, Args: []string{"myagent"}, SessionToken: tok,
 	}
 	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
-	if resp.Result != "ok" {
-		t.Fatalf("expected ok, got %s: %s", resp.Result, resp.Message)
+	if resp.Result != "error" {
+		t.Fatalf("expected error, got %s: %s", resp.Result, resp.Message)
+	}
+	if resp.ErrorCode != "E_INSTALL_GUI_ONLY" {
+		t.Fatalf("expected E_INSTALL_GUI_ONLY, got %s", resp.ErrorCode)
+	}
+	if !strings.Contains(resp.Message, "Carrier GUI") {
+		t.Fatalf("expected GUI guidance, got: %q", resp.Message)
 	}
 }
 
@@ -218,6 +281,65 @@ func TestHandleCommand_Install_NoArgs(t *testing.T) {
 	cmd := &GatewayCommand{
 		Provider: "telegram", ChatID: "123", RequestID: "r1",
 		Name: CmdInstall, Args: []string{}, SessionToken: tok,
+	}
+	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
+	if resp.ErrorCode != "E_INSTALL_GUI_ONLY" {
+		t.Errorf("expected E_INSTALL_GUI_ONLY, got %s", resp.ErrorCode)
+	}
+	if !strings.Contains(resp.Message, "Carrier GUI") {
+		t.Fatalf("expected GUI guidance, got: %q", resp.Message)
+	}
+}
+
+func TestHandleCommand_Onboard_GuiOnly(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, nil)
+	defer srv.Close()
+
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r1",
+		Name: CmdOnboard, Args: []string{}, SessionToken: tok,
+	}
+	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
+	if resp.Result != "error" {
+		t.Fatalf("expected error, got %s: %s", resp.Result, resp.Message)
+	}
+	if resp.ErrorCode != "E_ONBOARD_GUI_ONLY" {
+		t.Fatalf("expected E_ONBOARD_GUI_ONLY, got %s", resp.ErrorCode)
+	}
+	if !strings.Contains(resp.Message, "Carrier GUI") {
+		t.Fatalf("expected GUI guidance, got: %q", resp.Message)
+	}
+}
+
+func TestHandleCommand_Uninstall_Success(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/myagent/uninstall": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"uninstalled"}`)
+		},
+	})
+	defer srv.Close()
+
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r1",
+		Name: CmdUninstall, Args: []string{"myagent"}, SessionToken: tok,
+	}
+	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
+	if resp.Result != "ok" {
+		t.Fatalf("expected ok, got %s: %s", resp.Result, resp.Message)
+	}
+}
+
+func TestHandleCommand_Uninstall_NoArgs(t *testing.T) {
+	srv, dc, sessions, downloads, onboard := setupTestEnv(t, nil)
+	defer srv.Close()
+
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r1",
+		Name: CmdUninstall, Args: []string{}, SessionToken: tok,
 	}
 	resp := HandleCommand(context.Background(), cmd, dc, sessions, downloads, nil, onboard)
 	if resp.ErrorCode != "E_USAGE" {

--- a/daemon/internal/gateway/commands_test.go
+++ b/daemon/internal/gateway/commands_test.go
@@ -24,6 +24,12 @@ func TestParseInput_ValidCommands(t *testing.T) {
 			wantCmd: CmdPair, wantArgs: []string{"abc123"},
 		},
 		{
+			name:         "chat command with session token",
+			input:        "telegram 123 req-chat session-abc /chat hello from terminal",
+			wantProvider: "telegram", wantChatID: "123", wantReqID: "req-chat",
+			wantCmd: CmdChat, wantArgs: []string{"hello", "from", "terminal"}, wantSession: "session-abc",
+		},
+		{
 			name:         "agents command",
 			input:        "discord ch-1 req-2 /agents",
 			wantProvider: "discord", wantChatID: "ch-1", wantReqID: "req-2",
@@ -34,6 +40,12 @@ func TestParseInput_ValidCommands(t *testing.T) {
 			input:        "feishu chat-abc req-3 session-xyz123 /install myagent",
 			wantProvider: "feishu", wantChatID: "chat-abc", wantReqID: "req-3",
 			wantCmd: CmdInstall, wantArgs: []string{"myagent"}, wantSession: "session-xyz123",
+		},
+		{
+			name:         "uninstall with session token",
+			input:        "feishu chat-abc req-3b session-xyz123 /uninstall myagent",
+			wantProvider: "feishu", wantChatID: "chat-abc", wantReqID: "req-3b",
+			wantCmd: CmdUninstall, wantArgs: []string{"myagent"}, wantSession: "session-xyz123",
 		},
 		{
 			name:         "logs with agent and tail",
@@ -173,9 +185,9 @@ func TestFormatUptime(t *testing.T) {
 
 func TestParseConsent(t *testing.T) {
 	tests := []struct {
-		input   string
-		want    bool
-		wantOK  bool
+		input  string
+		want   bool
+		wantOK bool
 	}{
 		{"yes", true, true},
 		{"YES", true, true},

--- a/daemon/internal/gateway/credential_store.go
+++ b/daemon/internal/gateway/credential_store.go
@@ -1,0 +1,172 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	errCredentialNotFound           = errors.New("credential not found")
+	errCredentialBackendUnavailable = errors.New("credential backend unavailable")
+)
+
+func loadProviderCredential(providerID string) (string, string, bool, error) {
+	service := providerCredentialService(providerID)
+	if value, err := loadCredentialFromKeychain(service); err == nil {
+		return value, "macOS-keychain", true, nil
+	} else if !errors.Is(err, errCredentialNotFound) && !errors.Is(err, errCredentialBackendUnavailable) {
+		return "", "", false, err
+	}
+
+	value, err := loadCredentialFromFile(providerID)
+	if err == nil {
+		return value, "local-file", true, nil
+	}
+	if errors.Is(err, errCredentialNotFound) {
+		return "", "", false, nil
+	}
+	return "", "", false, err
+}
+
+func saveProviderCredential(providerID, value string) (string, error) {
+	service := providerCredentialService(providerID)
+	if err := saveCredentialToKeychain(service, value); err == nil {
+		return "macOS-keychain", nil
+	} else if !errors.Is(err, errCredentialBackendUnavailable) {
+		return "", err
+	}
+	if err := saveCredentialToFile(providerID, value); err != nil {
+		return "", err
+	}
+	return "local-file", nil
+}
+
+func providerCredentialService(providerID string) string {
+	return "carrier.provider." + strings.TrimSpace(providerID)
+}
+
+func keychainAvailable() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("CARRIER_DISABLE_KEYCHAIN")), "1") {
+		return false
+	}
+	_, err := exec.LookPath("security")
+	return err == nil
+}
+
+func loadCredentialFromKeychain(service string) (string, error) {
+	if !keychainAvailable() {
+		return "", errCredentialBackendUnavailable
+	}
+	cmd := exec.Command("security", "find-generic-password", "-a", "carrier", "-s", service, "-w")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.ToLower(strings.TrimSpace(stderr.String()))
+		if strings.Contains(msg, "could not be found") || strings.Contains(msg, "item not found") {
+			return "", errCredentialNotFound
+		}
+		return "", fmt.Errorf("read keychain credential for %s", service)
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", errCredentialNotFound
+	}
+	return value, nil
+}
+
+func saveCredentialToKeychain(service, value string) error {
+	if !keychainAvailable() {
+		return errCredentialBackendUnavailable
+	}
+	cmd := exec.Command("security", "add-generic-password", "-U", "-a", "carrier", "-s", service, "-w", value)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write keychain credential for %s", service)
+	}
+	return nil
+}
+
+func loadCredentialFromFile(providerID string) (string, error) {
+	path, err := credentialStorePath()
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", errCredentialNotFound
+		}
+		return "", fmt.Errorf("read credential file: %w", err)
+	}
+	var payload struct {
+		Providers map[string]string `json:"providers"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", fmt.Errorf("parse credential file: %w", err)
+	}
+	if payload.Providers == nil {
+		return "", errCredentialNotFound
+	}
+	value := strings.TrimSpace(payload.Providers[providerID])
+	if value == "" {
+		return "", errCredentialNotFound
+	}
+	return value, nil
+}
+
+func saveCredentialToFile(providerID, value string) error {
+	path, err := credentialStorePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create credential directory: %w", err)
+	}
+
+	payload := struct {
+		Providers map[string]string `json:"providers"`
+	}{
+		Providers: make(map[string]string),
+	}
+	if raw, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(raw, &payload)
+		if payload.Providers == nil {
+			payload.Providers = make(map[string]string)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read credential file: %w", err)
+	}
+
+	payload.Providers[providerID] = value
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credential file: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write credential file: %w", err)
+	}
+	return nil
+}
+
+func credentialStorePath() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("CARRIER_CREDENTIAL_STORE")); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "credentials.json"), nil
+}

--- a/daemon/internal/gateway/daemonclient.go
+++ b/daemon/internal/gateway/daemonclient.go
@@ -19,18 +19,18 @@ const (
 
 // AgentState mirrors the daemon's agent status.
 type AgentState struct {
-	ID                  string  `json:"id"`
-	Name                string  `json:"name"`
-	Version             string  `json:"version"`
-	InstallState        string  `json:"installState"`
-	Runtime             string  `json:"runtimeState"`
-	Health              string  `json:"health"`
-	Ports               []int   `json:"ports"`
-	StartedAt           *string `json:"startedAt,omitempty"`
-	RestartCount        int     `json:"restartCount"`
-	NeedsRemoteDiagnosis bool   `json:"needsRemoteDiagnosis"`
-	LastError           *string `json:"lastError,omitempty"`
-	UpdatedAt           string  `json:"updatedAt"`
+	ID                   string  `json:"id"`
+	Name                 string  `json:"name"`
+	Version              string  `json:"version"`
+	InstallState         string  `json:"installState"`
+	Runtime              string  `json:"runtimeState"`
+	Health               string  `json:"health"`
+	Ports                []int   `json:"ports"`
+	StartedAt            *string `json:"startedAt,omitempty"`
+	RestartCount         int     `json:"restartCount"`
+	NeedsRemoteDiagnosis bool    `json:"needsRemoteDiagnosis"`
+	LastError            *string `json:"lastError,omitempty"`
+	UpdatedAt            string  `json:"updatedAt"`
 }
 
 // LogsResult holds log lines from the daemon.
@@ -69,6 +69,13 @@ type RemoteDiagnosisHandoff struct {
 	ArtifactRef string        `json:"artifactRef"`
 	Status      HandoffStatus `json:"status"`
 	CreatedAt   string        `json:"createdAt"`
+}
+
+type BaseAgentChatResult struct {
+	Message    string `json:"message"`
+	Action     string `json:"action,omitempty"`
+	SelfHealed bool   `json:"selfHealed,omitempty"`
+	BackupRef  string `json:"backupRef,omitempty"`
 }
 
 // DaemonClientError is returned when the daemon returns a non-2xx response.
@@ -157,6 +164,12 @@ func (c *DaemonClient) StartAgent(ctx context.Context, agentID, actor, requestID
 // StopAgent stops an agent.
 func (c *DaemonClient) StopAgent(ctx context.Context, agentID, actor, requestID string) error {
 	_, err := c.request(ctx, http.MethodPost, "/api/v1/agents/"+url.PathEscape(agentID)+"/stop", nil, actor, requestID)
+	return err
+}
+
+// UninstallAgent uninstalls an agent.
+func (c *DaemonClient) UninstallAgent(ctx context.Context, agentID, actor, requestID string) error {
+	_, err := c.request(ctx, http.MethodPost, "/api/v1/agents/"+url.PathEscape(agentID)+"/uninstall", nil, actor, requestID)
 	return err
 }
 
@@ -284,6 +297,31 @@ func (c *DaemonClient) VerifyPairCode(ctx context.Context, code, actor, requestI
 	body := map[string]string{"code": code}
 	_, err := c.request(ctx, http.MethodPost, "/api/v1/pairing/verify-consume", body, actor, requestID)
 	return err
+}
+
+func (c *DaemonClient) ChatBaseAgent(
+	ctx context.Context,
+	provider string,
+	chatID string,
+	requestID string,
+	message string,
+	actor string,
+) (*BaseAgentChatResult, error) {
+	body := map[string]string{
+		"provider":  provider,
+		"chatId":    chatID,
+		"requestId": requestID,
+		"message":   message,
+	}
+	raw, err := c.request(ctx, http.MethodPost, "/api/v1/base-agent/chat", body, actor, requestID)
+	if err != nil {
+		return nil, err
+	}
+	var result BaseAgentChatResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("base-agent chat response: %w", err)
+	}
+	return &result, nil
 }
 
 func (c *DaemonClient) request(ctx context.Context, method, path string, body interface{}, actor, requestID string) ([]byte, error) {

--- a/daemon/internal/gateway/daemonclient_test.go
+++ b/daemon/internal/gateway/daemonclient_test.go
@@ -122,6 +122,22 @@ func TestDaemonClient_StopAgent(t *testing.T) {
 	}
 }
 
+func TestDaemonClient_UninstallAgent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents/a1/uninstall" || r.Method != http.MethodPost {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dc := NewDaemonClient(srv.URL, "", 5*time.Second)
+	err := dc.UninstallAgent(context.Background(), "a1", "actor", "req")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDaemonClient_GetStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{

--- a/daemon/internal/gateway/gateway.go
+++ b/daemon/internal/gateway/gateway.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -29,6 +30,11 @@ type GatewayConfig struct {
 	DiscordPublicKey        string // CARRIER_DISCORD_PUBLIC_KEY
 	FeishuVerificationToken string // CARRIER_FEISHU_VERIFICATION_TOKEN
 	TelegramWebhookSecret   string // CARRIER_TELEGRAM_WEBHOOK_SECRET
+	TelegramBotToken        string // CARRIER_TELEGRAM_BOT_TOKEN
+	TelegramTransportMode   string // CARRIER_TELEGRAM_TRANSPORT_MODE: auto|webhook|polling
+	TelegramWebhookURL      string // CARRIER_TELEGRAM_WEBHOOK_URL
+	TelegramPollingTimeout  int    // CARRIER_TELEGRAM_POLLING_TIMEOUT_SEC
+	TelegramAPIBaseURL      string // CARRIER_TELEGRAM_API_BASE_URL
 
 	// Limits
 	MaxCommandBodyBytes int // CARRIER_MAX_COMMAND_BODY_BYTES (default 64KB)
@@ -46,19 +52,24 @@ type GatewayConfig struct {
 // LoadGatewayConfigFromEnv loads GatewayConfig from environment variables.
 func LoadGatewayConfigFromEnv() *GatewayConfig {
 	cfg := &GatewayConfig{
-		Port:                parseEnvInt("CARRIER_GATEWAY_PORT", 8787),
-		Hostname:            envOrDefault("CARRIER_GATEWAY_HOST", "127.0.0.1"),
-		APIToken:            strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_API_TOKEN")),
-		DaemonBaseURL:       strings.TrimRight(strings.TrimSpace(envOrDefault("CARRIER_DAEMON_BASE_URL", "http://127.0.0.1:9090")), "/"),
-		DaemonToken:         strings.TrimSpace(os.Getenv("CARRIER_SERVER_API_TOKEN")),
-		DaemonTimeout:       time.Duration(parseEnvInt("CARRIER_DAEMON_TIMEOUT_MS", 30000)) * time.Millisecond,
-		DiscordPublicKey:    strings.TrimSpace(os.Getenv("CARRIER_DISCORD_PUBLIC_KEY")),
+		Port:                    parseEnvInt("CARRIER_GATEWAY_PORT", 8787),
+		Hostname:                envOrDefault("CARRIER_GATEWAY_HOST", "127.0.0.1"),
+		APIToken:                strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_API_TOKEN")),
+		DaemonBaseURL:           strings.TrimRight(strings.TrimSpace(envOrDefault("CARRIER_DAEMON_BASE_URL", "http://127.0.0.1:9090")), "/"),
+		DaemonToken:             strings.TrimSpace(os.Getenv("CARRIER_SERVER_API_TOKEN")),
+		DaemonTimeout:           time.Duration(parseEnvInt("CARRIER_DAEMON_TIMEOUT_MS", 30000)) * time.Millisecond,
+		DiscordPublicKey:        strings.TrimSpace(os.Getenv("CARRIER_DISCORD_PUBLIC_KEY")),
 		FeishuVerificationToken: strings.TrimSpace(os.Getenv("CARRIER_FEISHU_VERIFICATION_TOKEN")),
 		TelegramWebhookSecret:   strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_WEBHOOK_SECRET")),
-		MaxCommandBodyBytes: parseEnvInt("CARRIER_MAX_COMMAND_BODY_BYTES", defaultMaxCommandBodyBytes),
-		RateLimitPerSession: parseEnvInt("CARRIER_RATE_LIMIT_PER_SESSION", 30),
-		RateLimitGlobal:     parseEnvInt("CARRIER_RATE_LIMIT_GLOBAL", 200),
-		RateLimitWindow:     time.Duration(parseEnvInt("CARRIER_RATE_LIMIT_WINDOW_MS", 60000)) * time.Millisecond,
+		TelegramBotToken:        strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_BOT_TOKEN")),
+		TelegramTransportMode:   strings.ToLower(strings.TrimSpace(envOrDefault("CARRIER_TELEGRAM_TRANSPORT_MODE", "auto"))),
+		TelegramWebhookURL:      strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_WEBHOOK_URL")),
+		TelegramPollingTimeout:  parseEnvInt("CARRIER_TELEGRAM_POLLING_TIMEOUT_SEC", 30),
+		TelegramAPIBaseURL:      strings.TrimSpace(envOrDefault("CARRIER_TELEGRAM_API_BASE_URL", "https://api.telegram.org")),
+		MaxCommandBodyBytes:     parseEnvInt("CARRIER_MAX_COMMAND_BODY_BYTES", defaultMaxCommandBodyBytes),
+		RateLimitPerSession:     parseEnvInt("CARRIER_RATE_LIMIT_PER_SESSION", 30),
+		RateLimitGlobal:         parseEnvInt("CARRIER_RATE_LIMIT_GLOBAL", 200),
+		RateLimitWindow:         time.Duration(parseEnvInt("CARRIER_RATE_LIMIT_WINDOW_MS", 60000)) * time.Millisecond,
 	}
 
 	// Determine data dir
@@ -132,10 +143,18 @@ func StartGateway(cfg *GatewayConfig) error {
 	addr := fmt.Sprintf("%s:%d", cfg.Hostname, cfg.Port)
 	server := newGatewayHTTPServer(addr, mux)
 
+	transportCtx, cancelTransport := context.WithCancel(context.Background())
+	defer cancelTransport()
+
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("gateway listen %s: %w", addr, err)
 	}
+
+	if err := startTelegramTransport(transportCtx, cfg, daemon, sessions, downloads, rl, onboard); err != nil {
+		return err
+	}
+
 	log.Printf("[gateway] listening on http://%s", addr)
 	return server.Serve(ln)
 }

--- a/daemon/internal/gateway/managed_instances.go
+++ b/daemon/internal/gateway/managed_instances.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type managedAgentInstance struct {
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	AgentID      string `json:"agent_id"`
+	GatewayURL   string `json:"gateway_url"`
+	Workspace    string `json:"workspace_path,omitempty"`
+	ConfigPath   string `json:"config_path,omitempty"`
+	RecordPath   string `json:"record_path,omitempty"`
+	Channel      string `json:"channel,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	PairRequired bool   `json:"pair_required,omitempty"`
+	PairCode     string `json:"pair_code,omitempty"`
+	PairedChatID string `json:"paired_chat_id,omitempty"`
+	RuntimeState string `json:"runtime_state,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+type managedAgentInstanceFile struct {
+	Instances []managedAgentInstance `json:"instances"`
+}
+
+func managedInstancesPath() (string, error) {
+	if custom := strings.TrimSpace(os.Getenv("CARRIER_INSTANCE_STORE")); custom != "" {
+		return custom, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for instance store: %w", err)
+	}
+	return filepath.Join(home, ".carrier", "instances.json"), nil
+}
+
+func generateManagedInstanceID(prefix string) (string, error) {
+	p := strings.ToLower(strings.TrimSpace(prefix))
+	if p == "" {
+		p = "agent"
+	}
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate random id: %w", err)
+	}
+	return fmt.Sprintf("%s-%s", p, hex.EncodeToString(buf)), nil
+}
+
+func loadManagedInstances() ([]managedAgentInstance, string, error) {
+	path, err := managedInstancesPath()
+	if err != nil {
+		return nil, "", err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []managedAgentInstance{}, path, nil
+		}
+		return nil, "", fmt.Errorf("read instance store: %w", err)
+	}
+	var file managedAgentInstanceFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, "", fmt.Errorf("parse instance store: %w", err)
+	}
+	if file.Instances == nil {
+		file.Instances = []managedAgentInstance{}
+	}
+	return file.Instances, path, nil
+}
+
+func saveManagedInstances(path string, instances []managedAgentInstance) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("instance store path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create instance store dir: %w", err)
+	}
+	payload := managedAgentInstanceFile{Instances: instances}
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal instance store: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write instance store: %w", err)
+	}
+	return nil
+}
+
+func findManagedInstanceIndex(instances []managedAgentInstance, instanceID string) int {
+	id := strings.TrimSpace(instanceID)
+	for i, inst := range instances {
+		if strings.EqualFold(strings.TrimSpace(inst.ID), id) {
+			return i
+		}
+	}
+	return -1
+}
+
+func findManagedInstanceIndexByAgentID(instances []managedAgentInstance, agentID string) int {
+	id := strings.TrimSpace(agentID)
+	for i, inst := range instances {
+		if strings.EqualFold(strings.TrimSpace(inst.AgentID), id) {
+			return i
+		}
+	}
+	return -1
+}
+
+func upsertManagedInstance(inst managedAgentInstance) error {
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	idx := findManagedInstanceIndex(instances, inst.ID)
+	if idx >= 0 {
+		instances[idx] = inst
+	} else {
+		instances = append(instances, inst)
+	}
+	return saveManagedInstances(path, instances)
+}
+
+func cleanupManagedInstanceFiles(inst managedAgentInstance) error {
+	var firstErr error
+	removeFile := func(path string) {
+		if strings.TrimSpace(path) == "" {
+			return
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	removeDir := func(path string) {
+		p := strings.TrimSpace(path)
+		if p == "" {
+			return
+		}
+		if err := os.RemoveAll(p); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	removeFile(strings.TrimSpace(inst.RecordPath))
+	removeFile(strings.TrimSpace(inst.ConfigPath))
+	removeDir(strings.TrimSpace(inst.Workspace))
+	return firstErr
+}

--- a/daemon/internal/gateway/onboard.go
+++ b/daemon/internal/gateway/onboard.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 )
@@ -12,6 +13,8 @@ type OnboardStep string
 
 const (
 	OnboardIdle             OnboardStep = "idle"
+	OnboardChannelSelect    OnboardStep = "channel_select"
+	OnboardChannelToken     OnboardStep = "channel_token"
 	OnboardAgentSelected    OnboardStep = "agent_selected"
 	OnboardProviderSelected OnboardStep = "provider_selected"
 	OnboardAuthConfigured   OnboardStep = "auth_configured"
@@ -22,10 +25,15 @@ const (
 
 // OnboardSession is the state for a single chat's onboard flow.
 type OnboardSession struct {
-	Step             OnboardStep
-	SelectedAgent    string
-	SelectedProvider string // LLMProvider.ID
-	EnvVars          map[string]string
+	Step              OnboardStep
+	InstanceID        string
+	SelectedAgent     string
+	SelectedAgentName string
+	SelectedChannel   string
+	ChannelToken      string
+	SelectedProvider  string // LLMProvider.ID
+	WorkspacePath     string
+	EnvVars           map[string]string
 }
 
 // OnboardStore tracks per-session onboard state.
@@ -147,6 +155,10 @@ func onboardReply(ctx context.Context, requestID, sessionKey string, args []stri
 	switch sess.Step {
 	case OnboardIdle:
 		return onboardSelectAgent(ctx, requestID, sessionKey, input, daemon, store, actor)
+	case OnboardChannelSelect:
+		return onboardSelectChannel(requestID, sessionKey, input, store)
+	case OnboardChannelToken:
+		return onboardCaptureChannelToken(requestID, sessionKey, input, store)
 	case OnboardAgentSelected:
 		return onboardSelectProvider(requestID, sessionKey, input, store)
 	case OnboardProviderSelected:
@@ -183,12 +195,74 @@ func onboardSelectAgent(ctx context.Context, requestID, sessionKey, agentID stri
 		return errResp(requestID, "E_AGENT_NOT_FOUND", fmt.Sprintf("Agent %q not found. Run `/onboard` to see available agents.", agentID))
 	}
 	store.update(sessionKey, func(s *OnboardSession) {
-		s.Step = OnboardAgentSelected
 		s.SelectedAgent = agentID
+		s.SelectedAgentName = found.Name
+	})
+	if isPicoclawAgent(agentID) {
+		store.update(sessionKey, func(s *OnboardSession) {
+			s.Step = OnboardChannelSelect
+		})
+		return GatewayResponse{RequestID: requestID, Result: "ok", Message: renderPicoclawChannelPrompt()}
+	}
+	store.update(sessionKey, func(s *OnboardSession) {
+		s.Step = OnboardAgentSelected
 	})
 
 	// Build provider list
 	return buildProviderListResponse(requestID, found)
+}
+
+func onboardSelectChannel(requestID, sessionKey, input string, store *OnboardStore) GatewayResponse {
+	sess := store.get(sessionKey)
+	if sess == nil {
+		return errResp(requestID, "E_USAGE", "No active session. Run `/onboard` to start.")
+	}
+	if !isPicoclawAgent(sess.SelectedAgent) {
+		store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardAgentSelected })
+		return errResp(requestID, "E_USAGE", "Channel selection is only required for PicoClaw in this flow.")
+	}
+	channel, ok := parsePicoclawChannel(strings.TrimSpace(input))
+	if !ok {
+		return errResp(requestID, "E_USAGE", "Unsupported channel. Reply `/onboard telegram` to continue.")
+	}
+	store.update(sessionKey, func(s *OnboardSession) {
+		s.SelectedChannel = channel.ID
+		s.Step = OnboardChannelToken
+	})
+	return GatewayResponse{
+		RequestID: requestID,
+		Result:    "ok",
+		Message:   renderPicoclawChannelTokenPrompt(channel),
+	}
+}
+
+func onboardCaptureChannelToken(requestID, sessionKey, input string, store *OnboardStore) GatewayResponse {
+	sess := store.get(sessionKey)
+	if sess == nil {
+		return errResp(requestID, "E_USAGE", "No active session. Run `/onboard` to start.")
+	}
+	token := strings.TrimSpace(input)
+	if token == "" {
+		return errResp(requestID, "E_USAGE", "Bot token cannot be empty. Please paste the token to continue.")
+	}
+	store.update(sessionKey, func(s *OnboardSession) {
+		s.ChannelToken = token
+		s.Step = OnboardAgentSelected
+	})
+	name := strings.TrimSpace(sess.SelectedAgentName)
+	if name == "" {
+		name = sess.SelectedAgent
+	}
+	agent := &AgentState{ID: sess.SelectedAgent, Name: name}
+	resp := buildProviderListResponse(requestID, agent)
+	resp.Message = strings.TrimSpace(
+		fmt.Sprintf(
+			"✅ Channel configured for PicoClaw: `%s`.\n%s",
+			sess.SelectedChannel,
+			resp.Message,
+		),
+	)
+	return resp
 }
 
 // buildProviderListResponse constructs the provider selection prompt.
@@ -223,6 +297,7 @@ func buildProviderListResponse(requestID string, agent *AgentState) GatewayRespo
 
 	lines = append(lines, "Reply with a provider ID (e.g. `/onboard anthropic`) to continue,")
 	lines = append(lines, "or reply `/onboard skip` to skip provider selection.")
+	lines = append(lines, "or reply `/onboard reuse` to reuse Carrier default provider and saved credential.")
 	return GatewayResponse{RequestID: requestID, Result: "ok", Message: strings.Join(lines, "\n")}
 }
 
@@ -245,6 +320,51 @@ func authModeBadge(m AuthMode) string {
 
 func onboardSelectProvider(requestID, sessionKey, input string, store *OnboardStore) GatewayResponse {
 	lower := strings.ToLower(strings.TrimSpace(input))
+
+	if lower == "reuse" {
+		defaultProviderID := detectCarrierDefaultProviderID()
+		if defaultProviderID == "" {
+			return errResp(requestID, "E_PROVIDER_NOT_FOUND", "No Carrier default provider found. Select a provider ID explicitly.")
+		}
+		p := GetLLMProvider(defaultProviderID)
+		if p == nil {
+			return errResp(requestID, "E_PROVIDER_NOT_FOUND", fmt.Sprintf("Carrier default provider %q is not available.", defaultProviderID))
+		}
+		store.update(sessionKey, func(s *OnboardSession) {
+			s.Step = OnboardProviderSelected
+			s.SelectedProvider = p.ID
+		})
+		value, backend, ok, err := loadProviderCredential(p.ID)
+		if err != nil {
+			return errResp(requestID, "E_AUTH_INPUT", fmt.Sprintf("failed to load saved credential for %s: %v", p.Name, err))
+		}
+		if ok && p.EnvVar != "" && strings.TrimSpace(value) != "" {
+			store.update(sessionKey, func(s *OnboardSession) {
+				for k, v := range ProviderEnvVarsToSet(p, value) {
+					s.EnvVars[k] = v
+				}
+				s.Step = OnboardAuthConfigured
+			})
+			lines := []string{
+				fmt.Sprintf("✅ Reused Carrier default provider **%s** (`%s`).", p.Name, p.ID),
+				fmt.Sprintf("Credential loaded from %s.", backend),
+				"",
+			}
+			lines = append(lines, onboardEnvVarsPromptLines(store.get(sessionKey))...)
+			return GatewayResponse{RequestID: requestID, Result: "ok", Message: strings.Join(lines, "\n")}
+		}
+		if p.AuthMode == AuthModeNone {
+			store.update(sessionKey, func(s *OnboardSession) {
+				s.Step = OnboardAuthConfigured
+			})
+			return onboardPromptEnvVars(requestID, store.get(sessionKey))
+		}
+		lines := []string{
+			fmt.Sprintf("Carrier default provider is **%s** (`%s`), but no saved credential was found.", p.Name, p.ID),
+			BuildProviderAuthPrompt(p),
+		}
+		return GatewayResponse{RequestID: requestID, Result: "ok", Message: strings.Join(lines, "\n\n")}
+	}
 
 	// User can skip provider selection
 	if lower == "skip" || lower == "done" {
@@ -291,11 +411,26 @@ func onboardSelectProvider(requestID, sessionKey, input string, store *OnboardSt
 		"",
 		prompt,
 	}
+	if hint := credentialReuseHint(p); hint != "" {
+		lines = append(lines, "")
+		lines = append(lines, hint)
+	}
 	if p.ExampleModel != "" {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Suggested model: `%s`", p.ExampleModel))
 	}
 	return GatewayResponse{RequestID: requestID, Result: "ok", Message: strings.Join(lines, "\n")}
+}
+
+func credentialReuseHint(p *LLMProvider) string {
+	if p == nil {
+		return ""
+	}
+	_, backend, ok, err := loadProviderCredential(p.ID)
+	if err != nil || !ok {
+		return ""
+	}
+	return fmt.Sprintf("Saved credential detected for **%s** (%s). Reply `/onboard reuse` to use it.", p.Name, backend)
 }
 
 func onboardHandleAuth(requestID, sessionKey, input string, store *OnboardStore) GatewayResponse {
@@ -329,13 +464,19 @@ func onboardHandleAuth(requestID, sessionKey, input string, store *OnboardStore)
 		// Merge any env vars from auth result into session
 		if result.EnvVar != "" && result.Value != "" {
 			store.update(sessionKey, func(s *OnboardSession) {
-				s.EnvVars[result.EnvVar] = result.Value
+				for k, v := range ProviderEnvVarsToSet(p, result.Value) {
+					s.EnvVars[k] = v
+				}
 			})
 		}
 		store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardAuthConfigured })
 		sess = store.get(sessionKey)
 
 		lines := []string{"✅ Authentication configured.", ""}
+		if strings.TrimSpace(result.Instructions) != "" {
+			lines = append(lines, result.Instructions)
+			lines = append(lines, "")
+		}
 		lines = append(lines, onboardEnvVarsPromptLines(sess)...)
 		return GatewayResponse{RequestID: requestID, Result: "ok", Message: strings.Join(lines, "\n")}
 	}
@@ -384,13 +525,17 @@ func onboardEnvInput(requestID, sessionKey, input string, store *OnboardStore) G
 			envSummary = "\nEnvironment variables: " + strings.Join(keys, ", ")
 		}
 
+		channelLine := ""
+		if sess.SelectedChannel != "" {
+			channelLine = fmt.Sprintf("\nChannel: %s", sess.SelectedChannel)
+		}
 		providerLine := ""
 		if sess.SelectedProvider != "" {
 			providerLine = fmt.Sprintf("\nLLM Provider: %s", sess.SelectedProvider)
 		}
 
 		lines := []string{
-			fmt.Sprintf("Ready to install **%s**?%s%s", sess.SelectedAgent, providerLine, envSummary),
+			fmt.Sprintf("Ready to install **%s**?%s%s%s", sess.SelectedAgent, channelLine, providerLine, envSummary),
 			"",
 			"Reply `/onboard yes` to proceed or `/onboard no` to go back.",
 		}
@@ -426,6 +571,21 @@ func onboardConfirm(ctx context.Context, requestID, sessionKey, input string, da
 	}
 	agentID := sess.SelectedAgent
 	store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardInstalling })
+	setupNotes := []string{}
+	if isPicoclawAgent(agentID) {
+		result, err := preparePicoclawManagedOnboard(sess, actor)
+		if err != nil {
+			store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardEnvConfigured })
+			return errResp(requestID, "E_ENV", fmt.Sprintf("failed to prepare picoclaw onboarding artifacts: %v", err))
+		}
+		setupNotes = append(setupNotes, fmt.Sprintf("PicoClaw workspace: %s", result.WorkspacePath))
+		setupNotes = append(setupNotes, fmt.Sprintf("PicoClaw config: %s", result.ConfigPath))
+		setupNotes = append(setupNotes, fmt.Sprintf("Carrier record: %s", result.RecordPath))
+	}
+	if err := applyOnboardEnvVars(sess.EnvVars); err != nil {
+		store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardEnvConfigured })
+		return errResp(requestID, "E_ENV", fmt.Sprintf("failed to apply environment variables: %v", err))
+	}
 
 	if err := daemon.InstallAgent(ctx, agentID, actor, requestID); err != nil {
 		store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardDone })
@@ -444,11 +604,60 @@ func onboardConfirm(ctx context.Context, requestID, sessionKey, input string, da
 		health = statuses[0].Health
 	}
 	store.update(sessionKey, func(s *OnboardSession) { s.Step = OnboardDone })
+	pairHint := ""
+	if isPicoclawAgent(agentID) {
+		if logs, logErr := daemon.GetLogs(ctx, agentID, 120, actor, requestID); logErr == nil && logs != nil {
+			if pairCode := extractPairCode(logs.Lines); pairCode != "" {
+				pairHint = fmt.Sprintf("PicoClaw pair code: `%s`. Send `/pair %s` in your PicoClaw Telegram bot.", pairCode, pairCode)
+			}
+		}
+		if pairHint == "" {
+			pairHint = "Open your PicoClaw Telegram bot and finish any in-bot pairing/authorization prompts to complete onboarding."
+		}
+	}
+	lines := []string{fmt.Sprintf("🎉 %s installed and running (%s). Onboarding complete!", agentID, health)}
+	if len(setupNotes) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, setupNotes...)
+	}
+	if pairHint != "" {
+		lines = append(lines, "")
+		lines = append(lines, pairHint)
+	}
 	return GatewayResponse{
 		RequestID: requestID,
 		Result:    "ok",
-		Message:   fmt.Sprintf("🎉 %s installed and running (%s). Onboarding complete!", agentID, health),
+		Message:   strings.Join(lines, "\n"),
 	}
+}
+
+func detectCarrierDefaultProviderID() string {
+	providerID := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_PROVIDER_ID"))
+	if providerID != "" {
+		return providerID
+	}
+	modelID := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_MODEL_ID"))
+	if modelID == "" {
+		return ""
+	}
+	parts := strings.SplitN(modelID, "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
+func applyOnboardEnvVars(envVars map[string]string) error {
+	for k, v := range envVars {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		if err := os.Setenv(key, v); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	return nil
 }
 
 func onboardCancel(requestID, sessionKey string, store *OnboardStore) GatewayResponse {

--- a/daemon/internal/gateway/onboard_test.go
+++ b/daemon/internal/gateway/onboard_test.go
@@ -1,6 +1,8 @@
 package gateway
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -314,7 +316,11 @@ func TestOnboardHandleAuth_Skip(t *testing.T) {
 	}
 }
 
-func TestOnboardHandleAuth_OAuth_Confirm(t *testing.T) {
+func TestOnboardHandleAuth_OAuthDeviceCode_Token(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+
 	s := NewOnboardStore()
 	key := "telegram:10"
 	s.start(key)
@@ -324,17 +330,87 @@ func TestOnboardHandleAuth_OAuth_Confirm(t *testing.T) {
 		sess.SelectedProvider = "openai-codex"
 	})
 
-	resp := onboardHandleAuth("req-1", key, "confirm", s)
+	resp := onboardHandleAuth("req-1", key, "codex-token-1", s)
 	if resp.Result != "ok" {
-		t.Errorf("expected ok after confirm, got: %+v", resp)
+		t.Errorf("expected ok after token input, got: %+v", resp)
 	}
 	sess := s.get(key)
 	if sess.Step != OnboardAuthConfigured {
 		t.Errorf("expected auth_configured, got %q", sess.Step)
 	}
+	if sess.EnvVars["OPENAI_CODEX_TOKEN"] != "codex-token-1" {
+		t.Fatalf("expected OPENAI_CODEX_TOKEN to be set, got %v", sess.EnvVars)
+	}
+}
+
+func TestOnboardHandleAuth_OAuthDeviceCode_Reuse(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+
+	s := NewOnboardStore()
+	key := "telegram:10-reuse"
+	s.start(key)
+	s.update(key, func(sess *OnboardSession) {
+		sess.Step = OnboardProviderSelected
+		sess.SelectedAgent = "openclaw"
+		sess.SelectedProvider = "openai-codex"
+	})
+	if resp := onboardHandleAuth("req-1", key, "codex-token-2", s); resp.Result != "ok" {
+		t.Fatalf("seed token should succeed: %+v", resp)
+	}
+
+	key2 := "telegram:10-reuse-2"
+	s.start(key2)
+	s.update(key2, func(sess *OnboardSession) {
+		sess.Step = OnboardProviderSelected
+		sess.SelectedAgent = "openclaw"
+		sess.SelectedProvider = "openai-codex"
+	})
+	resp := onboardHandleAuth("req-2", key2, "reuse", s)
+	if resp.Result != "ok" {
+		t.Fatalf("reuse should succeed: %+v", resp)
+	}
+	sess2 := s.get(key2)
+	if sess2.EnvVars["OPENAI_CODEX_TOKEN"] != "codex-token-2" {
+		t.Fatalf("expected reused OPENAI_CODEX_TOKEN, got %v", sess2.EnvVars)
+	}
+	if !strings.Contains(resp.Message, "Reused saved credential") {
+		t.Fatalf("expected reuse message, got %q", resp.Message)
+	}
+}
+
+func TestOnboardHandleAuth_OAuthDeviceCode_ConfirmRejected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+
+	s := NewOnboardStore()
+	key := "telegram:10-confirm"
+	s.start(key)
+	s.update(key, func(sess *OnboardSession) {
+		sess.Step = OnboardProviderSelected
+		sess.SelectedAgent = "openclaw"
+		sess.SelectedProvider = "openai-codex"
+	})
+
+	resp := onboardHandleAuth("req-1", key, "confirm", s)
+	if resp.Result != "error" {
+		t.Fatalf("expected error for confirm-only input, got %+v", resp)
+	}
+	if resp.ErrorCode != "E_AUTH_INPUT" {
+		t.Fatalf("expected E_AUTH_INPUT, got %q", resp.ErrorCode)
+	}
+	if !strings.Contains(resp.Message, "OPENAI_CODEX_TOKEN") {
+		t.Fatalf("expected token guidance, got %q", resp.Message)
+	}
 }
 
 func TestOnboardHandleAuth_OAuth_BadInput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+
 	s := NewOnboardStore()
 	key := "telegram:11"
 	s.start(key)
@@ -344,9 +420,9 @@ func TestOnboardHandleAuth_OAuth_BadInput(t *testing.T) {
 		sess.SelectedProvider = "qwen-portal"
 	})
 
-	resp := onboardHandleAuth("req-1", key, "randomtext", s)
+	resp := onboardHandleAuth("req-1", key, "", s)
 	if resp.Result != "error" {
-		t.Errorf("expected error for invalid OAuth input, got: %+v", resp)
+		t.Errorf("expected error for empty OAuth token input, got: %+v", resp)
 	}
 }
 
@@ -391,5 +467,17 @@ func TestOnboardStoreNewSteps(t *testing.T) {
 	s.update(key, func(sess *OnboardSession) { sess.Step = OnboardAuthConfigured })
 	if !s.hasActive(key) {
 		t.Error("auth_configured should be active")
+	}
+}
+
+func TestApplyOnboardEnvVars(t *testing.T) {
+	const key = "CARRIER_ONBOARD_ENV_TEST"
+	t.Setenv(key, "old")
+
+	if err := applyOnboardEnvVars(map[string]string{key: "new"}); err != nil {
+		t.Fatalf("applyOnboardEnvVars returned error: %v", err)
+	}
+	if got := os.Getenv(key); got != "new" {
+		t.Fatalf("env %s = %q, want %q", key, got, "new")
 	}
 }

--- a/daemon/internal/gateway/pairing_sessions.go
+++ b/daemon/internal/gateway/pairing_sessions.go
@@ -1,0 +1,50 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+)
+
+type pairingSessionSummary struct {
+	Provider  string `json:"provider"`
+	ChatID    string `json:"chatId"`
+	CreatedAt string `json:"createdAt"`
+	LastSeen  string `json:"lastSeenAt"`
+}
+
+func handlePairingSessions(w http.ResponseWriter, r *http.Request, requestID string, sessions *SessionStore) {
+	if sessions == nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", "session store is not initialized"))
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("provider")))
+	if provider == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "provider query parameter is required"))
+		return
+	}
+	if !IsValidProviderType(provider) {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "unsupported provider"))
+		return
+	}
+
+	records := sessions.ListSessions(provider)
+	items := make([]pairingSessionSummary, 0, len(records))
+	for _, rec := range records {
+		if rec == nil {
+			continue
+		}
+		items = append(items, pairingSessionSummary{
+			Provider:  rec.Provider,
+			ChatID:    rec.ChatID,
+			CreatedAt: rec.CreatedAt,
+			LastSeen:  rec.LastSeenAt,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"requestId": requestID,
+		"result":    "ok",
+		"provider":  provider,
+		"sessions":  items,
+	})
+}

--- a/daemon/internal/gateway/picoclaw_onboard.go
+++ b/daemon/internal/gateway/picoclaw_onboard.go
@@ -1,0 +1,393 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type picoclawChannel struct {
+	ID         string
+	Name       string
+	TokenLabel string
+}
+
+type picoclawManagedOnboardResult struct {
+	WorkspacePath string
+	ConfigPath    string
+	RecordPath    string
+}
+
+var (
+	picoclawPairCodePattern = regexp.MustCompile(`\bpair-[a-f0-9]{32}\b`)
+	picoclawPairedPattern   = regexp.MustCompile(`(?i)\bpaired\s+telegram:([0-9]+)\b`)
+	picoclawChannels        = []picoclawChannel{
+		{
+			ID:         "telegram",
+			Name:       "Telegram",
+			TokenLabel: "Telegram bot token for PicoClaw",
+		},
+	}
+)
+
+func isPicoclawAgent(agentID string) bool {
+	return strings.EqualFold(strings.TrimSpace(agentID), "picoclaw")
+}
+
+func parsePicoclawChannel(input string) (picoclawChannel, bool) {
+	id := strings.ToLower(strings.TrimSpace(input))
+	for _, ch := range picoclawChannels {
+		if id == ch.ID {
+			return ch, true
+		}
+	}
+	return picoclawChannel{}, false
+}
+
+func renderPicoclawChannelPrompt() string {
+	lines := []string{
+		"Selected agent: **PicoClaw** (picoclaw)",
+		"",
+		"**Step 2 — Choose a channel for PicoClaw**",
+	}
+	for _, ch := range picoclawChannels {
+		lines = append(lines, fmt.Sprintf("  • `%s` — %s", ch.ID, ch.Name))
+	}
+	lines = append(lines, "")
+	lines = append(lines, "Reply with the channel ID (e.g. `/onboard telegram`).")
+	return strings.Join(lines, "\n")
+}
+
+func renderPicoclawChannelTokenPrompt(ch picoclawChannel) string {
+	return strings.Join([]string{
+		fmt.Sprintf("✅ PicoClaw channel selected: **%s** (`%s`).", ch.Name, ch.ID),
+		"",
+		fmt.Sprintf("Paste %s.", ch.TokenLabel),
+	}, "\n")
+}
+
+func extractPairCode(lines []string) string {
+	for _, line := range lines {
+		code := strings.TrimSpace(picoclawPairCodePattern.FindString(line))
+		if code != "" {
+			return code
+		}
+	}
+	return ""
+}
+
+func extractPairedTelegramChatID(lines []string) string {
+	for _, line := range lines {
+		matches := picoclawPairedPattern.FindStringSubmatch(line)
+		if len(matches) < 2 {
+			continue
+		}
+		chatID := strings.TrimSpace(matches[1])
+		if chatID != "" {
+			return chatID
+		}
+	}
+	return ""
+}
+
+func preparePicoclawManagedOnboard(sess *OnboardSession, actor string) (*picoclawManagedOnboardResult, error) {
+	if sess == nil {
+		return nil, fmt.Errorf("nil onboarding session")
+	}
+	if !isPicoclawAgent(sess.SelectedAgent) {
+		return nil, fmt.Errorf("managed onboarding is only supported for picoclaw")
+	}
+	if strings.TrimSpace(sess.SelectedChannel) == "" {
+		return nil, fmt.Errorf("picoclaw channel is required")
+	}
+	if strings.TrimSpace(sess.ChannelToken) == "" {
+		return nil, fmt.Errorf("picoclaw channel token is required")
+	}
+	if strings.TrimSpace(sess.SelectedProvider) == "" {
+		return nil, fmt.Errorf("picoclaw provider is required")
+	}
+	provider := GetLLMProvider(sess.SelectedProvider)
+	if provider == nil {
+		return nil, fmt.Errorf("unknown provider %q", sess.SelectedProvider)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	instanceID := strings.TrimSpace(sess.InstanceID)
+	if instanceID == "" {
+		instanceID = "picoclaw"
+	}
+	workspacePath := strings.TrimSpace(sess.WorkspacePath)
+	if workspacePath == "" {
+		workspacePath = filepath.Join(home, ".picoclaw", "instances", instanceID, "workspace")
+	}
+	configPath := filepath.Join(home, ".picoclaw", "config.json")
+	recordPath := filepath.Join(home, ".carrier", "agents", instanceID+".json")
+
+	if err := os.MkdirAll(workspacePath, 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(recordPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create record dir: %w", err)
+	}
+
+	if err := backupIfExists(configPath); err != nil {
+		return nil, fmt.Errorf("backup existing picoclaw config: %w", err)
+	}
+
+	modelID := strings.TrimSpace(provider.ExampleModel)
+	if modelID == "" {
+		modelID = provider.ID + "/default"
+	}
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		if _, name, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(name) != "" {
+			modelID = "openai/" + strings.TrimSpace(name)
+		} else {
+			modelID = "openai/gpt-5.3-codex"
+		}
+	}
+	modelName := modelID
+	if _, name, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(name) != "" {
+		modelName = strings.TrimSpace(name)
+	}
+	providerKey := provider.ID
+	if vendor, _, ok := strings.Cut(modelID, "/"); ok && strings.TrimSpace(vendor) != "" {
+		providerKey = strings.TrimSpace(vendor)
+	}
+	providerKey = mapCarrierProviderToPicoclawProvider(providerKey)
+	modelItem := map[string]interface{}{
+		"model_name": modelName,
+		"model":      modelID,
+	}
+	providerItem := map[string]interface{}{}
+	token := pickProviderToken(provider, sess.EnvVars)
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		modelItem["auth_method"] = "oauth"
+		providerItem["auth_method"] = "oauth"
+		if token != "" {
+			modelItem["api_key"] = token
+			providerItem["api_key"] = token
+		}
+		accountID := extractOpenAIAccountID(token)
+		if err := savePicoclawAuthCredential(home, "openai", token, accountID); err != nil {
+			return nil, fmt.Errorf("write picoclaw auth store: %w", err)
+		}
+	} else if token != "" {
+		modelItem["api_key"] = token
+		providerItem["api_key"] = token
+	}
+
+	chatID := actorChatID(actor)
+	allowFrom := []string{}
+	if chatID != "" {
+		allowFrom = append(allowFrom, chatID)
+	}
+	channels := map[string]interface{}{
+		sess.SelectedChannel: map[string]interface{}{
+			"enabled":    true,
+			"token":      sess.ChannelToken,
+			"allow_from": allowFrom,
+		},
+	}
+
+	payload := map[string]interface{}{
+		"agents": map[string]interface{}{
+			"defaults": map[string]interface{}{
+				"workspace":             workspacePath,
+				"provider":              providerKey,
+				"model":                 modelName,
+				"max_tokens":            8192,
+				"temperature":           0.7,
+				"max_tool_iterations":   20,
+				"restrict_to_workspace": true,
+			},
+		},
+		"model_list": []interface{}{modelItem},
+		"providers": map[string]interface{}{
+			providerKey: providerItem,
+		},
+		"channels": channels,
+	}
+
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal picoclaw config: %w", err)
+	}
+	if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("write picoclaw config: %w", err)
+	}
+
+	record := map[string]interface{}{
+		"instance_id":    instanceID,
+		"agent_id":       "picoclaw",
+		"workspace_path": workspacePath,
+		"config_path":    configPath,
+		"channel":        sess.SelectedChannel,
+		"provider":       provider.ID,
+		"updated_at":     time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	recordRaw, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal carrier record: %w", err)
+	}
+	if err := os.WriteFile(recordPath, append(recordRaw, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("write carrier record: %w", err)
+	}
+
+	return &picoclawManagedOnboardResult{
+		WorkspacePath: workspacePath,
+		ConfigPath:    configPath,
+		RecordPath:    recordPath,
+	}, nil
+}
+
+func backupIfExists(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	backupPath := fmt.Sprintf("%s.bak.%s", path, time.Now().UTC().Format("20060102T150405Z"))
+	return os.Rename(path, backupPath)
+}
+
+func actorChatID(actor string) string {
+	_, chatID, ok := strings.Cut(strings.TrimSpace(actor), ":")
+	if !ok {
+		return ""
+	}
+	trimmed := strings.TrimSpace(chatID)
+	if trimmed == "" {
+		return ""
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return trimmed
+}
+
+func mapCarrierProviderToPicoclawProvider(providerID string) string {
+	switch strings.ToLower(strings.TrimSpace(providerID)) {
+	case "openai-codex":
+		return "openai"
+	default:
+		return strings.TrimSpace(providerID)
+	}
+}
+
+func pickProviderToken(provider *LLMProvider, envVars map[string]string) string {
+	if provider == nil || envVars == nil {
+		return ""
+	}
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		for _, key := range []string{"OPENAI_CODEX_TOKEN", "OPENAI_API_KEY", provider.EnvVar} {
+			if token := strings.TrimSpace(envVars[key]); token != "" {
+				return token
+			}
+		}
+		return ""
+	}
+	if provider.EnvVar == "" {
+		return ""
+	}
+	return strings.TrimSpace(envVars[provider.EnvVar])
+}
+
+type picoclawAuthCredential struct {
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id,omitempty"`
+	Provider    string `json:"provider"`
+	AuthMethod  string `json:"auth_method"`
+}
+
+type picoclawAuthStore struct {
+	Credentials map[string]*picoclawAuthCredential `json:"credentials"`
+}
+
+func savePicoclawAuthCredential(home, providerID, accessToken, accountID string) error {
+	if strings.TrimSpace(accessToken) == "" {
+		return fmt.Errorf("empty access token")
+	}
+	path := filepath.Join(home, ".picoclaw", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create auth dir: %w", err)
+	}
+
+	store := picoclawAuthStore{Credentials: map[string]*picoclawAuthCredential{}}
+	if existing, err := os.ReadFile(path); err == nil && len(existing) > 0 {
+		if err := json.Unmarshal(existing, &store); err != nil {
+			return fmt.Errorf("parse existing auth store: %w", err)
+		}
+	}
+	if store.Credentials == nil {
+		store.Credentials = map[string]*picoclawAuthCredential{}
+	}
+	store.Credentials[strings.TrimSpace(providerID)] = &picoclawAuthCredential{
+		AccessToken: strings.TrimSpace(accessToken),
+		AccountID:   strings.TrimSpace(accountID),
+		Provider:    strings.TrimSpace(providerID),
+		AuthMethod:  "oauth",
+	}
+
+	raw, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal auth store: %w", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write auth store: %w", err)
+	}
+	return nil
+}
+
+func extractOpenAIAccountID(token string) string {
+	claims, err := parseJWTClaims(token)
+	if err != nil {
+		return ""
+	}
+	if accountID, ok := claims["chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		return strings.TrimSpace(accountID)
+	}
+	if accountID, ok := claims["https://api.openai.com/auth.chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		return strings.TrimSpace(accountID)
+	}
+	if authClaim, ok := claims["https://api.openai.com/auth"].(map[string]interface{}); ok {
+		if accountID, ok := authClaim["chatgpt_account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+			return strings.TrimSpace(accountID)
+		}
+	}
+	return ""
+}
+
+func parseJWTClaims(token string) (map[string]interface{}, error) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("token is not a JWT")
+	}
+	payload := parts[1]
+	decoded, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode jwt payload: %w", err)
+		}
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return nil, fmt.Errorf("decode jwt claims: %w", err)
+	}
+	return claims, nil
+}

--- a/daemon/internal/gateway/picoclaw_onboard_test.go
+++ b/daemon/internal/gateway/picoclaw_onboard_test.go
@@ -1,0 +1,206 @@
+package gateway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePicoclawChannel(t *testing.T) {
+	if _, ok := parsePicoclawChannel("telegram"); !ok {
+		t.Fatal("expected telegram channel to be supported")
+	}
+	if _, ok := parsePicoclawChannel("discord"); ok {
+		t.Fatal("did not expect discord channel to be supported in managed picoclaw flow")
+	}
+}
+
+func TestOnboardSelectProvider_ReuseCarrierDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai-codex")
+
+	if _, err := saveProviderCredential("openai-codex", "codex-token-1"); err != nil {
+		t.Fatalf("saveProviderCredential: %v", err)
+	}
+
+	s := NewOnboardStore()
+	key := "telegram:reuse"
+	s.start(key)
+	s.update(key, func(sess *OnboardSession) {
+		sess.Step = OnboardAgentSelected
+		sess.SelectedAgent = "picoclaw"
+	})
+
+	resp := onboardSelectProvider("req-1", key, "reuse", s)
+	if resp.Result != "ok" {
+		t.Fatalf("expected ok, got: %+v", resp)
+	}
+	sess := s.get(key)
+	if sess.Step != OnboardAuthConfigured {
+		t.Fatalf("expected auth_configured, got %q", sess.Step)
+	}
+	if sess.SelectedProvider != "openai-codex" {
+		t.Fatalf("expected selected provider openai-codex, got %q", sess.SelectedProvider)
+	}
+	if got := sess.EnvVars["OPENAI_CODEX_TOKEN"]; got != "codex-token-1" {
+		t.Fatalf("expected OPENAI_CODEX_TOKEN to be reused, got %q", got)
+	}
+	if !strings.Contains(resp.Message, "Reused Carrier default provider") {
+		t.Fatalf("expected reuse confirmation in message, got %q", resp.Message)
+	}
+}
+
+func TestPreparePicoclawManagedOnboard_WritesConfigAndRecord(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+
+	sess := &OnboardSession{
+		SelectedAgent:    "picoclaw",
+		SelectedChannel:  "telegram",
+		ChannelToken:     "telegram-token-abc",
+		SelectedProvider: "openai-codex",
+		EnvVars: map[string]string{
+			"OPENAI_CODEX_TOKEN": "codex-token-value",
+		},
+	}
+
+	result, err := preparePicoclawManagedOnboard(sess, "telegram:418258935")
+	if err != nil {
+		t.Fatalf("preparePicoclawManagedOnboard: %v", err)
+	}
+	if result.WorkspacePath == "" || result.ConfigPath == "" || result.RecordPath == "" {
+		t.Fatalf("expected non-empty output paths, got %+v", result)
+	}
+
+	cfgRaw, err := os.ReadFile(result.ConfigPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
+		t.Fatalf("parse config json: %v", err)
+	}
+
+	modelList, ok := cfg["model_list"].([]interface{})
+	if !ok || len(modelList) != 1 {
+		t.Fatalf("expected 1 model in model_list, got %#v", cfg["model_list"])
+	}
+	model, ok := modelList[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected model entry map, got %#v", modelList[0])
+	}
+	if model["model"] != "openai/gpt-5.3-codex" {
+		t.Fatalf("unexpected model id: %v", model["model"])
+	}
+	if model["auth_method"] != "oauth" {
+		t.Fatalf("unexpected auth_method: %v", model["auth_method"])
+	}
+	agents, ok := cfg["agents"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected agents object, got %#v", cfg["agents"])
+	}
+	defaults, ok := agents["defaults"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected agents.defaults object, got %#v", agents["defaults"])
+	}
+	if defaults["provider"] != "openai" {
+		t.Fatalf("unexpected default provider: %v", defaults["provider"])
+	}
+	if defaults["model"] != "gpt-5.3-codex" {
+		t.Fatalf("unexpected default model: %v", defaults["model"])
+	}
+
+	providers, ok := cfg["providers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected providers object, got %#v", cfg["providers"])
+	}
+	openaiProvider, ok := providers["openai"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected providers.openai object, got %#v", providers["openai"])
+	}
+	if openaiProvider["auth_method"] != "oauth" {
+		t.Fatalf("unexpected providers.openai.auth_method: %v", openaiProvider["auth_method"])
+	}
+
+	authPath := filepath.Join(tmp, ".picoclaw", "auth.json")
+	authRaw, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read auth store: %v", err)
+	}
+	var authStore map[string]interface{}
+	if err := json.Unmarshal(authRaw, &authStore); err != nil {
+		t.Fatalf("parse auth store json: %v", err)
+	}
+	creds, ok := authStore["credentials"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected credentials map, got %#v", authStore["credentials"])
+	}
+	openaiCred, ok := creds["openai"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected openai credential, got %#v", creds["openai"])
+	}
+	if openaiCred["access_token"] != "codex-token-value" {
+		t.Fatalf("unexpected openai access_token: %v", openaiCred["access_token"])
+	}
+	if openaiCred["auth_method"] != "oauth" {
+		t.Fatalf("unexpected openai auth_method: %v", openaiCred["auth_method"])
+	}
+
+	recordRaw, err := os.ReadFile(result.RecordPath)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	var record map[string]interface{}
+	if err := json.Unmarshal(recordRaw, &record); err != nil {
+		t.Fatalf("parse record json: %v", err)
+	}
+	if record["workspace_path"] != result.WorkspacePath {
+		t.Fatalf("record workspace_path mismatch: got %v want %s", record["workspace_path"], result.WorkspacePath)
+	}
+}
+
+func TestExtractPairCode(t *testing.T) {
+	lines := []string{
+		"booting...",
+		"PAIR_CODE: pair-abcdef0123456789abcdef0123456789",
+	}
+	if got := extractPairCode(lines); got != "pair-abcdef0123456789abcdef0123456789" {
+		t.Fatalf("extractPairCode mismatch: %q", got)
+	}
+}
+
+func TestExtractPairedTelegramChatID(t *testing.T) {
+	lines := []string{
+		"booting...",
+		"✅ paired telegram:418258935",
+	}
+	if got := extractPairedTelegramChatID(lines); got != "418258935" {
+		t.Fatalf("extractPairedTelegramChatID mismatch: %q", got)
+	}
+}
+
+func TestActorChatID(t *testing.T) {
+	if got := actorChatID("telegram:418258935"); got != "418258935" {
+		t.Fatalf("actorChatID numeric mismatch: %q", got)
+	}
+	if got := actorChatID("webui:add"); got != "" {
+		t.Fatalf("actorChatID should ignore non-numeric chat id, got %q", got)
+	}
+}
+
+func TestExtractOpenAIAccountID_FromClaims(t *testing.T) {
+	tokenWithTopLevel := "aaaa.eyJjaGF0Z3B0X2FjY291bnRfaWQiOiJhY2N0LTEifQ.bbbb"
+	if got := extractOpenAIAccountID(tokenWithTopLevel); got != "acct-1" {
+		t.Fatalf("extractOpenAIAccountID top-level mismatch: %q", got)
+	}
+
+	tokenWithNamespaced := "aaaa.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGguY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdC0yIn0.bbbb"
+	if got := extractOpenAIAccountID(tokenWithNamespaced); got != "acct-2" {
+		t.Fatalf("extractOpenAIAccountID namespaced mismatch: %q", got)
+	}
+}

--- a/daemon/internal/gateway/provider_auth.go
+++ b/daemon/internal/gateway/provider_auth.go
@@ -22,20 +22,30 @@ type ProviderAuthResult struct {
 func BuildProviderAuthPrompt(p *LLMProvider) string {
 	switch p.AuthMode {
 	case AuthModeAPIKey:
-		return fmt.Sprintf("Please paste your API key for **%s** (env: `%s`):", p.Name, p.EnvVar)
+		return fmt.Sprintf(
+			"Please paste your API key for **%s** (env: `%s`).\n\n"+
+				"Tip: reply `/onboard reuse` to reuse a credential saved by Carrier.",
+			p.Name, p.EnvVar,
+		)
 	case AuthModeOAuthDeviceCode:
+		if strings.TrimSpace(p.EnvVar) == "" {
+			return fmt.Sprintf(
+				"**%s** uses an OAuth device-code flow.\n\n"+
+					"Complete auth in your tool, then reply `/onboard confirm` when done.",
+				p.Name,
+			)
+		}
 		return fmt.Sprintf(
 			"**%s** uses an OAuth device-code flow.\n\n"+
-				"Run the following command to authenticate, then reply `/onboard confirm` when done:\n\n"+
-				"```\nopenclaw models auth login --provider %s\n```",
-			p.Name, p.ID,
+				"Complete the device-code login in your auth tool/browser, then paste `%s` here.\n\n"+
+				"Tip: reply `/onboard reuse` to reuse a credential saved by Carrier.",
+			p.Name, p.EnvVar,
 		)
 	case AuthModeOAuthPlugin:
 		return fmt.Sprintf(
 			"**%s** uses an OAuth plugin flow.\n\n"+
-				"Run the following command to authenticate, then reply `/onboard confirm` when done:\n\n"+
-				"```\nopenclaw models auth login --provider %s\n```",
-			p.Name, p.ID,
+				"Complete auth in the provider plugin/CLI, then reply `/onboard confirm` when done.",
+			p.Name,
 		)
 	case AuthModeGcloudADC:
 		return fmt.Sprintf(
@@ -56,27 +66,27 @@ func BuildProviderAuthPrompt(p *LLMProvider) string {
 // It returns a ProviderAuthResult describing what happened.
 func HandleProviderAuthInput(p *LLMProvider, input string) (*ProviderAuthResult, error) {
 	input = strings.TrimSpace(input)
+	lower := strings.ToLower(input)
 
 	switch p.AuthMode {
 	case AuthModeAPIKey:
-		if input == "" {
-			return nil, fmt.Errorf("API key cannot be empty; please paste your %s key", p.EnvVar)
+		return handlePastedCredentialInput(p, input, lower, "API key")
+
+	case AuthModeOAuthDeviceCode:
+		// Prefer token paste so Carrier can persist and later reuse credentials.
+		if strings.TrimSpace(p.EnvVar) == "" {
+			if lower == "confirm" || lower == "done" || lower == "yes" || lower == "y" {
+				return &ProviderAuthResult{Done: true}, nil
+			}
+			return nil, fmt.Errorf("reply `/onboard confirm` once you have completed the auth steps shown above")
 		}
-		return &ProviderAuthResult{
-			EnvVar: p.EnvVar,
-			Value:  input,
-			Done:   true,
-		}, nil
+		if lower == "confirm" || lower == "done" || lower == "yes" || lower == "y" {
+			return nil, fmt.Errorf("please paste `%s` after device-code login, or reply `/onboard reuse`", p.EnvVar)
+		}
+		return handlePastedCredentialInput(p, input, lower, p.EnvVar+" token")
 
-	case AuthModeNone:
-		// No key needed — auto-complete.
-		return &ProviderAuthResult{
-			Done: true,
-		}, nil
-
-	case AuthModeOAuthDeviceCode, AuthModeOAuthPlugin, AuthModeGcloudADC:
+	case AuthModeOAuthPlugin, AuthModeGcloudADC:
 		// These require external tooling. We accept "confirm" / "done" / "yes" to proceed.
-		lower := strings.ToLower(input)
 		if lower == "confirm" || lower == "done" || lower == "yes" || lower == "y" {
 			return &ProviderAuthResult{
 				Done: true,
@@ -84,16 +94,70 @@ func HandleProviderAuthInput(p *LLMProvider, input string) (*ProviderAuthResult,
 		}
 		return nil, fmt.Errorf("reply `/onboard confirm` once you have completed the auth steps shown above")
 
+	case AuthModeNone:
+		// No key needed — auto-complete.
+		return &ProviderAuthResult{
+			Done: true,
+		}, nil
+
 	default:
 		return &ProviderAuthResult{Done: true}, nil
 	}
 }
 
+func handlePastedCredentialInput(p *LLMProvider, input, lowerInput, label string) (*ProviderAuthResult, error) {
+	if strings.TrimSpace(p.EnvVar) == "" {
+		return nil, fmt.Errorf("provider %s does not expose an env var for interactive auth input", p.Name)
+	}
+	if lowerInput == "reuse" {
+		value, backend, ok, err := loadProviderCredential(p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load saved credential for %s: %w", p.Name, err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("no saved credential found for %s; please paste your %s", p.Name, label)
+		}
+		return &ProviderAuthResult{
+			EnvVar:       p.EnvVar,
+			Value:        value,
+			Instructions: fmt.Sprintf("Reused saved credential for **%s** from %s.", p.Name, backend),
+			Done:         true,
+		}, nil
+	}
+
+	if input == "" {
+		return nil, fmt.Errorf("%s cannot be empty; please paste `%s`", label, p.EnvVar)
+	}
+	result := &ProviderAuthResult{
+		EnvVar: p.EnvVar,
+		Value:  input,
+		Done:   true,
+	}
+	backend, err := saveProviderCredential(p.ID, input)
+	if err != nil {
+		result.Instructions = fmt.Sprintf("Credential applied for this onboarding session, but failed to save: %v", err)
+		return result, nil
+	}
+	result.Instructions = fmt.Sprintf("Credential saved for future reuse (%s).", backend)
+	return result, nil
+}
+
 // ProviderEnvVarsToSet returns the env var map entries that should be auto-set for a provider,
 // given a credential value. For api_key mode this is {EnvVar: value}; for others it may be empty.
 func ProviderEnvVarsToSet(p *LLMProvider, value string) map[string]string {
-	if p.AuthMode == AuthModeAPIKey && p.EnvVar != "" && value != "" {
-		return map[string]string{p.EnvVar: value}
+	if p == nil {
+		return nil
 	}
-	return nil
+	trimmed := strings.TrimSpace(value)
+	if strings.TrimSpace(p.EnvVar) == "" || trimmed == "" {
+		return nil
+	}
+	out := map[string]string{p.EnvVar: trimmed}
+	// Compatibility alias:
+	// some downstream runtimes (including older PicoClaw flows) still
+	// resolve OpenAI-compatible credentials from OPENAI_API_KEY.
+	if strings.EqualFold(strings.TrimSpace(p.ID), "openai-codex") {
+		out["OPENAI_API_KEY"] = trimmed
+	}
+	return out
 }

--- a/daemon/internal/gateway/provider_auth_test.go
+++ b/daemon/internal/gateway/provider_auth_test.go
@@ -1,11 +1,23 @@
 package gateway
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
+func prepareCredentialStore(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "credentials.json")
+	t.Setenv("CARRIER_CREDENTIAL_STORE", path)
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+	return path
+}
+
 func TestHandleProviderAuthInput_APIKey_Valid(t *testing.T) {
+	prepareCredentialStore(t)
+
 	p := GetLLMProvider("anthropic")
 	if p == nil {
 		t.Fatal("anthropic provider not found")
@@ -23,9 +35,14 @@ func TestHandleProviderAuthInput_APIKey_Valid(t *testing.T) {
 	if result.Value != "sk-test-key-12345" {
 		t.Errorf("Value: got %q", result.Value)
 	}
+	if !strings.Contains(result.Instructions, "Credential saved") {
+		t.Errorf("expected save message, got %q", result.Instructions)
+	}
 }
 
 func TestHandleProviderAuthInput_APIKey_Empty(t *testing.T) {
+	prepareCredentialStore(t)
+
 	p := GetLLMProvider("openai")
 	if p == nil {
 		t.Fatal("openai provider not found")
@@ -37,6 +54,8 @@ func TestHandleProviderAuthInput_APIKey_Empty(t *testing.T) {
 }
 
 func TestHandleProviderAuthInput_APIKey_Whitespace(t *testing.T) {
+	prepareCredentialStore(t)
+
 	p := GetLLMProvider("mistral")
 	_, err := HandleProviderAuthInput(p, "   ")
 	if err == nil {
@@ -61,28 +80,79 @@ func TestHandleProviderAuthInput_None_AutoComplete(t *testing.T) {
 	}
 }
 
-func TestHandleProviderAuthInput_OAuthDeviceCode_Confirm(t *testing.T) {
+func TestHandleProviderAuthInput_OAuthDeviceCode_Token(t *testing.T) {
+	prepareCredentialStore(t)
+
 	p := GetLLMProvider("openai-codex")
 	if p == nil {
 		t.Fatal("openai-codex provider not found")
 	}
-	for _, input := range []string{"confirm", "done", "yes", "y"} {
-		result, err := HandleProviderAuthInput(p, input)
-		if err != nil {
-			t.Errorf("input %q: unexpected error: %v", input, err)
-			continue
-		}
-		if !result.Done {
-			t.Errorf("input %q: result should be done", input)
-		}
+	result, err := HandleProviderAuthInput(p, "codex-token-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Done {
+		t.Error("result should be done")
+	}
+	if result.EnvVar != "OPENAI_CODEX_TOKEN" {
+		t.Errorf("EnvVar: got %q, want OPENAI_CODEX_TOKEN", result.EnvVar)
+	}
+	if result.Value != "codex-token-abc" {
+		t.Errorf("Value: got %q", result.Value)
 	}
 }
 
-func TestHandleProviderAuthInput_OAuthDeviceCode_Reject(t *testing.T) {
-	p := GetLLMProvider("qwen-portal")
-	_, err := HandleProviderAuthInput(p, "not-a-valid-confirm")
+func TestHandleProviderAuthInput_OAuthDeviceCode_ConfirmRejected(t *testing.T) {
+	prepareCredentialStore(t)
+
+	p := GetLLMProvider("openai-codex")
+	if p == nil {
+		t.Fatal("openai-codex provider not found")
+	}
+	_, err := HandleProviderAuthInput(p, "confirm")
 	if err == nil {
-		t.Error("expected error for non-confirm input in OAuth device code flow")
+		t.Fatal("expected error for confirm input in OAuth device-code flow")
+	}
+	if !strings.Contains(err.Error(), "OPENAI_CODEX_TOKEN") {
+		t.Fatalf("expected OPENAI_CODEX_TOKEN guidance, got %v", err)
+	}
+}
+
+func TestHandleProviderAuthInput_OAuthDeviceCode_Reuse(t *testing.T) {
+	prepareCredentialStore(t)
+
+	p := GetLLMProvider("openai-codex")
+	if p == nil {
+		t.Fatal("openai-codex provider not found")
+	}
+	if _, err := HandleProviderAuthInput(p, "first-token"); err != nil {
+		t.Fatalf("seed token failed: %v", err)
+	}
+	result, err := HandleProviderAuthInput(p, "reuse")
+	if err != nil {
+		t.Fatalf("reuse failed: %v", err)
+	}
+	if result.Value != "first-token" {
+		t.Fatalf("expected reused token first-token, got %q", result.Value)
+	}
+	if !strings.Contains(result.Instructions, "Reused saved credential") {
+		t.Fatalf("expected reuse message, got %q", result.Instructions)
+	}
+}
+
+func TestHandleProviderAuthInput_OAuthDeviceCode_ReuseWithoutSavedValue(t *testing.T) {
+	prepareCredentialStore(t)
+
+	p := GetLLMProvider("openai-codex")
+	if p == nil {
+		t.Fatal("openai-codex provider not found")
+	}
+	_, err := HandleProviderAuthInput(p, "reuse")
+	if err == nil {
+		t.Fatal("expected error when no saved credential exists")
+	}
+	if !strings.Contains(err.Error(), "no saved credential") {
+		t.Fatalf("expected no-saved-credential error, got %v", err)
 	}
 }
 
@@ -117,24 +187,33 @@ func TestBuildProviderAuthPrompt_APIKey(t *testing.T) {
 	if !strings.Contains(prompt, "Anthropic") {
 		t.Errorf("expected provider name in prompt, got: %q", prompt)
 	}
+	if !strings.Contains(prompt, "/onboard reuse") {
+		t.Errorf("expected reuse hint in prompt, got: %q", prompt)
+	}
 }
 
 func TestBuildProviderAuthPrompt_OAuthDeviceCode(t *testing.T) {
 	p := GetLLMProvider("openai-codex")
 	prompt := BuildProviderAuthPrompt(p)
-	if !strings.Contains(prompt, "openclaw models auth login") {
-		t.Errorf("expected login command in prompt, got: %q", prompt)
+	if !strings.Contains(prompt, "OPENAI_CODEX_TOKEN") {
+		t.Errorf("expected token env var in prompt, got: %q", prompt)
 	}
-	if !strings.Contains(prompt, "openai-codex") {
-		t.Errorf("expected provider ID in prompt, got: %q", prompt)
+	if !strings.Contains(prompt, "/onboard reuse") {
+		t.Errorf("expected reuse hint in prompt, got: %q", prompt)
+	}
+	if strings.Contains(prompt, "openclaw models auth login") {
+		t.Errorf("legacy login command should not appear, got: %q", prompt)
 	}
 }
 
 func TestBuildProviderAuthPrompt_OAuthPlugin(t *testing.T) {
 	p := GetLLMProvider("google-gemini-cli")
 	prompt := BuildProviderAuthPrompt(p)
-	if !strings.Contains(prompt, "openclaw models auth login") {
-		t.Errorf("expected login command in prompt, got: %q", prompt)
+	if !strings.Contains(prompt, "/onboard confirm") {
+		t.Errorf("expected confirm guidance in prompt, got: %q", prompt)
+	}
+	if strings.Contains(prompt, "openclaw models auth login") {
+		t.Errorf("legacy login command should not appear, got: %q", prompt)
 	}
 }
 
@@ -159,6 +238,17 @@ func TestProviderEnvVarsToSet_APIKey(t *testing.T) {
 	m := ProviderEnvVarsToSet(p, "my-key")
 	if m["ANTHROPIC_API_KEY"] != "my-key" {
 		t.Errorf("expected ANTHROPIC_API_KEY=my-key, got %v", m)
+	}
+}
+
+func TestProviderEnvVarsToSet_OAuthDeviceCode(t *testing.T) {
+	p := GetLLMProvider("openai-codex")
+	m := ProviderEnvVarsToSet(p, "codex-token")
+	if m["OPENAI_CODEX_TOKEN"] != "codex-token" {
+		t.Errorf("expected OPENAI_CODEX_TOKEN=codex-token, got %v", m)
+	}
+	if m["OPENAI_API_KEY"] != "codex-token" {
+		t.Errorf("expected OPENAI_API_KEY=codex-token alias, got %v", m)
 	}
 }
 

--- a/daemon/internal/gateway/provider_default.go
+++ b/daemon/internal/gateway/provider_default.go
@@ -1,0 +1,56 @@
+package gateway
+
+import (
+	"os"
+	"strings"
+)
+
+func buildCarrierDefaultProviderInfo() map[string]interface{} {
+	info := map[string]interface{}{
+		"configured": false,
+		"available":  false,
+		"reusable":   false,
+	}
+
+	providerID := strings.TrimSpace(os.Getenv("CARRIER_DEFAULT_PROVIDER_ID"))
+	if providerID == "" {
+		return info
+	}
+
+	info["configured"] = true
+	info["id"] = providerID
+
+	provider := GetLLMProvider(providerID)
+	if provider == nil {
+		info["reason"] = "default provider is not in gateway catalog"
+		return info
+	}
+
+	info["available"] = true
+	info["provider"] = provider
+
+	if provider.AuthMode == AuthModeNone {
+		info["has_saved_credential"] = true
+		info["credential_backend"] = "none"
+		info["reusable"] = true
+		return info
+	}
+
+	_, backend, hasSaved, err := loadProviderCredential(provider.ID)
+	if err != nil {
+		info["has_saved_credential"] = false
+		info["reusable"] = false
+		info["reason"] = "failed to read saved credential"
+		info["credential_error"] = err.Error()
+		return info
+	}
+	info["has_saved_credential"] = hasSaved
+	if hasSaved {
+		info["reusable"] = true
+		info["credential_backend"] = backend
+	} else {
+		info["reusable"] = false
+		info["reason"] = "no saved credential"
+	}
+	return info
+}

--- a/daemon/internal/gateway/providers.go
+++ b/daemon/internal/gateway/providers.go
@@ -27,6 +27,16 @@ type NormalizedCommand struct {
 	RawText   string
 }
 
+// NormalizedMessage is a platform-agnostic parsed inbound message.
+// Command is nil when the message is plain chat text (non-slash command).
+type NormalizedMessage struct {
+	Provider  string
+	ChatID    string
+	RequestID string
+	RawText   string
+	Command   *NormalizedCommand
+}
+
 // ToGatewayInput converts a normalized command to the gateway input string.
 func ToGatewayInput(nc *NormalizedCommand) string {
 	parts := []string{nc.Provider, nc.ChatID, nc.RequestID, nc.Command}
@@ -36,8 +46,8 @@ func ToGatewayInput(nc *NormalizedCommand) string {
 
 // --- Telegram ---
 
-// ParseTelegramUpdate parses a Telegram update payload into a normalized command.
-func ParseTelegramUpdate(payload map[string]interface{}) *NormalizedCommand {
+// ParseTelegramMessage parses a Telegram update payload into a normalized message.
+func ParseTelegramMessage(payload map[string]interface{}) *NormalizedMessage {
 	var message map[string]interface{}
 	for _, field := range []string{"message", "edited_message", "channel_post", "edited_channel_post"} {
 		if m, ok := asMap(payload[field]); ok {
@@ -56,20 +66,33 @@ func ParseTelegramUpdate(payload map[string]interface{}) *NormalizedCommand {
 		return nil
 	}
 
-	parsed := parseCommandText(rawText)
-	if parsed == nil {
-		return nil
-	}
-
 	requestID := buildRequestID("tg", toID(payload["update_id"]), toID(message["message_id"]))
-	return &NormalizedCommand{
+	out := &NormalizedMessage{
 		Provider:  "telegram",
 		ChatID:    chatID,
 		RequestID: requestID,
-		Command:   parsed.command,
-		Args:      parsed.args,
 		RawText:   rawText,
 	}
+	if parsed := parseCommandText(rawText); parsed != nil {
+		out.Command = &NormalizedCommand{
+			Provider:  out.Provider,
+			ChatID:    out.ChatID,
+			RequestID: out.RequestID,
+			Command:   parsed.command,
+			Args:      parsed.args,
+			RawText:   rawText,
+		}
+	}
+	return out
+}
+
+// ParseTelegramUpdate parses a Telegram update payload into a normalized command.
+func ParseTelegramUpdate(payload map[string]interface{}) *NormalizedCommand {
+	msg := ParseTelegramMessage(payload)
+	if msg == nil {
+		return nil
+	}
+	return msg.Command
 }
 
 // VerifyTelegramSecret does a constant-time comparison of the provided secret.
@@ -120,6 +143,22 @@ func RenderTelegramResponse(resp GatewayResponse) map[string]interface{} {
 	return result
 }
 
+// RenderTelegramWebhookResponse wraps a gateway response as a Telegram Bot API
+// webhook response payload (sendMessage method call).
+func RenderTelegramWebhookResponse(resp GatewayResponse, chatID string) map[string]interface{} {
+	base := RenderTelegramResponse(resp)
+	text, _ := base["text"].(string)
+	out := map[string]interface{}{
+		"method":  "sendMessage",
+		"chat_id": chatID,
+		"text":    text,
+	}
+	if v, ok := base["disable_web_page_preview"]; ok {
+		out["disable_web_page_preview"] = v
+	}
+	return out
+}
+
 // --- Discord ---
 
 // VerifyDiscordSignature verifies the Ed25519 signature on a Discord webhook request.
@@ -159,8 +198,8 @@ func VerifyDiscordSignature(r *http.Request, body []byte, publicKeyHex string, m
 	return ed25519.Verify(ed25519.PublicKey(pubKeyBytes), message, sig)
 }
 
-// ParseDiscordPayload parses a Discord webhook payload into a normalized command.
-func ParseDiscordPayload(payload map[string]interface{}) *NormalizedCommand {
+// ParseDiscordMessage parses a Discord payload into a normalized message.
+func ParseDiscordMessage(payload map[string]interface{}) *NormalizedMessage {
 	// Slash-command interaction (type=2)
 	if t := toFloat(payload["type"]); t == 2 {
 		data, _ := asMap(payload["data"])
@@ -174,13 +213,20 @@ func ParseDiscordPayload(payload map[string]interface{}) *NormalizedCommand {
 			return nil
 		}
 		requestID := buildRequestID("dc", toID(payload["id"]))
-		return &NormalizedCommand{
+		cmd := &NormalizedCommand{
 			Provider:  "discord",
 			ChatID:    chatID,
 			RequestID: requestID,
 			Command:   normalizeCommandName("/" + cmdName),
 			Args:      options,
 			RawText:   "/" + cmdName + " " + strings.Join(options, " "),
+		}
+		return &NormalizedMessage{
+			Provider:  cmd.Provider,
+			ChatID:    cmd.ChatID,
+			RequestID: cmd.RequestID,
+			RawText:   cmd.RawText,
+			Command:   cmd,
 		}
 	}
 
@@ -190,23 +236,37 @@ func ParseDiscordPayload(payload map[string]interface{}) *NormalizedCommand {
 	if content == "" || chatID == "" {
 		return nil
 	}
-	parsed := parseCommandText(content)
-	if parsed == nil {
-		return nil
-	}
 	var interactionID string
 	if interaction, ok := asMap(payload["interaction"]); ok {
 		interactionID = toID(interaction["id"])
 	}
 	requestID := buildRequestID("dc", toID(payload["id"]), interactionID)
-	return &NormalizedCommand{
+	out := &NormalizedMessage{
 		Provider:  "discord",
 		ChatID:    chatID,
 		RequestID: requestID,
-		Command:   parsed.command,
-		Args:      parsed.args,
 		RawText:   content,
 	}
+	if parsed := parseCommandText(content); parsed != nil {
+		out.Command = &NormalizedCommand{
+			Provider:  out.Provider,
+			ChatID:    out.ChatID,
+			RequestID: out.RequestID,
+			Command:   parsed.command,
+			Args:      parsed.args,
+			RawText:   content,
+		}
+	}
+	return out
+}
+
+// ParseDiscordPayload parses a Discord webhook payload into a normalized command.
+func ParseDiscordPayload(payload map[string]interface{}) *NormalizedCommand {
+	msg := ParseDiscordMessage(payload)
+	if msg == nil {
+		return nil
+	}
+	return msg.Command
 }
 
 // RenderDiscordResponse renders a GatewayResponse for Discord.
@@ -262,8 +322,8 @@ func ExtractFeishuChallenge(payload map[string]interface{}) (string, bool) {
 	return challenge, true
 }
 
-// ParseFeishuEvent parses a Feishu event payload into a normalized command.
-func ParseFeishuEvent(payload map[string]interface{}) *NormalizedCommand {
+// ParseFeishuMessage parses a Feishu event payload into a normalized message.
+func ParseFeishuMessage(payload map[string]interface{}) *NormalizedMessage {
 	t, _ := payload["type"].(string)
 	if t == "url_verification" {
 		return nil
@@ -286,24 +346,37 @@ func ParseFeishuEvent(payload map[string]interface{}) *NormalizedCommand {
 		return nil
 	}
 
-	parsed := parseCommandText(rawText)
-	if parsed == nil {
-		return nil
-	}
-
 	requestID := buildRequestID("fs",
 		toID(header["event_id"]),
 		toID(message["message_id"]),
 		toID(payload["uuid"]),
 	)
-	return &NormalizedCommand{
+	out := &NormalizedMessage{
 		Provider:  "feishu",
 		ChatID:    chatID,
 		RequestID: requestID,
-		Command:   parsed.command,
-		Args:      parsed.args,
 		RawText:   rawText,
 	}
+	if parsed := parseCommandText(rawText); parsed != nil {
+		out.Command = &NormalizedCommand{
+			Provider:  out.Provider,
+			ChatID:    out.ChatID,
+			RequestID: out.RequestID,
+			Command:   parsed.command,
+			Args:      parsed.args,
+			RawText:   rawText,
+		}
+	}
+	return out
+}
+
+// ParseFeishuEvent parses a Feishu event payload into a normalized command.
+func ParseFeishuEvent(payload map[string]interface{}) *NormalizedCommand {
+	msg := ParseFeishuMessage(payload)
+	if msg == nil {
+		return nil
+	}
+	return msg.Command
 }
 
 // RenderFeishuResponse renders a GatewayResponse for Feishu.

--- a/daemon/internal/gateway/providers_test.go
+++ b/daemon/internal/gateway/providers_test.go
@@ -152,6 +152,26 @@ func TestParseTelegramUpdate_NonCommand(t *testing.T) {
 	}
 }
 
+func TestParseTelegramMessage_NonCommand(t *testing.T) {
+	payload := map[string]interface{}{
+		"update_id": float64(1),
+		"message": map[string]interface{}{
+			"text": "Hello world",
+			"chat": map[string]interface{}{"id": float64(1)},
+		},
+	}
+	msg := ParseTelegramMessage(payload)
+	if msg == nil {
+		t.Fatal("expected normalized message for non-command text")
+	}
+	if msg.Command != nil {
+		t.Fatalf("expected nil command for non-command text, got %+v", msg.Command)
+	}
+	if msg.RawText != "Hello world" {
+		t.Fatalf("raw text = %q, want %q", msg.RawText, "Hello world")
+	}
+}
+
 // --- Feishu ---
 
 func TestVerifyFeishuToken(t *testing.T) {
@@ -218,6 +238,30 @@ func TestParseFeishuEvent(t *testing.T) {
 	}
 }
 
+func TestParseFeishuMessage_NonCommand(t *testing.T) {
+	payload := map[string]interface{}{
+		"header": map[string]interface{}{
+			"event_id": "ev2",
+		},
+		"event": map[string]interface{}{
+			"message": map[string]interface{}{
+				"chat_id": "chat-456",
+				"content": `{"text":"hello"}`,
+			},
+		},
+	}
+	msg := ParseFeishuMessage(payload)
+	if msg == nil {
+		t.Fatal("expected normalized message for non-command text")
+	}
+	if msg.Command != nil {
+		t.Fatalf("expected nil command for non-command text, got %+v", msg.Command)
+	}
+	if msg.ChatID != "chat-456" {
+		t.Fatalf("chatID = %q, want %q", msg.ChatID, "chat-456")
+	}
+}
+
 // --- Discord payload parsing ---
 
 func TestParseDiscordPayload_MessageCreate(t *testing.T) {
@@ -256,6 +300,24 @@ func TestParseDiscordPayload_SlashCommand(t *testing.T) {
 	}
 }
 
+func TestParseDiscordMessage_NonCommand(t *testing.T) {
+	payload := map[string]interface{}{
+		"id":         "msg-2",
+		"channel_id": "ch-non-command",
+		"content":    "hello",
+	}
+	msg := ParseDiscordMessage(payload)
+	if msg == nil {
+		t.Fatal("expected normalized message for non-command text")
+	}
+	if msg.Command != nil {
+		t.Fatalf("expected nil command for non-command text, got %+v", msg.Command)
+	}
+	if msg.RawText != "hello" {
+		t.Fatalf("raw text = %q, want %q", msg.RawText, "hello")
+	}
+}
+
 // --- Renderers ---
 
 func TestRenderTelegramResponse_OK(t *testing.T) {
@@ -289,6 +351,26 @@ func TestRenderTelegramResponse_Error(t *testing.T) {
 	}
 	if !strings.Contains(text, "E_SESSION_REQUIRED") {
 		t.Errorf("should contain error code: %q", text)
+	}
+}
+
+func TestRenderTelegramWebhookResponse_OK(t *testing.T) {
+	resp := GatewayResponse{
+		RequestID:    "r1",
+		Result:       "ok",
+		Message:      "paired telegram:123",
+		SessionToken: "session-abc",
+	}
+	rendered := RenderTelegramWebhookResponse(resp, "123")
+	if rendered["method"] != "sendMessage" {
+		t.Fatalf("expected method sendMessage, got %v", rendered["method"])
+	}
+	if rendered["chat_id"] != "123" {
+		t.Fatalf("expected chat_id=123, got %v", rendered["chat_id"])
+	}
+	text, _ := rendered["text"].(string)
+	if !strings.Contains(text, "session-abc") {
+		t.Fatalf("expected session token in text, got %q", text)
 	}
 }
 

--- a/daemon/internal/gateway/server.go
+++ b/daemon/internal/gateway/server.go
@@ -32,6 +32,7 @@ type requestIDKey struct{}
 // buildGatewayMux constructs the gateway HTTP mux.
 func buildGatewayMux(cfg *GatewayConfig, daemon *DaemonClient, sessions *SessionStore, downloads *DownloadStore, rl *GatewayRateLimiter, onboard *OnboardStore, setup *SetupStore) http.Handler {
 	mux := http.NewServeMux()
+	telegramPairs := newTelegramPairStore()
 
 	// Health
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -88,6 +89,86 @@ func buildGatewayMux(cfg *GatewayConfig, daemon *DaemonClient, sessions *Session
 		default:
 			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
 		}
+	})
+	mux.HandleFunc("/api/v1/add", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleWebUIAdd(w, r, requestID, daemon)
+	})
+	mux.HandleFunc("/api/v1/telegram/pair/init", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleTelegramPairInit(w, r, requestID, cfg, telegramPairs)
+	})
+	mux.HandleFunc("/api/v1/telegram/pair/wait", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleTelegramPairWait(w, r, requestID, cfg, telegramPairs)
+	})
+	mux.HandleFunc("/api/v1/pairing/sessions", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handlePairingSessions(w, r, requestID, sessions)
+	})
+	mux.HandleFunc("/api/v1/agents", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleWebUIAgents(w, r, requestID, daemon)
+	})
+	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleWebUIAgent(w, r, requestID, daemon)
+	})
+	mux.HandleFunc("/api/v1/instances", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleWebUIInstances(w, r, requestID, daemon)
+	})
+	mux.HandleFunc("/api/v1/instances/", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDFromCtx(r.Context())
+		if err := checkGatewayToken(r, cfg.APIToken); err != nil {
+			writeJSON(w, http.StatusUnauthorized, gatewayErrBody(err.code, err.msg))
+			return
+		}
+		handleWebUIInstance(w, r, requestID, daemon)
 	})
 	// Legacy alias
 	mux.HandleFunc("/setup", func(w http.ResponseWriter, r *http.Request) {
@@ -195,6 +276,7 @@ func buildGatewayMux(cfg *GatewayConfig, daemon *DaemonClient, sessions *Session
 		}
 		requestID := requestIDFromCtx(r.Context())
 		byCategory := LLMProvidersByCategory()
+		carrierDefaultProvider := buildCarrierDefaultProviderInfo()
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"requestId": requestID,
 			"result":    "ok",
@@ -204,6 +286,7 @@ func buildGatewayMux(cfg *GatewayConfig, daemon *DaemonClient, sessions *Session
 				"custom":  byCategory["custom"],
 				"local":   byCategory["local"],
 			},
+			"carrier_default_provider": carrierDefaultProvider,
 		})
 	})
 
@@ -265,20 +348,19 @@ func handleTelegramWebhook(w http.ResponseWriter, r *http.Request, cfg *GatewayC
 		return
 	}
 
-	nc := ParseTelegramUpdate(payload)
-	if nc == nil {
+	msg := ParseTelegramMessage(payload)
+	if msg == nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"requestId": requestID, "result": "ok", "message": "ignored non-command telegram update"})
 		return
 	}
 
-	session := sessions.GetSession("telegram", nc.ChatID)
-	var sessionToken string
-	if session != nil {
-		sessionToken = session.SessionToken
+	var resp GatewayResponse
+	if msg.Command != nil {
+		resp = processTelegramCommand(r.Context(), msg.Command, daemon, sessions, downloads, rl, onboard)
+	} else {
+		resp = processBaseAgentChat(r.Context(), msg.Provider, msg.ChatID, msg.RequestID, msg.RawText, daemon, sessions, rl)
 	}
-	input := InjectSessionToken(ToGatewayInput(nc), sessionToken)
-	resp := SafeHandleCommand(r.Context(), input, daemon, sessions, downloads, rl, onboard)
-	writeJSON(w, http.StatusOK, RenderTelegramResponse(resp))
+	writeJSON(w, http.StatusOK, RenderTelegramWebhookResponse(resp, msg.ChatID))
 }
 
 func handleDiscordWebhook(w http.ResponseWriter, r *http.Request, cfg *GatewayConfig, daemon *DaemonClient, sessions *SessionStore, downloads *DownloadStore, rl *GatewayRateLimiter, onboard *OnboardStore) {
@@ -306,19 +388,24 @@ func handleDiscordWebhook(w http.ResponseWriter, r *http.Request, cfg *GatewayCo
 		return
 	}
 
-	nc := ParseDiscordPayload(payload)
-	if nc == nil {
+	msg := ParseDiscordMessage(payload)
+	if msg == nil {
 		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "unsupported discord payload"))
 		return
 	}
 
-	session := sessions.GetSession("discord", nc.ChatID)
-	var sessionToken string
-	if session != nil {
-		sessionToken = session.SessionToken
+	var resp GatewayResponse
+	if msg.Command != nil {
+		session := sessions.GetSession("discord", msg.ChatID)
+		var sessionToken string
+		if session != nil {
+			sessionToken = session.SessionToken
+		}
+		input := InjectSessionToken(ToGatewayInput(msg.Command), sessionToken)
+		resp = SafeHandleCommand(r.Context(), input, daemon, sessions, downloads, rl, onboard)
+	} else {
+		resp = processBaseAgentChat(r.Context(), msg.Provider, msg.ChatID, msg.RequestID, msg.RawText, daemon, sessions, rl)
 	}
-	input := InjectSessionToken(ToGatewayInput(nc), sessionToken)
-	resp := SafeHandleCommand(r.Context(), input, daemon, sessions, downloads, rl, onboard)
 	rendered := RenderDiscordResponse(resp)
 
 	_ = requestID
@@ -358,20 +445,68 @@ func handleFeishuWebhook(w http.ResponseWriter, r *http.Request, cfg *GatewayCon
 		return
 	}
 
-	nc := ParseFeishuEvent(payload)
-	if nc == nil {
+	msg := ParseFeishuMessage(payload)
+	if msg == nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"requestId": requestID, "result": "ok", "message": "ignored non-command feishu event"})
 		return
 	}
 
-	session := sessions.GetSession("feishu", nc.ChatID)
-	var sessionToken string
-	if session != nil {
-		sessionToken = session.SessionToken
+	var resp GatewayResponse
+	if msg.Command != nil {
+		session := sessions.GetSession("feishu", msg.ChatID)
+		var sessionToken string
+		if session != nil {
+			sessionToken = session.SessionToken
+		}
+		input := InjectSessionToken(ToGatewayInput(msg.Command), sessionToken)
+		resp = SafeHandleCommand(r.Context(), input, daemon, sessions, downloads, rl, onboard)
+	} else {
+		resp = processBaseAgentChat(r.Context(), msg.Provider, msg.ChatID, msg.RequestID, msg.RawText, daemon, sessions, rl)
 	}
-	input := InjectSessionToken(ToGatewayInput(nc), sessionToken)
-	resp := SafeHandleCommand(r.Context(), input, daemon, sessions, downloads, rl, onboard)
 	writeJSON(w, http.StatusOK, RenderFeishuResponse(resp))
+}
+
+func processBaseAgentChat(
+	ctx context.Context,
+	provider string,
+	chatID string,
+	requestID string,
+	message string,
+	daemon *DaemonClient,
+	sessions *SessionStore,
+	rl *GatewayRateLimiter,
+) GatewayResponse {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return GatewayResponse{RequestID: requestID, Result: "ok", Message: "empty message ignored"}
+	}
+	session := sessions.GetSession(provider, chatID)
+	if session == nil {
+		return errResp(requestID, "E_SESSION_REQUIRED", "chat is not paired; run /pair <code> first")
+	}
+	if rl != nil {
+		key := fmt.Sprintf("%s:%s", provider, chatID)
+		result := rl.Check(key)
+		if !result.Allowed {
+			return errResp(requestID, result.ErrorCode, result.Message)
+		}
+	}
+	sessions.Touch(provider, chatID)
+
+	actor := fmt.Sprintf("%s:%s", provider, chatID)
+	chatResult, err := daemon.ChatBaseAgent(ctx, provider, chatID, requestID, trimmed, actor)
+	if err != nil {
+		return daemonErrResp(requestID, err)
+	}
+	respMessage := strings.TrimSpace(chatResult.Message)
+	if respMessage == "" {
+		respMessage = "base agent completed with no output"
+	}
+	return GatewayResponse{
+		RequestID: requestID,
+		Result:    "ok",
+		Message:   respMessage,
+	}
 }
 
 func handleDownload(w http.ResponseWriter, r *http.Request, cfg *GatewayConfig, downloads *DownloadStore) {

--- a/daemon/internal/gateway/server_test.go
+++ b/daemon/internal/gateway/server_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 
 func buildTestMux(t *testing.T, daemonHandlers map[string]http.HandlerFunc) (http.Handler, *httptest.Server, *SessionStore) {
 	t.Helper()
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(t.TempDir(), "instances.json"))
 	srv := newMockDaemon(daemonHandlers)
 	dc := NewDaemonClient(srv.URL, "test-token", 5*time.Second)
 	sessions := NewSessionStore("", 0, nil)
@@ -24,6 +27,7 @@ func buildTestMux(t *testing.T, daemonHandlers map[string]http.HandlerFunc) (htt
 	cfg := &GatewayConfig{
 		APIToken:            "test-gateway-token",
 		MaxCommandBodyBytes: 64 * 1024,
+		TelegramAPIBaseURL:  srv.URL,
 	}
 	mux := buildGatewayMux(cfg, dc, sessions, downloads, rl, onboard, setup)
 	return mux, srv, sessions
@@ -639,5 +643,708 @@ func TestProvidersEndpoint_ContainsAnthropicAndOllama(t *testing.T) {
 	}
 	if !strings.Contains(body, "none") {
 		t.Errorf("expected 'none' auth mode in response body")
+	}
+}
+
+func TestProvidersEndpoint_CarrierDefaultProviderReusable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "openai-codex")
+	if _, err := saveProviderCredential("openai-codex", "codex-token-test"); err != nil {
+		t.Fatalf("saveProviderCredential: %v", err)
+	}
+
+	mux, srv, _ := buildTestMux(t, nil)
+	defer srv.Close()
+
+	req := httptest.NewRequest("GET", "/api/v1/providers", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	defaultProvider, ok := body["carrier_default_provider"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected carrier_default_provider map, got %T", body["carrier_default_provider"])
+	}
+	if configured, _ := defaultProvider["configured"].(bool); !configured {
+		t.Fatalf("expected configured=true, got %#v", defaultProvider)
+	}
+	if reusable, _ := defaultProvider["reusable"].(bool); !reusable {
+		t.Fatalf("expected reusable=true, got %#v", defaultProvider)
+	}
+	if id := fmt.Sprintf("%v", defaultProvider["id"]); id != "openai-codex" {
+		t.Fatalf("expected default id openai-codex, got %s", id)
+	}
+}
+
+func TestAgentsEndpoint_ListSuccess(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"GET /api/v1/agents": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"agents":[{"id":"openclaw","runtimeState":"running"}]}`)
+		},
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest("GET", "/api/v1/agents", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "openclaw") {
+		t.Fatalf("expected openclaw in response, got %s", w.Body.String())
+	}
+}
+
+func TestAgentsEndpoint_StatusSuccess(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"GET /api/v1/agents/openclaw/status": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"statuses":[{"id":"openclaw","runtimeState":"running"}]}`)
+		},
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest("GET", "/api/v1/agents/openclaw/status", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "openclaw") {
+		t.Fatalf("expected openclaw in response, got %s", w.Body.String())
+	}
+}
+
+func TestAgentsEndpoint_StartActionSuccess(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/openclaw/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		},
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest("POST", "/api/v1/agents/openclaw/start", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"action":"start"`) {
+		t.Fatalf("expected action=start in response, got %s", w.Body.String())
+	}
+}
+
+func TestInstancesEndpoint_ListSuccess(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"GET /api/v1/agents/picoclaw/status": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"statuses":[{"id":"picoclaw","runtimeState":"running"}]}`)
+		},
+	})
+	defer srv.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := upsertManagedInstance(managedAgentInstance{
+		ID:           "picoclaw-abc12345",
+		Type:         "picoclaw",
+		AgentID:      "picoclaw",
+		GatewayURL:   "http://127.0.0.1:8787",
+		RuntimeState: "running",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("upsertManagedInstance: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/instances", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "picoclaw-abc12345") {
+		t.Fatalf("expected instance id in response, got %s", w.Body.String())
+	}
+}
+
+func TestInstancesEndpoint_StopSuccess(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/picoclaw/stop": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		},
+	})
+	defer srv.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := upsertManagedInstance(managedAgentInstance{
+		ID:           "picoclaw-xyz98765",
+		Type:         "picoclaw",
+		AgentID:      "picoclaw",
+		GatewayURL:   "http://127.0.0.1:8787",
+		RuntimeState: "running",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("upsertManagedInstance: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/instances/picoclaw-xyz98765/stop", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 || instances[0].RuntimeState != "stopped" {
+		t.Fatalf("expected stopped instance persisted, got %+v", instances)
+	}
+}
+
+func TestInstancesEndpoint_BackfillFromDaemonInstalledAgent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"GET /api/v1/agents": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"agents":[{"id":"picoclaw","installState":"installed","runtimeState":"stopped"}]}`)
+		},
+		"GET /api/v1/agents/picoclaw/status": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"statuses":[{"id":"picoclaw","runtimeState":"stopped"}]}`)
+		},
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest("GET", "/api/v1/instances", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "picoclaw-default") {
+		t.Fatalf("expected backfilled instance id in response, got %s", w.Body.String())
+	}
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 backfilled instance, got %d", len(instances))
+	}
+	if instances[0].AgentID != "picoclaw" {
+		t.Fatalf("expected backfilled agentID=picoclaw, got %+v", instances[0])
+	}
+}
+
+func TestAgentsEndpoint_InstallCreatesManagedInstance(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/openclaw/install": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		},
+	})
+	defer srv.Close()
+
+	req := httptest.NewRequest("POST", "/api/v1/agents/openclaw/install", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 managed instance, got %d", len(instances))
+	}
+	if instances[0].AgentID != "openclaw" {
+		t.Fatalf("expected managed instance for openclaw, got %+v", instances[0])
+	}
+}
+
+// --- /api/v1/add ---
+
+func TestAddEndpoint_MethodNotAllowed(t *testing.T) {
+	mux, srv, _ := buildTestMux(t, nil)
+	defer srv.Close()
+
+	req := httptest.NewRequest("GET", "/api/v1/add", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestAddEndpoint_PicoClawSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/picoclaw/install": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"installed"}`)
+		},
+		"POST /api/v1/agents/picoclaw/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"running"}`)
+		},
+		"GET /api/v1/agents/picoclaw/logs": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"lines":["PAIR_CODE: pair-0123456789abcdef0123456789abcdef"],"truncated":false}`)
+		},
+	})
+	defer srv.Close()
+
+	body := `{
+		"agentId":"picoclaw",
+		"channel":"telegram",
+		"channelToken":"tg-token",
+		"providerId":"openai",
+		"providerToken":"sk-test-token",
+		"reuseCredential":false,
+		"envVars":{"FOO":"bar"}
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/add", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"result":"ok"`) {
+		t.Fatalf("expected ok result, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairCode":"pair-0123456789abcdef0123456789abcdef"`) {
+		t.Fatalf("expected pairCode in response, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairRequired":true`) {
+		t.Fatalf("expected pairRequired=true in response, got %s", w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse add response: %v", err)
+	}
+	instanceID, _ := resp["instanceId"].(string)
+	if strings.TrimSpace(instanceID) == "" {
+		t.Fatalf("expected non-empty instanceId, got %v", resp["instanceId"])
+	}
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 managed instance, got %d", len(instances))
+	}
+	if instances[0].ID != instanceID {
+		t.Fatalf("instance id mismatch: store=%s response=%s", instances[0].ID, instanceID)
+	}
+	if !instances[0].PairRequired {
+		t.Fatalf("expected instance pair_required=true, got %+v", instances[0])
+	}
+	if instances[0].RuntimeState != "pending_pair" {
+		t.Fatalf("expected runtime_state pending_pair, got %+v", instances[0])
+	}
+}
+
+func TestAddEndpoint_PicoClawSuccess_ReuseSavedOpenAICodexCredential(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_DISABLE_KEYCHAIN", "1")
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+
+	if _, err := saveProviderCredential("openai-codex", "codex-saved-token"); err != nil {
+		t.Fatalf("saveProviderCredential: %v", err)
+	}
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/picoclaw/install": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"installed"}`)
+		},
+		"POST /api/v1/agents/picoclaw/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"running"}`)
+		},
+		"GET /api/v1/agents/picoclaw/logs": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"lines":[],"truncated":false}`)
+		},
+	})
+	defer srv.Close()
+
+	body := `{
+		"agentId":"picoclaw",
+		"channel":"telegram",
+		"channelToken":"tg-token",
+		"channelChatId":"418258935",
+		"providerId":"openai-codex",
+		"reuseCredential":true,
+		"envVars":{"FOO":"bar"}
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/add", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"result":"ok"`) {
+		t.Fatalf("expected ok result, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairRequired":false`) {
+		t.Fatalf("expected pairRequired=false in response, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairedChatId":"418258935"`) {
+		t.Fatalf("expected pairedChatId in response, got %s", w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse add response: %v", err)
+	}
+	envKeysRaw, ok := resp["envKeys"].([]interface{})
+	if !ok {
+		t.Fatalf("expected envKeys array, got %#v", resp["envKeys"])
+	}
+	envKeySet := map[string]bool{}
+	for _, item := range envKeysRaw {
+		envKeySet[fmt.Sprintf("%v", item)] = true
+	}
+	for _, key := range []string{"FOO", "OPENAI_CODEX_TOKEN", "OPENAI_API_KEY"} {
+		if !envKeySet[key] {
+			t.Fatalf("expected envKeys to include %s, got %#v", key, envKeysRaw)
+		}
+	}
+
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 managed instance, got %d", len(instances))
+	}
+	inst := instances[0]
+	if inst.Provider != "openai-codex" {
+		t.Fatalf("expected provider=openai-codex, got %+v", inst)
+	}
+	if inst.PairedChatID != "418258935" || inst.PairRequired {
+		t.Fatalf("expected pre-paired chat state, got %+v", inst)
+	}
+	if inst.RuntimeState != "running" {
+		t.Fatalf("expected runtime_state running, got %+v", inst)
+	}
+
+	cfgPath := filepath.Join(tmp, ".picoclaw", "config.json")
+	cfgRaw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read picoclaw config: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
+		t.Fatalf("parse picoclaw config: %v", err)
+	}
+	modelList, ok := cfg["model_list"].([]interface{})
+	if !ok || len(modelList) != 1 {
+		t.Fatalf("expected one model entry, got %#v", cfg["model_list"])
+	}
+	model, ok := modelList[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected model entry object, got %#v", modelList[0])
+	}
+	if got := strings.TrimSpace(fmt.Sprintf("%v", model["auth_method"])); got != "oauth" {
+		t.Fatalf("expected auth_method oauth, got %q", got)
+	}
+	if got := strings.TrimSpace(fmt.Sprintf("%v", model["api_key"])); got != "codex-saved-token" {
+		t.Fatalf("expected model api_key from saved credential, got %q", got)
+	}
+
+	authPath := filepath.Join(tmp, ".picoclaw", "auth.json")
+	authRaw, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read picoclaw auth store: %v", err)
+	}
+	if !strings.Contains(string(authRaw), "codex-saved-token") {
+		t.Fatalf("expected auth store to contain saved codex token")
+	}
+}
+
+func TestAddEndpoint_PicoClawSuccess_WithEnvFallbackChannelAndToken(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+	t.Setenv("CARRIER_TELEGRAM_BOT_TOKEN", "tg-fallback-token")
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/picoclaw/install": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"installed"}`)
+		},
+		"POST /api/v1/agents/picoclaw/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"running"}`)
+		},
+		"GET /api/v1/agents/picoclaw/logs": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"lines":[],"truncated":false}`)
+		},
+	})
+	defer srv.Close()
+
+	body := `{
+		"agentId":"picoclaw",
+		"providerId":"openai",
+		"providerToken":"sk-test-token",
+		"reuseCredential":false,
+		"envVars":{"FOO":"bar"}
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/add", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"result":"ok"`) {
+		t.Fatalf("expected ok result, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairRequired":true`) {
+		t.Fatalf("expected pairRequired=true in response, got %s", w.Body.String())
+	}
+}
+
+func TestAddEndpoint_PicoClawSuccess_WithPrefetchedTelegramChatID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_CREDENTIAL_STORE", filepath.Join(tmp, "credentials.json"))
+	t.Setenv("CARRIER_INSTANCE_STORE", filepath.Join(tmp, "instances.json"))
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /api/v1/agents/picoclaw/install": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"installed"}`)
+		},
+		"POST /api/v1/agents/picoclaw/start": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"status":"running"}`)
+		},
+		"POST /bottg-prefetched/getUpdates": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"ok":true,"result":[]}`)
+		},
+		"GET /api/v1/agents/picoclaw/logs": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"lines":[],"truncated":false}`)
+		},
+	})
+	defer srv.Close()
+
+	body := `{
+		"agentId":"picoclaw",
+		"channel":"telegram",
+		"channelToken":"tg-prefetched",
+		"channelChatId":"418258935",
+		"providerId":"openai",
+		"providerToken":"sk-test-token",
+		"reuseCredential":false,
+		"envVars":{"FOO":"bar"}
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/add", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairRequired":false`) {
+		t.Fatalf("expected pairRequired=false in response, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"pairedChatId":"418258935"`) {
+		t.Fatalf("expected pairedChatId in response, got %s", w.Body.String())
+	}
+
+	instances, _, err := loadManagedInstances()
+	if err != nil {
+		t.Fatalf("loadManagedInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 managed instance, got %d", len(instances))
+	}
+	if instances[0].PairRequired {
+		t.Fatalf("expected pair_required=false, got %+v", instances[0])
+	}
+	if instances[0].PairedChatID != "418258935" {
+		t.Fatalf("expected paired chat id 418258935, got %+v", instances[0])
+	}
+	if instances[0].RuntimeState != "running" {
+		t.Fatalf("expected runtime_state running, got %+v", instances[0])
+	}
+
+	cfgPath := filepath.Join(tmp, ".picoclaw", "config.json")
+	cfgRaw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read picoclaw config: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
+		t.Fatalf("parse picoclaw config: %v", err)
+	}
+	channels, ok := cfg["channels"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected channels object, got %#v", cfg["channels"])
+	}
+	telegram, ok := channels["telegram"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected channels.telegram object, got %#v", channels["telegram"])
+	}
+	allowFrom, ok := telegram["allow_from"].([]interface{})
+	if !ok {
+		t.Fatalf("expected allow_from list, got %#v", telegram["allow_from"])
+	}
+	if len(allowFrom) != 1 || fmt.Sprintf("%v", allowFrom[0]) != "418258935" {
+		t.Fatalf("expected allow_from [418258935], got %#v", allowFrom)
+	}
+}
+
+func TestTelegramPairInitAndWait_Success(t *testing.T) {
+	var pairCode string
+	callCount := 0
+
+	mux, srv, _ := buildTestMux(t, map[string]http.HandlerFunc{
+		"POST /bottg-test-token/getUpdates": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			if callCount == 1 {
+				fmt.Fprint(w, `{"ok":true,"result":[{"update_id":100,"message":{"chat":{"id":999},"text":"old message"}}]}`)
+				return
+			}
+			fmt.Fprintf(w, `{"ok":true,"result":[{"update_id":101,"message":{"chat":{"id":418258935},"text":"/pair %s"}}]}`, pairCode)
+		},
+	})
+	defer srv.Close()
+
+	initReq := httptest.NewRequest("POST", "/api/v1/telegram/pair/init", strings.NewReader(`{"token":"tg-test-token"}`))
+	initReq.Header.Set("Authorization", "Bearer test-gateway-token")
+	initReq.Header.Set("Content-Type", "application/json")
+	initRec := httptest.NewRecorder()
+	mux.ServeHTTP(initRec, initReq)
+	if initRec.Code != http.StatusOK {
+		t.Fatalf("pair init expected 200, got %d: %s", initRec.Code, initRec.Body.String())
+	}
+	var initResp map[string]interface{}
+	if err := json.Unmarshal(initRec.Body.Bytes(), &initResp); err != nil {
+		t.Fatalf("parse pair init response: %v", err)
+	}
+	sessionID, _ := initResp["sessionId"].(string)
+	pairCode, _ = initResp["pairCode"].(string)
+	if strings.TrimSpace(sessionID) == "" || strings.TrimSpace(pairCode) == "" {
+		t.Fatalf("expected sessionId and pairCode, got %v", initResp)
+	}
+
+	waitReq := httptest.NewRequest("POST", "/api/v1/telegram/pair/wait", strings.NewReader(fmt.Sprintf(`{"sessionId":%q}`, sessionID)))
+	waitReq.Header.Set("Authorization", "Bearer test-gateway-token")
+	waitReq.Header.Set("Content-Type", "application/json")
+	waitRec := httptest.NewRecorder()
+	mux.ServeHTTP(waitRec, waitReq)
+	if waitRec.Code != http.StatusOK {
+		t.Fatalf("pair wait expected 200, got %d: %s", waitRec.Code, waitRec.Body.String())
+	}
+	var waitResp map[string]interface{}
+	if err := json.Unmarshal(waitRec.Body.Bytes(), &waitResp); err != nil {
+		t.Fatalf("parse pair wait response: %v", err)
+	}
+	if paired, _ := waitResp["paired"].(bool); !paired {
+		t.Fatalf("expected paired=true, got %v", waitResp)
+	}
+	if chatID := fmt.Sprintf("%v", waitResp["chatId"]); chatID != "418258935" {
+		t.Fatalf("expected chat id 418258935, got %s", chatID)
+	}
+}
+
+func TestPairingSessionsEndpoint_ReturnsLatestFirst(t *testing.T) {
+	mux, srv, sessions := buildTestMux(t, nil)
+	defer srv.Close()
+
+	sessions.CreateSession("telegram", "1001")
+	time.Sleep(2 * time.Millisecond)
+	sessions.CreateSession("telegram", "1002")
+	sessions.CreateSession("discord", "2001")
+
+	req := httptest.NewRequest("GET", "/api/v1/pairing/sessions?provider=telegram", nil)
+	req.Header.Set("Authorization", "Bearer test-gateway-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Sessions []struct {
+			Provider string `json:"provider"`
+			ChatID   string `json:"chatId"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(resp.Sessions) != 2 {
+		t.Fatalf("expected 2 telegram sessions, got %#v", resp.Sessions)
+	}
+	if resp.Sessions[0].ChatID != "1002" {
+		t.Fatalf("expected latest chat id first (1002), got %#v", resp.Sessions)
+	}
+	if resp.Sessions[0].Provider != "telegram" || resp.Sessions[1].Provider != "telegram" {
+		t.Fatalf("expected provider telegram for all sessions, got %#v", resp.Sessions)
 	}
 }

--- a/daemon/internal/gateway/server_webhook_test.go
+++ b/daemon/internal/gateway/server_webhook_test.go
@@ -171,7 +171,7 @@ func TestTelegramWebhook_NonCommand(t *testing.T) {
 	}
 	mux := buildGatewayMux(cfg, dc, sessions, downloads, rl, onboard, setup)
 
-	// Non-command message should be ignored
+	// Non-command message should route to base-agent chat and require pairing first
 	body := `{"update_id":1,"message":{"chat":{"id":123},"text":"hello"}}`
 	req := httptest.NewRequest("POST", "/webhook/telegram", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -185,8 +185,9 @@ func TestTelegramWebhook_NonCommand(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if msg, ok := resp["message"].(string); ok && !strings.Contains(msg, "ignored") {
-		t.Errorf("expected ignored message, got %q", msg)
+	text, _ := resp["text"].(string)
+	if !strings.Contains(text, "E_SESSION_REQUIRED") {
+		t.Errorf("expected E_SESSION_REQUIRED in text, got %q", text)
 	}
 }
 

--- a/daemon/internal/gateway/session.go
+++ b/daemon/internal/gateway/session.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -101,6 +103,49 @@ func (s *SessionStore) GetSession(provider, chatID string) *SessionRecord {
 	}
 	copy := *rec
 	return &copy
+}
+
+// ListSessions returns a copy of current sessions filtered by provider (if non-empty),
+// sorted by LastSeenAt (desc) then CreatedAt (desc).
+func (s *SessionStore) ListSessions(provider string) []*SessionRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	filter := strings.ToLower(strings.TrimSpace(provider))
+	records := make([]*SessionRecord, 0, len(s.sessions))
+	for _, rec := range s.sessions {
+		if rec == nil {
+			continue
+		}
+		if filter != "" && strings.ToLower(strings.TrimSpace(rec.Provider)) != filter {
+			continue
+		}
+		cp := *rec
+		records = append(records, &cp)
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		ti := parseSessionTime(records[i].LastSeenAt)
+		tj := parseSessionTime(records[j].LastSeenAt)
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		ci := parseSessionTime(records[i].CreatedAt)
+		cj := parseSessionTime(records[j].CreatedAt)
+		if !ci.Equal(cj) {
+			return ci.After(cj)
+		}
+		return sessionKey(records[i].Provider, records[i].ChatID) < sessionKey(records[j].Provider, records[j].ChatID)
+	})
+	return records
+}
+
+func parseSessionTime(raw string) time.Time {
+	ts, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
 }
 
 // Touch updates the LastSeenAt timestamp.

--- a/daemon/internal/gateway/telegram_pairing.go
+++ b/daemon/internal/gateway/telegram_pairing.go
@@ -1,0 +1,287 @@
+package gateway
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	telegramPairSessionTTL   = 5 * time.Minute
+	telegramPairWaitTimeout  = 60 * time.Second
+	telegramPairPollTimeoutS = 20
+)
+
+type telegramPairSession struct {
+	ID           string
+	PairCode     string
+	Token        string
+	NextOffset   int64
+	PairedChatID string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}
+
+type telegramPairStore struct {
+	mu       sync.Mutex
+	sessions map[string]*telegramPairSession
+}
+
+func newTelegramPairStore() *telegramPairStore {
+	return &telegramPairStore{
+		sessions: map[string]*telegramPairSession{},
+	}
+}
+
+func (s *telegramPairStore) create(token string, nextOffset int64) (*telegramPairSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneExpiredLocked(time.Now().UTC())
+
+	sessionID, err := randomHex(12)
+	if err != nil {
+		return nil, err
+	}
+	codeSuffix, err := randomHex(8)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	session := &telegramPairSession{
+		ID:         "tgpair-" + sessionID,
+		PairCode:   "tg-" + codeSuffix,
+		Token:      strings.TrimSpace(token),
+		NextOffset: nextOffset,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(telegramPairSessionTTL),
+	}
+	s.sessions[session.ID] = session
+	copy := *session
+	return &copy, nil
+}
+
+func (s *telegramPairStore) get(sessionID string) (*telegramPairSession, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	s.pruneExpiredLocked(now)
+	session, ok := s.sessions[strings.TrimSpace(sessionID)]
+	if !ok {
+		return nil, false
+	}
+	copy := *session
+	return &copy, true
+}
+
+func (s *telegramPairStore) save(session *telegramPairSession) {
+	if s == nil || session == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[session.ID] = &telegramPairSession{
+		ID:           session.ID,
+		PairCode:     session.PairCode,
+		Token:        session.Token,
+		NextOffset:   session.NextOffset,
+		PairedChatID: session.PairedChatID,
+		CreatedAt:    session.CreatedAt,
+		ExpiresAt:    session.ExpiresAt,
+	}
+}
+
+func (s *telegramPairStore) pruneExpiredLocked(now time.Time) {
+	for id, sess := range s.sessions {
+		if now.After(sess.ExpiresAt) {
+			delete(s.sessions, id)
+		}
+	}
+}
+
+func randomHex(numBytes int) (string, error) {
+	if numBytes <= 0 {
+		return "", fmt.Errorf("numBytes must be positive")
+	}
+	raw := make([]byte, numBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+type telegramPairInitRequest struct {
+	Token string `json:"token"`
+}
+
+func handleTelegramPairInit(w http.ResponseWriter, r *http.Request, requestID string, cfg *GatewayConfig, store *telegramPairStore) {
+	if store == nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", "telegram pairing store is not initialized"))
+		return
+	}
+	var req telegramPairInitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "request body must be valid JSON"))
+		return
+	}
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "telegram token is required"))
+		return
+	}
+
+	api := newTelegramBotAPI(token, cfg.TelegramAPIBaseURL, nil)
+	ctx, cancel := context.WithTimeout(r.Context(), 12*time.Second)
+	defer cancel()
+	updates, err := api.GetUpdates(ctx, 0, 1)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_TELEGRAM_AUTH", fmt.Sprintf("telegram token validation failed: %v", err)))
+		return
+	}
+	nextOffset := int64(0)
+	for _, update := range updates {
+		if id := telegramUpdateID(update); id >= nextOffset {
+			nextOffset = id + 1
+		}
+	}
+
+	session, err := store.create(token, nextOffset)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"requestId": requestID,
+		"result":    "ok",
+		"sessionId": session.ID,
+		"pairCode":  session.PairCode,
+		"command":   "/pair " + session.PairCode,
+		"expiresAt": session.ExpiresAt.Format(time.RFC3339Nano),
+	})
+}
+
+type telegramPairWaitRequest struct {
+	SessionID string `json:"sessionId"`
+}
+
+func handleTelegramPairWait(w http.ResponseWriter, r *http.Request, requestID string, cfg *GatewayConfig, store *telegramPairStore) {
+	if store == nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", "telegram pairing store is not initialized"))
+		return
+	}
+	var req telegramPairWaitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "request body must be valid JSON"))
+		return
+	}
+	sessionID := strings.TrimSpace(req.SessionID)
+	if sessionID == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "sessionId is required"))
+		return
+	}
+	session, ok := store.get(sessionID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, gatewayErrBody("E_PAIR_SESSION_NOT_FOUND", "telegram pair session not found or expired"))
+		return
+	}
+	if strings.TrimSpace(session.PairedChatID) != "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requestId": requestID,
+			"result":    "ok",
+			"paired":    true,
+			"chatId":    session.PairedChatID,
+			"pairCode":  session.PairCode,
+		})
+		return
+	}
+
+	api := newTelegramBotAPI(session.Token, cfg.TelegramAPIBaseURL, nil)
+	offset := session.NextOffset
+	deadline := time.Now().UTC().Add(telegramPairWaitTimeout)
+
+	for {
+		if time.Now().UTC().After(deadline) {
+			session.NextOffset = offset
+			store.save(session)
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"requestId": requestID,
+				"result":    "ok",
+				"paired":    false,
+				"pairCode":  session.PairCode,
+				"message":   "pairing not detected yet; try again after sending the pair command",
+			})
+			return
+		}
+
+		remaining := time.Until(deadline)
+		pollSeconds := telegramPairPollTimeoutS
+		if remaining < time.Duration(pollSeconds)*time.Second {
+			pollSeconds = int(remaining.Seconds())
+			if pollSeconds < 1 {
+				pollSeconds = 1
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(pollSeconds+8)*time.Second)
+		updates, err := api.GetUpdates(ctx, offset, pollSeconds)
+		cancel()
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_TELEGRAM_API", fmt.Sprintf("telegram getUpdates failed: %v", err)))
+			return
+		}
+
+		foundChatID := ""
+		for _, update := range updates {
+			if id := telegramUpdateID(update); id >= offset {
+				offset = id + 1
+			}
+			msg := ParseTelegramMessage(update)
+			if msg == nil {
+				continue
+			}
+			if telegramPairCommandMatched(msg.RawText, session.PairCode) {
+				foundChatID = strings.TrimSpace(msg.ChatID)
+				if foundChatID != "" {
+					break
+				}
+			}
+		}
+		if foundChatID != "" {
+			session.NextOffset = offset
+			session.PairedChatID = foundChatID
+			store.save(session)
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"requestId": requestID,
+				"result":    "ok",
+				"paired":    true,
+				"chatId":    foundChatID,
+				"pairCode":  session.PairCode,
+			})
+			return
+		}
+		session.NextOffset = offset
+		store.save(session)
+	}
+}
+
+func telegramPairCommandMatched(rawText, pairCode string) bool {
+	parsed := parseCommandText(rawText)
+	if parsed == nil {
+		return false
+	}
+	switch parsed.command {
+	case "/pair", "/start":
+	default:
+		return false
+	}
+	if len(parsed.args) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(parsed.args[0]), strings.TrimSpace(pairCode))
+}

--- a/daemon/internal/gateway/telegram_pairing_test.go
+++ b/daemon/internal/gateway/telegram_pairing_test.go
@@ -1,0 +1,26 @@
+package gateway
+
+import "testing"
+
+func TestTelegramPairCommandMatched(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		code string
+		want bool
+	}{
+		{name: "pair exact", raw: "/pair tg-abc123", code: "tg-abc123", want: true},
+		{name: "pair mention suffix", raw: "/pair@mybot tg-abc123", code: "tg-abc123", want: true},
+		{name: "start accepted", raw: "/start tg-abc123", code: "tg-abc123", want: true},
+		{name: "wrong code", raw: "/pair tg-zzz", code: "tg-abc123", want: false},
+		{name: "no command", raw: "hello", code: "tg-abc123", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := telegramPairCommandMatched(tc.raw, tc.code)
+			if got != tc.want {
+				t.Fatalf("telegramPairCommandMatched(%q,%q)=%v want %v", tc.raw, tc.code, got, tc.want)
+			}
+		})
+	}
+}

--- a/daemon/internal/gateway/telegram_transport.go
+++ b/daemon/internal/gateway/telegram_transport.go
@@ -1,0 +1,409 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	telegramTransportAuto    = "auto"
+	telegramTransportWebhook = "webhook"
+	telegramTransportPolling = "polling"
+)
+
+type telegramAPI interface {
+	SetWebhook(ctx context.Context, webhookURL, webhookSecret string) error
+	GetWebhookInfo(ctx context.Context) (telegramWebhookInfo, error)
+	DeleteWebhook(ctx context.Context) error
+	GetUpdates(ctx context.Context, offset int64, timeoutSec int) ([]map[string]interface{}, error)
+	SendMessage(ctx context.Context, chatID, text string, disableWebPagePreview bool) error
+}
+
+type telegramWebhookInfo struct {
+	URL string `json:"url"`
+}
+
+type telegramBotAPI struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newTelegramBotAPI(token, baseURL string, client *http.Client) *telegramBotAPI {
+	normalizedBase := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalizedBase == "" {
+		normalizedBase = "https://api.telegram.org"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 45 * time.Second}
+	}
+	return &telegramBotAPI{
+		baseURL: normalizedBase,
+		token:   strings.TrimSpace(token),
+		client:  client,
+	}
+}
+
+func (a *telegramBotAPI) SetWebhook(ctx context.Context, webhookURL, webhookSecret string) error {
+	payload := map[string]interface{}{
+		"url": webhookURL,
+	}
+	if strings.TrimSpace(webhookSecret) != "" {
+		payload["secret_token"] = strings.TrimSpace(webhookSecret)
+	}
+	return a.call(ctx, "setWebhook", payload, nil)
+}
+
+func (a *telegramBotAPI) GetWebhookInfo(ctx context.Context) (telegramWebhookInfo, error) {
+	var info telegramWebhookInfo
+	if err := a.call(ctx, "getWebhookInfo", map[string]interface{}{}, &info); err != nil {
+		return telegramWebhookInfo{}, err
+	}
+	return info, nil
+}
+
+func (a *telegramBotAPI) DeleteWebhook(ctx context.Context) error {
+	payload := map[string]interface{}{
+		"drop_pending_updates": false,
+	}
+	return a.call(ctx, "deleteWebhook", payload, nil)
+}
+
+func (a *telegramBotAPI) GetUpdates(ctx context.Context, offset int64, timeoutSec int) ([]map[string]interface{}, error) {
+	if timeoutSec <= 0 {
+		timeoutSec = 30
+	}
+	payload := map[string]interface{}{
+		"offset":          offset,
+		"timeout":         timeoutSec,
+		"allowed_updates": []string{"message", "edited_message", "channel_post", "edited_channel_post"},
+	}
+	var updates []map[string]interface{}
+	if err := a.call(ctx, "getUpdates", payload, &updates); err != nil {
+		return nil, err
+	}
+	return updates, nil
+}
+
+func (a *telegramBotAPI) SendMessage(ctx context.Context, chatID, text string, disableWebPagePreview bool) error {
+	payload := map[string]interface{}{
+		"chat_id": chatID,
+		"text":    text,
+	}
+	if disableWebPagePreview {
+		payload["disable_web_page_preview"] = true
+	}
+	return a.call(ctx, "sendMessage", payload, nil)
+}
+
+type telegramAPIEnvelope struct {
+	OK          bool            `json:"ok"`
+	Description string          `json:"description"`
+	Result      json.RawMessage `json:"result"`
+}
+
+func (a *telegramBotAPI) call(ctx context.Context, method string, payload interface{}, out interface{}) error {
+	if strings.TrimSpace(a.token) == "" {
+		return errors.New("telegram bot token is empty")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", method, err)
+	}
+
+	urlStr := fmt.Sprintf("%s/bot%s/%s", a.baseURL, a.token, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("telegram %s request failed: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", method, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("telegram %s HTTP %d: %s", method, resp.StatusCode, strings.TrimSpace(string(respBytes)))
+	}
+
+	var envelope telegramAPIEnvelope
+	if err := json.Unmarshal(respBytes, &envelope); err != nil {
+		return fmt.Errorf("decode %s response: %w", method, err)
+	}
+	if !envelope.OK {
+		if envelope.Description == "" {
+			envelope.Description = "unknown telegram API error"
+		}
+		return fmt.Errorf("telegram %s failed: %s", method, envelope.Description)
+	}
+	if out != nil && len(envelope.Result) > 0 && string(envelope.Result) != "null" {
+		if err := json.Unmarshal(envelope.Result, out); err != nil {
+			return fmt.Errorf("decode %s result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+func startTelegramTransport(
+	ctx context.Context,
+	cfg *GatewayConfig,
+	daemon *DaemonClient,
+	sessions *SessionStore,
+	downloads *DownloadStore,
+	rl *GatewayRateLimiter,
+	onboard *OnboardStore,
+) error {
+	mode := strings.ToLower(strings.TrimSpace(cfg.TelegramTransportMode))
+	if mode == "" {
+		mode = telegramTransportAuto
+	}
+
+	token := strings.TrimSpace(cfg.TelegramBotToken)
+	if token == "" {
+		if mode == telegramTransportAuto {
+			log.Printf("[gateway/telegram] transport disabled: missing CARRIER_TELEGRAM_BOT_TOKEN")
+			return nil
+		}
+		return fmt.Errorf("telegram transport mode %q requires CARRIER_TELEGRAM_BOT_TOKEN", mode)
+	}
+
+	api := newTelegramBotAPI(token, cfg.TelegramAPIBaseURL, nil)
+	selectedMode, reason, err := resolveTelegramTransportMode(ctx, cfg, api)
+	if err != nil {
+		return err
+	}
+
+	switch selectedMode {
+	case telegramTransportWebhook:
+		log.Printf("[gateway/telegram] transport=webhook url=%s", strings.TrimSpace(cfg.TelegramWebhookURL))
+		return nil
+	case telegramTransportPolling:
+		if strings.TrimSpace(reason) != "" {
+			log.Printf("[gateway/telegram] transport=polling (fallback reason: %s)", reason)
+		} else {
+			log.Printf("[gateway/telegram] transport=polling")
+		}
+		go runTelegramPollingLoop(ctx, cfg, api, daemon, sessions, downloads, rl, onboard)
+		return nil
+	default:
+		return fmt.Errorf("unknown telegram transport mode resolved: %s", selectedMode)
+	}
+}
+
+func resolveTelegramTransportMode(ctx context.Context, cfg *GatewayConfig, api telegramAPI) (mode string, reason string, err error) {
+	requestedMode := strings.ToLower(strings.TrimSpace(cfg.TelegramTransportMode))
+	if requestedMode == "" {
+		requestedMode = telegramTransportAuto
+	}
+
+	switch requestedMode {
+	case telegramTransportAuto:
+		webhookURL, webhookErr := normalizeTelegramWebhookURL(cfg.TelegramWebhookURL)
+		if webhookErr == nil {
+			if setErr := api.SetWebhook(ctx, webhookURL, cfg.TelegramWebhookSecret); setErr == nil {
+				info, infoErr := api.GetWebhookInfo(ctx)
+				if infoErr == nil && strings.TrimSpace(info.URL) == webhookURL {
+					return telegramTransportWebhook, "", nil
+				}
+				if infoErr != nil {
+					reason = fmt.Sprintf("webhook verification failed: %v", infoErr)
+				} else {
+					reason = fmt.Sprintf("webhook verification failed: expected %q, got %q", webhookURL, strings.TrimSpace(info.URL))
+				}
+			} else {
+				reason = fmt.Sprintf("setWebhook failed: %v", setErr)
+			}
+		} else {
+			reason = webhookErr.Error()
+		}
+		if delErr := api.DeleteWebhook(ctx); delErr != nil {
+			if reason == "" {
+				reason = fmt.Sprintf("deleteWebhook failed: %v", delErr)
+			} else {
+				reason = reason + "; deleteWebhook failed: " + delErr.Error()
+			}
+		}
+		return telegramTransportPolling, reason, nil
+
+	case telegramTransportWebhook:
+		webhookURL, webhookErr := normalizeTelegramWebhookURL(cfg.TelegramWebhookURL)
+		if webhookErr != nil {
+			return "", "", fmt.Errorf("telegram webhook mode requires a valid public HTTPS CARRIER_TELEGRAM_WEBHOOK_URL: %w", webhookErr)
+		}
+		if err := api.SetWebhook(ctx, webhookURL, cfg.TelegramWebhookSecret); err != nil {
+			return "", "", fmt.Errorf("telegram webhook setup failed: %w", err)
+		}
+		info, err := api.GetWebhookInfo(ctx)
+		if err != nil {
+			return "", "", fmt.Errorf("telegram webhook verification failed: %w", err)
+		}
+		if strings.TrimSpace(info.URL) != webhookURL {
+			return "", "", fmt.Errorf("telegram webhook verification failed: expected %q, got %q", webhookURL, strings.TrimSpace(info.URL))
+		}
+		return telegramTransportWebhook, "", nil
+
+	case telegramTransportPolling:
+		if err := api.DeleteWebhook(ctx); err != nil {
+			log.Printf("[gateway/telegram] warning: deleteWebhook before polling failed: %v", err)
+		}
+		return telegramTransportPolling, "", nil
+
+	default:
+		return "", "", fmt.Errorf("invalid CARRIER_TELEGRAM_TRANSPORT_MODE %q (expected auto|webhook|polling)", requestedMode)
+	}
+}
+
+func runTelegramPollingLoop(
+	ctx context.Context,
+	cfg *GatewayConfig,
+	api telegramAPI,
+	daemon *DaemonClient,
+	sessions *SessionStore,
+	downloads *DownloadStore,
+	rl *GatewayRateLimiter,
+	onboard *OnboardStore,
+) {
+	pollTimeout := cfg.TelegramPollingTimeout
+	if pollTimeout <= 0 {
+		pollTimeout = 30
+	}
+
+	var offset int64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		updates, err := api.GetUpdates(ctx, offset, pollTimeout)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("[gateway/telegram] polling error: %v", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+
+		for _, update := range updates {
+			if updateID := telegramUpdateID(update); updateID >= offset {
+				offset = updateID + 1
+			}
+
+			msg := ParseTelegramMessage(update)
+			if msg == nil {
+				continue
+			}
+
+			var resp GatewayResponse
+			if msg.Command != nil {
+				resp = processTelegramCommand(ctx, msg.Command, daemon, sessions, downloads, rl, onboard)
+			} else {
+				resp = processBaseAgentChat(ctx, msg.Provider, msg.ChatID, msg.RequestID, msg.RawText, daemon, sessions, rl)
+			}
+			rendered := RenderTelegramResponse(resp)
+			text, _ := rendered["text"].(string)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			disableWebPagePreview, _ := rendered["disable_web_page_preview"].(bool)
+			if err := api.SendMessage(ctx, msg.ChatID, text, disableWebPagePreview); err != nil {
+				log.Printf("[gateway/telegram] sendMessage failed (chat=%s request=%s): %v", msg.ChatID, msg.RequestID, err)
+			}
+		}
+	}
+}
+
+func processTelegramCommand(
+	ctx context.Context,
+	nc *NormalizedCommand,
+	daemon *DaemonClient,
+	sessions *SessionStore,
+	downloads *DownloadStore,
+	rl *GatewayRateLimiter,
+	onboard *OnboardStore,
+) GatewayResponse {
+	session := sessions.GetSession("telegram", nc.ChatID)
+	var sessionToken string
+	if session != nil {
+		sessionToken = session.SessionToken
+	}
+	input := InjectSessionToken(ToGatewayInput(nc), sessionToken)
+	return SafeHandleCommand(ctx, input, daemon, sessions, downloads, rl, onboard)
+}
+
+func telegramUpdateID(update map[string]interface{}) int64 {
+	raw := toID(update["update_id"])
+	if raw == "" {
+		return 0
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+func normalizeTelegramWebhookURL(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", errors.New("missing CARRIER_TELEGRAM_WEBHOOK_URL")
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid webhook URL: %w", err)
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return "", errors.New("webhook URL must use https")
+	}
+	if strings.TrimSpace(u.Hostname()) == "" {
+		return "", errors.New("webhook URL host is empty")
+	}
+	if !isPublicWebhookHost(u.Hostname()) {
+		return "", errors.New("webhook URL host must be public and reachable by Telegram")
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = "/webhook/telegram"
+	}
+	return u.String(), nil
+}
+
+func isPublicWebhookHost(host string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(host))
+	if trimmed == "" {
+		return false
+	}
+	if trimmed == "localhost" || strings.HasSuffix(trimmed, ".local") {
+		return false
+	}
+	if ip := net.ParseIP(trimmed); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() ||
+			ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return false
+		}
+	}
+	return true
+}

--- a/daemon/internal/gateway/telegram_transport_test.go
+++ b/daemon/internal/gateway/telegram_transport_test.go
@@ -1,0 +1,149 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeTelegramAPI struct {
+	setWebhookCalls int
+	getInfoCalls    int
+	deleteCalls     int
+
+	setWebhookErr error
+	getInfoErr    error
+	deleteErr     error
+
+	webhookInfo telegramWebhookInfo
+}
+
+func (f *fakeTelegramAPI) SetWebhook(_ context.Context, _ string, _ string) error {
+	f.setWebhookCalls++
+	return f.setWebhookErr
+}
+
+func (f *fakeTelegramAPI) GetWebhookInfo(_ context.Context) (telegramWebhookInfo, error) {
+	f.getInfoCalls++
+	if f.getInfoErr != nil {
+		return telegramWebhookInfo{}, f.getInfoErr
+	}
+	return f.webhookInfo, nil
+}
+
+func (f *fakeTelegramAPI) DeleteWebhook(_ context.Context) error {
+	f.deleteCalls++
+	return f.deleteErr
+}
+
+func (f *fakeTelegramAPI) GetUpdates(_ context.Context, _ int64, _ int) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (f *fakeTelegramAPI) SendMessage(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
+func TestNormalizeTelegramWebhookURL(t *testing.T) {
+	t.Run("normalizes path", func(t *testing.T) {
+		got, err := normalizeTelegramWebhookURL("https://example.com")
+		if err != nil {
+			t.Fatalf("normalizeTelegramWebhookURL error: %v", err)
+		}
+		if got != "https://example.com/webhook/telegram" {
+			t.Fatalf("normalized URL = %q, want %q", got, "https://example.com/webhook/telegram")
+		}
+	})
+
+	t.Run("rejects non-https", func(t *testing.T) {
+		if _, err := normalizeTelegramWebhookURL("http://example.com/webhook/telegram"); err == nil {
+			t.Fatal("expected error for non-https URL")
+		}
+	})
+
+	t.Run("rejects localhost", func(t *testing.T) {
+		if _, err := normalizeTelegramWebhookURL("https://127.0.0.1/webhook/telegram"); err == nil {
+			t.Fatal("expected error for localhost URL")
+		}
+	})
+}
+
+func TestResolveTelegramTransportMode_AutoWebhookSuccess(t *testing.T) {
+	fake := &fakeTelegramAPI{
+		webhookInfo: telegramWebhookInfo{
+			URL: "https://public.example.com/webhook/telegram",
+		},
+	}
+	cfg := &GatewayConfig{
+		TelegramTransportMode: telegramTransportAuto,
+		TelegramWebhookURL:    "https://public.example.com/webhook/telegram",
+	}
+
+	mode, reason, err := resolveTelegramTransportMode(context.Background(), cfg, fake)
+	if err != nil {
+		t.Fatalf("resolveTelegramTransportMode error: %v", err)
+	}
+	if mode != telegramTransportWebhook {
+		t.Fatalf("mode = %q, want %q", mode, telegramTransportWebhook)
+	}
+	if reason != "" {
+		t.Fatalf("reason = %q, want empty", reason)
+	}
+	if fake.setWebhookCalls != 1 {
+		t.Fatalf("setWebhookCalls = %d, want 1", fake.setWebhookCalls)
+	}
+	if fake.getInfoCalls != 1 {
+		t.Fatalf("getInfoCalls = %d, want 1", fake.getInfoCalls)
+	}
+	if fake.deleteCalls != 0 {
+		t.Fatalf("deleteCalls = %d, want 0", fake.deleteCalls)
+	}
+}
+
+func TestResolveTelegramTransportMode_AutoFallbackPolling(t *testing.T) {
+	fake := &fakeTelegramAPI{}
+	cfg := &GatewayConfig{
+		TelegramTransportMode: telegramTransportAuto,
+		TelegramWebhookURL:    "https://127.0.0.1/webhook/telegram",
+	}
+
+	mode, reason, err := resolveTelegramTransportMode(context.Background(), cfg, fake)
+	if err != nil {
+		t.Fatalf("resolveTelegramTransportMode error: %v", err)
+	}
+	if mode != telegramTransportPolling {
+		t.Fatalf("mode = %q, want %q", mode, telegramTransportPolling)
+	}
+	if !strings.Contains(reason, "public") {
+		t.Fatalf("reason = %q, want contains %q", reason, "public")
+	}
+	if fake.setWebhookCalls != 0 {
+		t.Fatalf("setWebhookCalls = %d, want 0", fake.setWebhookCalls)
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", fake.deleteCalls)
+	}
+}
+
+func TestResolveTelegramTransportMode_WebhookInvalidURL(t *testing.T) {
+	fake := &fakeTelegramAPI{}
+	cfg := &GatewayConfig{
+		TelegramTransportMode: telegramTransportWebhook,
+		TelegramWebhookURL:    "http://example.com/webhook/telegram",
+	}
+
+	_, _, err := resolveTelegramTransportMode(context.Background(), cfg, fake)
+	if err == nil {
+		t.Fatal("expected error for invalid webhook URL in strict webhook mode")
+	}
+}
+
+func TestStartTelegramTransport_RequiresTokenForExplicitMode(t *testing.T) {
+	cfg := &GatewayConfig{
+		TelegramTransportMode: telegramTransportWebhook,
+	}
+	err := startTelegramTransport(context.Background(), cfg, nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when token is missing in explicit webhook mode")
+	}
+}

--- a/daemon/internal/gateway/webui_add.go
+++ b/daemon/internal/gateway/webui_add.go
@@ -1,0 +1,283 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type webUIAddRequest struct {
+	AgentID         string            `json:"agentId"`
+	InstanceID      string            `json:"instanceId,omitempty"`
+	Channel         string            `json:"channel"`
+	ChannelToken    string            `json:"channelToken"`
+	ChannelChatID   string            `json:"channelChatId,omitempty"`
+	ProviderID      string            `json:"providerId"`
+	ProviderToken   string            `json:"providerToken"`
+	ReuseCredential bool              `json:"reuseCredential"`
+	EnvVars         map[string]string `json:"envVars"`
+}
+
+func handleWebUIAdd(w http.ResponseWriter, r *http.Request, requestID string, daemon *DaemonClient) {
+	var req webUIAddRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "request body must be valid JSON"))
+		return
+	}
+	agentID := strings.ToLower(strings.TrimSpace(req.AgentID))
+	if agentID == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "agentId is required"))
+		return
+	}
+
+	actor := "webui:add"
+	if agentID != "picoclaw" {
+		instanceID := strings.TrimSpace(req.InstanceID)
+		if instanceID == "" {
+			generatedID, genErr := generateManagedInstanceID(agentID)
+			if genErr != nil {
+				writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", genErr.Error()))
+				return
+			}
+			instanceID = generatedID
+		}
+		if err := daemon.InstallAgent(r.Context(), agentID, actor, requestID); err != nil {
+			writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_COMMAND_FAILED", err.Error()))
+			return
+		}
+		if err := daemon.StartAgent(r.Context(), agentID, actor, requestID); err != nil {
+			writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_COMMAND_FAILED", err.Error()))
+			return
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		inst := managedAgentInstance{
+			ID:           instanceID,
+			Type:         agentID,
+			AgentID:      agentID,
+			GatewayURL:   gatewayURLFromRequest(r),
+			RuntimeState: "running",
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}
+		warning := ""
+		if err := upsertManagedInstance(inst); err != nil {
+			warning = err.Error()
+		}
+		payload := map[string]interface{}{
+			"requestId":  requestID,
+			"result":     "ok",
+			"message":    fmt.Sprintf("%s installed and started", agentID),
+			"agentId":    agentID,
+			"instanceId": instanceID,
+		}
+		if warning != "" {
+			payload["warning"] = warning
+		}
+		writeJSON(w, http.StatusOK, payload)
+		return
+	}
+
+	ch, ok := parsePicoclawChannel(req.Channel)
+	if !ok && strings.TrimSpace(req.Channel) == "" {
+		if strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_BOT_TOKEN")) != "" {
+			req.Channel = "telegram"
+			ch, ok = parsePicoclawChannel(req.Channel)
+		}
+	}
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "unsupported channel for picoclaw"))
+		return
+	}
+	channelToken := strings.TrimSpace(req.ChannelToken)
+	if channelToken == "" && ch.ID == "telegram" {
+		channelToken = strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_BOT_TOKEN"))
+	}
+	if channelToken == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "channelToken is required"))
+		return
+	}
+	provider := GetLLMProvider(req.ProviderID)
+	if provider == nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_PROVIDER_NOT_FOUND", "providerId is invalid"))
+		return
+	}
+
+	envVars := sanitizeEnvVars(req.EnvVars)
+	token := strings.TrimSpace(req.ProviderToken)
+	if provider.AuthMode != AuthModeNone {
+		if token == "" || req.ReuseCredential {
+			value, _, hasSaved, err := loadProviderCredential(provider.ID)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_AUTH_INPUT", fmt.Sprintf("load saved credential failed: %v", err)))
+				return
+			}
+			if !hasSaved {
+				writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_AUTH_INPUT", fmt.Sprintf("no saved credential for provider %s", provider.ID)))
+				return
+			}
+			token = strings.TrimSpace(value)
+		}
+		if token == "" {
+			writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_AUTH_INPUT", fmt.Sprintf("provider %s requires credential", provider.ID)))
+			return
+		}
+		for k, v := range ProviderEnvVarsToSet(provider, token) {
+			envVars[k] = v
+		}
+	}
+
+	sess := &OnboardSession{
+		SelectedAgent:    "picoclaw",
+		SelectedChannel:  ch.ID,
+		ChannelToken:     channelToken,
+		SelectedProvider: provider.ID,
+		EnvVars:          envVars,
+	}
+	instanceID := strings.TrimSpace(req.InstanceID)
+	if instanceID == "" {
+		generatedID, genErr := generateManagedInstanceID("picoclaw")
+		if genErr != nil {
+			writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", genErr.Error()))
+			return
+		}
+		instanceID = generatedID
+	}
+	sess.InstanceID = instanceID
+	if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		sess.WorkspacePath = filepath.Join(home, ".picoclaw", "instances", instanceID, "workspace")
+	}
+
+	prefetchedChatID := strings.TrimSpace(req.ChannelChatID)
+	if strings.EqualFold(ch.ID, "telegram") && prefetchedChatID != "" {
+		if actorChatID("telegram:"+prefetchedChatID) == "" {
+			writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "channelChatId must be a numeric telegram chat id"))
+			return
+		}
+		actor = "telegram:" + prefetchedChatID
+	}
+
+	result, err := preparePicoclawManagedOnboard(sess, actor)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_ENV", fmt.Sprintf("prepare picoclaw config failed: %v", err)))
+		return
+	}
+	if err := applyOnboardEnvVars(sess.EnvVars); err != nil {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_ENV", fmt.Sprintf("apply env vars failed: %v", err)))
+		return
+	}
+	if err := daemon.InstallAgent(r.Context(), "picoclaw", actor, requestID); err != nil {
+		writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_COMMAND_FAILED", err.Error()))
+		return
+	}
+	if err := daemon.StartAgent(r.Context(), "picoclaw", actor, requestID); err != nil {
+		writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_COMMAND_FAILED", err.Error()))
+		return
+	}
+
+	pairCode := ""
+	pairedChatID := prefetchedChatID
+	if logs, err := daemon.GetLogs(r.Context(), "picoclaw", 120, actor, requestID); err == nil && logs != nil {
+		pairCode = extractPairCode(logs.Lines)
+		if strings.TrimSpace(pairedChatID) == "" {
+			pairedChatID = extractPairedTelegramChatID(logs.Lines)
+		}
+	}
+	pairRequired := strings.EqualFold(ch.ID, "telegram") && strings.TrimSpace(pairedChatID) == ""
+	runtimeState := "running"
+	if pairRequired {
+		runtimeState = "pending_pair"
+	}
+
+	envKeys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		envKeys = append(envKeys, k)
+	}
+	sort.Strings(envKeys)
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	inst := managedAgentInstance{
+		ID:           instanceID,
+		Type:         "picoclaw",
+		AgentID:      "picoclaw",
+		GatewayURL:   gatewayURLFromRequest(r),
+		Workspace:    result.WorkspacePath,
+		ConfigPath:   result.ConfigPath,
+		RecordPath:   result.RecordPath,
+		Channel:      ch.ID,
+		Provider:     provider.ID,
+		PairRequired: pairRequired,
+		PairCode:     pairCode,
+		PairedChatID: pairedChatID,
+		RuntimeState: runtimeState,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	warning := ""
+	if err := upsertManagedInstance(inst); err != nil {
+		warning = err.Error()
+	}
+	payload := map[string]interface{}{
+		"requestId":     requestID,
+		"result":        "ok",
+		"message":       "picoclaw configured, installed, and started",
+		"agentId":       "picoclaw",
+		"instanceId":    instanceID,
+		"pairCode":      pairCode,
+		"pairRequired":  pairRequired,
+		"pairedChatId":  pairedChatID,
+		"workspacePath": result.WorkspacePath,
+		"configPath":    result.ConfigPath,
+		"recordPath":    result.RecordPath,
+		"envKeys":       envKeys,
+	}
+	if warning != "" {
+		payload["warning"] = warning
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func sanitizeEnvVars(input map[string]string) map[string]string {
+	if len(input) == 0 {
+		return map[string]string{}
+	}
+	sanitized := make(map[string]string, len(input))
+	for k, v := range input {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		sanitized[key] = strings.TrimSpace(v)
+	}
+	return sanitized
+}
+
+func gatewayURLFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+		scheme = strings.ToLower(forwarded)
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" {
+		host = strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_HOST"))
+		if host == "" || host == "0.0.0.0" || host == "::" {
+			host = "127.0.0.1"
+		}
+		port := strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_PORT"))
+		if port == "" {
+			port = "8787"
+		}
+		host = host + ":" + port
+	}
+	return fmt.Sprintf("%s://%s", scheme, host)
+}

--- a/daemon/internal/gateway/webui_agents.go
+++ b/daemon/internal/gateway/webui_agents.go
@@ -1,0 +1,202 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func handleWebUIAgents(w http.ResponseWriter, r *http.Request, requestID string, daemon *DaemonClient) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+		return
+	}
+
+	agents, err := daemon.ListAgents(r.Context(), "webui:agents:list", requestID)
+	if err != nil {
+		writeDaemonAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, agents)
+}
+
+func handleWebUIAgent(w http.ResponseWriter, r *http.Request, requestID string, daemon *DaemonClient) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(r.URL.Path), "/api/v1/agents/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "agent path is required"))
+		return
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) < 2 {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "agent action path is required"))
+		return
+	}
+
+	agentID := strings.TrimSpace(parts[0])
+	action := strings.TrimSpace(parts[1])
+	if agentID == "" || action == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "agent id and action are required"))
+		return
+	}
+
+	switch action {
+	case "status":
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		statuses, err := daemon.GetStatus(r.Context(), agentID, "webui:agents:status", requestID)
+		if err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		if len(statuses) == 0 {
+			writeJSON(w, http.StatusNotFound, gatewayErrBody("E_AGENT_NOT_FOUND", fmt.Sprintf("agent %s not found", agentID)))
+			return
+		}
+		writeJSON(w, http.StatusOK, statuses[0])
+		return
+	case "logs":
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		tail := parsePositiveInt(r.URL.Query().Get("tail"), 200)
+		logs, err := daemon.GetLogs(r.Context(), agentID, tail, "webui:agents:logs", requestID)
+		if err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, logs)
+		return
+	case "install", "start", "stop", "uninstall":
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		var err error
+		actor := "webui:agents:" + action
+		switch action {
+		case "install":
+			err = daemon.InstallAgent(r.Context(), agentID, actor, requestID)
+		case "start":
+			err = daemon.StartAgent(r.Context(), agentID, actor, requestID)
+		case "stop":
+			err = daemon.StopAgent(r.Context(), agentID, actor, requestID)
+		case "uninstall":
+			err = daemon.UninstallAgent(r.Context(), agentID, actor, requestID)
+		}
+		if err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		if syncErr := syncManagedInstanceByAgentAction(r, agentID, action); syncErr != nil {
+			writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", syncErr.Error()))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requestId": requestID,
+			"result":    "ok",
+			"agentId":   agentID,
+			"action":    action,
+		})
+		return
+	default:
+		writeJSON(w, http.StatusNotFound, gatewayErrBody("E_USAGE", "unsupported agent action"))
+		return
+	}
+}
+
+func writeDaemonAPIError(w http.ResponseWriter, err error) {
+	if de, ok := err.(*DaemonClientError); ok {
+		status := http.StatusBadGateway
+		switch de.Code {
+		case "E_AGENT_NOT_FOUND":
+			status = http.StatusNotFound
+		case "E_USAGE":
+			status = http.StatusBadRequest
+		case "E_SESSION_REQUIRED":
+			status = http.StatusUnauthorized
+		}
+		writeJSON(w, status, gatewayErrBody(de.Code, de.Message))
+		return
+	}
+	writeJSON(w, http.StatusBadGateway, gatewayErrBody("E_COMMAND_FAILED", err.Error()))
+}
+
+func syncManagedInstanceByAgentAction(r *http.Request, agentID, action string) error {
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	idx := findManagedInstanceIndexByAgentID(instances, agentID)
+
+	switch action {
+	case "install":
+		if idx >= 0 {
+			if strings.TrimSpace(instances[idx].RuntimeState) == "" {
+				instances[idx].RuntimeState = "stopped"
+			}
+			instances[idx].UpdatedAt = now
+			return saveManagedInstances(path, instances)
+		}
+		instanceID := agentID + "-default"
+		if findManagedInstanceIndex(instances, instanceID) >= 0 {
+			generatedID, genErr := generateManagedInstanceID(agentID)
+			if genErr != nil {
+				return genErr
+			}
+			instanceID = generatedID
+		}
+		instances = append(instances, managedAgentInstance{
+			ID:           instanceID,
+			Type:         agentID,
+			AgentID:      agentID,
+			GatewayURL:   gatewayURLFromRequest(r),
+			RuntimeState: "stopped",
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+		return saveManagedInstances(path, instances)
+	case "start", "stop":
+		targetState := "stopped"
+		if action == "start" {
+			targetState = "running"
+		}
+		if idx >= 0 {
+			instances[idx].RuntimeState = targetState
+			instances[idx].UpdatedAt = now
+			return saveManagedInstances(path, instances)
+		}
+		instanceID := agentID + "-default"
+		if findManagedInstanceIndex(instances, instanceID) >= 0 {
+			generatedID, genErr := generateManagedInstanceID(agentID)
+			if genErr != nil {
+				return genErr
+			}
+			instanceID = generatedID
+		}
+		instances = append(instances, managedAgentInstance{
+			ID:           instanceID,
+			Type:         agentID,
+			AgentID:      agentID,
+			GatewayURL:   gatewayURLFromRequest(r),
+			RuntimeState: targetState,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+		return saveManagedInstances(path, instances)
+	case "uninstall":
+		if idx < 0 {
+			return nil
+		}
+		_ = cleanupManagedInstanceFiles(instances[idx])
+		instances = append(instances[:idx], instances[idx+1:]...)
+		return saveManagedInstances(path, instances)
+	default:
+		return nil
+	}
+}

--- a/daemon/internal/gateway/webui_instances.go
+++ b/daemon/internal/gateway/webui_instances.go
@@ -1,0 +1,389 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+func handleWebUIInstances(w http.ResponseWriter, r *http.Request, requestID string, daemon *DaemonClient) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+		return
+	}
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+		return
+	}
+	if len(instances) > 0 {
+		updated := mergeManagedRuntimeState(r, daemon, instances, requestID)
+		if updated {
+			_ = saveManagedInstances(path, instances)
+		}
+	}
+	instances, updated, backfillErr := backfillManagedInstancesFromDaemon(r, daemon, instances, requestID)
+	if backfillErr == nil && updated {
+		_ = saveManagedInstances(path, instances)
+	}
+	if updatePairingStateFromLogs(r, daemon, instances, requestID) {
+		_ = saveManagedInstances(path, instances)
+	}
+
+	sort.Slice(instances, func(i, j int) bool {
+		ti := parseManagedTimestamp(instances[i].UpdatedAt)
+		tj := parseManagedTimestamp(instances[j].UpdatedAt)
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return strings.ToLower(strings.TrimSpace(instances[i].ID)) < strings.ToLower(strings.TrimSpace(instances[j].ID))
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"requestId": requestID,
+		"result":    "ok",
+		"instances": instances,
+	})
+}
+
+func updatePairingStateFromLogs(r *http.Request, daemon *DaemonClient, instances []managedAgentInstance, requestID string) bool {
+	if daemon == nil || len(instances) == 0 {
+		return false
+	}
+	changedAny := false
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for i := range instances {
+		inst := &instances[i]
+		agentID := strings.TrimSpace(inst.AgentID)
+		channel := strings.TrimSpace(inst.Channel)
+		if agentID == "" {
+			agentID = strings.TrimSpace(inst.Type)
+		}
+		if !strings.EqualFold(agentID, "picoclaw") || !strings.EqualFold(channel, "telegram") {
+			continue
+		}
+		if !inst.PairRequired && strings.TrimSpace(inst.PairedChatID) != "" {
+			continue
+		}
+
+		logs, err := daemon.GetLogs(r.Context(), "picoclaw", 120, "webui:instances:pair-state", requestID)
+		if err != nil || logs == nil {
+			continue
+		}
+		changed := false
+		if pairCode := extractPairCode(logs.Lines); pairCode != "" && pairCode != strings.TrimSpace(inst.PairCode) {
+			inst.PairCode = pairCode
+			changed = true
+		}
+		if pairedChatID := extractPairedTelegramChatID(logs.Lines); pairedChatID != "" {
+			if pairedChatID != strings.TrimSpace(inst.PairedChatID) {
+				inst.PairedChatID = pairedChatID
+				changed = true
+			}
+			if inst.PairRequired {
+				inst.PairRequired = false
+				changed = true
+			}
+			if strings.EqualFold(strings.TrimSpace(inst.RuntimeState), "pending_pair") {
+				inst.RuntimeState = "running"
+				changed = true
+			}
+		} else {
+			if !inst.PairRequired {
+				inst.PairRequired = true
+				changed = true
+			}
+			if strings.EqualFold(strings.TrimSpace(inst.RuntimeState), "running") || strings.TrimSpace(inst.RuntimeState) == "" {
+				inst.RuntimeState = "pending_pair"
+				changed = true
+			}
+		}
+		if changed {
+			inst.UpdatedAt = now
+			changedAny = true
+		}
+	}
+	return changedAny
+}
+
+func backfillManagedInstancesFromDaemon(r *http.Request, daemon *DaemonClient, instances []managedAgentInstance, requestID string) ([]managedAgentInstance, bool, error) {
+	if daemon == nil {
+		return instances, false, nil
+	}
+	agents, err := daemon.ListAgents(r.Context(), "webui:instances:backfill", requestID)
+	if err != nil {
+		return instances, false, err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	changed := false
+	for _, agent := range agents {
+		agentID := strings.TrimSpace(agent.ID)
+		if agentID == "" {
+			continue
+		}
+		installState := strings.ToLower(strings.TrimSpace(agent.InstallState))
+		runtimeState := strings.TrimSpace(agent.Runtime)
+		shouldTrack := installState == "installed" || strings.EqualFold(runtimeState, "running") || strings.EqualFold(runtimeState, "healthy")
+		if !shouldTrack {
+			continue
+		}
+		idx := findManagedInstanceIndexByAgentID(instances, agentID)
+		if idx >= 0 {
+			updated := false
+			if strings.TrimSpace(instances[idx].Type) == "" {
+				instances[idx].Type = agentID
+				updated = true
+			}
+			if strings.TrimSpace(instances[idx].GatewayURL) == "" {
+				instances[idx].GatewayURL = gatewayURLFromRequest(r)
+				updated = true
+			}
+			if runtimeState != "" && strings.TrimSpace(instances[idx].RuntimeState) != runtimeState {
+				instances[idx].RuntimeState = runtimeState
+				updated = true
+			}
+			if updated {
+				instances[idx].UpdatedAt = now
+				changed = true
+			}
+			continue
+		}
+
+		instanceID := agentID + "-default"
+		if findManagedInstanceIndex(instances, instanceID) >= 0 {
+			generatedID, genErr := generateManagedInstanceID(agentID)
+			if genErr != nil {
+				return instances, changed, genErr
+			}
+			instanceID = generatedID
+		}
+		instances = append(instances, managedAgentInstance{
+			ID:           instanceID,
+			Type:         agentID,
+			AgentID:      agentID,
+			GatewayURL:   gatewayURLFromRequest(r),
+			RuntimeState: defaultRuntimeState(runtimeState, installState),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+		changed = true
+	}
+	return instances, changed, nil
+}
+
+func defaultRuntimeState(runtimeState, installState string) string {
+	rs := strings.TrimSpace(runtimeState)
+	if rs != "" {
+		return rs
+	}
+	if strings.EqualFold(strings.TrimSpace(installState), "installed") {
+		return "stopped"
+	}
+	return "unknown"
+}
+
+func handleWebUIInstance(w http.ResponseWriter, r *http.Request, requestID string, daemon *DaemonClient) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(r.URL.Path), "/api/v1/instances/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "instance path is required"))
+		return
+	}
+	parts := strings.Split(trimmed, "/")
+	instanceID := strings.TrimSpace(parts[0])
+	if instanceID == "" {
+		writeJSON(w, http.StatusBadRequest, gatewayErrBody("E_USAGE", "instance id is required"))
+		return
+	}
+
+	instances, path, err := loadManagedInstances()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+		return
+	}
+	idx := findManagedInstanceIndex(instances, instanceID)
+	if idx < 0 {
+		writeJSON(w, http.StatusNotFound, gatewayErrBody("E_INSTANCE_NOT_FOUND", fmt.Sprintf("instance %s not found", instanceID)))
+		return
+	}
+	inst := instances[idx]
+
+	if len(parts) == 1 {
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requestId": requestID,
+			"result":    "ok",
+			"instance":  inst,
+		})
+		return
+	}
+
+	action := strings.TrimSpace(parts[1])
+	switch action {
+	case "logs":
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+		tail := parsePositiveInt(r.URL.Query().Get("tail"), 200)
+		logs, err := daemon.GetLogs(r.Context(), inst.AgentID, tail, "webui:instances:logs", requestID)
+		if err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, logs)
+		return
+	case "start", "stop", "uninstall":
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+			return
+		}
+	default:
+		writeJSON(w, http.StatusNotFound, gatewayErrBody("E_USAGE", "unsupported instance action"))
+		return
+	}
+
+	actor := "webui:instances:" + action
+	warning := ""
+	switch action {
+	case "start":
+		if err := daemon.StartAgent(r.Context(), inst.AgentID, actor, requestID); err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		instances[idx].RuntimeState = "running"
+		instances[idx].UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := saveManagedInstances(path, instances); err != nil {
+			writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requestId": requestID,
+			"result":    "ok",
+			"action":    action,
+			"instance":  instances[idx],
+		})
+		return
+	case "stop":
+		if err := daemon.StopAgent(r.Context(), inst.AgentID, actor, requestID); err != nil {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		instances[idx].RuntimeState = "stopped"
+		instances[idx].UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := saveManagedInstances(path, instances); err != nil {
+			writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requestId": requestID,
+			"result":    "ok",
+			"action":    action,
+			"instance":  instances[idx],
+		})
+		return
+	case "uninstall":
+		_ = daemon.StopAgent(r.Context(), inst.AgentID, actor, requestID)
+		if err := daemon.UninstallAgent(r.Context(), inst.AgentID, actor, requestID); err != nil && !isDaemonAgentNotFound(err) {
+			writeDaemonAPIError(w, err)
+			return
+		}
+		if err := cleanupManagedInstanceFiles(inst); err != nil {
+			warning = err.Error()
+		}
+		instances = append(instances[:idx], instances[idx+1:]...)
+		if err := saveManagedInstances(path, instances); err != nil {
+			writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", err.Error()))
+			return
+		}
+
+		payload := map[string]interface{}{
+			"requestId":  requestID,
+			"result":     "ok",
+			"action":     action,
+			"instanceId": inst.ID,
+		}
+		if warning != "" {
+			payload["warning"] = warning
+		}
+		writeJSON(w, http.StatusOK, payload)
+		return
+	}
+}
+
+func isDaemonAgentNotFound(err error) bool {
+	de, ok := err.(*DaemonClientError)
+	return ok && strings.EqualFold(strings.TrimSpace(de.Code), "E_AGENT_NOT_FOUND")
+}
+
+func mergeManagedRuntimeState(r *http.Request, daemon *DaemonClient, instances []managedAgentInstance, requestID string) bool {
+	if daemon == nil || len(instances) == 0 {
+		return false
+	}
+	agentStates := map[string]string{}
+	agentIDs := make([]string, 0, len(instances))
+	seen := map[string]struct{}{}
+	for _, inst := range instances {
+		agentID := strings.TrimSpace(inst.AgentID)
+		if agentID == "" {
+			continue
+		}
+		key := strings.ToLower(agentID)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		agentIDs = append(agentIDs, agentID)
+	}
+	if len(agentIDs) == 0 {
+		return false
+	}
+	actor := "webui:instances:list"
+	for _, agentID := range agentIDs {
+		statuses, err := daemon.GetStatus(r.Context(), agentID, actor, requestID)
+		if err != nil || len(statuses) == 0 {
+			continue
+		}
+		state := strings.TrimSpace(statuses[0].Runtime)
+		if state == "" {
+			continue
+		}
+		agentStates[strings.ToLower(agentID)] = state
+	}
+	if len(agentStates) == 0 {
+		return false
+	}
+
+	changed := false
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for i := range instances {
+		key := strings.ToLower(strings.TrimSpace(instances[i].AgentID))
+		state, ok := agentStates[key]
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(instances[i].RuntimeState) != state {
+			instances[i].RuntimeState = state
+			instances[i].UpdatedAt = now
+			changed = true
+		}
+	}
+	return changed
+}
+
+func parseManagedTimestamp(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
+}

--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -32,6 +33,7 @@ import (
 	"carrier/daemon/internal/config"
 	"carrier/daemon/internal/lifecycle"
 	"carrier/daemon/internal/logging"
+	"carrier/daemon/internal/memory"
 	"carrier/daemon/internal/ratelimit"
 )
 
@@ -71,7 +73,15 @@ func Run() {
 	}
 	opts = append(opts, lifecycle.WithCrashLoopConfig(cfg.Lifecycle.CrashThreshold, window, cooldown))
 
+	memRoot, err := defaultMemoryRoot()
+	if err != nil {
+		log.Fatalf("resolve memory root: %v", err)
+	}
+	memStore := memory.NewStore(memory.WithRootDir(memRoot))
+	opts = append(opts, lifecycle.WithMemoryStore(memStore))
+
 	svc := lifecycle.NewService(baseagent.NoopTriager{}, opts...)
+	baseRuntime := baseagent.NewRuntime(newLifecycleAgentServiceAdapter(svc), memStore)
 
 	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {
 		log.Fatalf("register openclaw manifest: %v", err)
@@ -110,7 +120,7 @@ func Run() {
 	ready := &atomic.Bool{}
 	ready.Store(false)
 	pairLimiter := ratelimit.New(ratelimit.WithMax(5), ratelimit.WithWindow(1*time.Minute))
-	mux := buildHTTPMux(svc, ready, pairStore, pairLimiter)
+	mux := buildHTTPMuxWithBaseAgent(svc, baseRuntime, ready, pairStore, pairLimiter)
 	var handler http.Handler = mux
 	if cfg.Server.APIToken != "" {
 		handler = bearerAuthMiddleware(cfg.Server.APIToken, mux)
@@ -155,7 +165,22 @@ func Run() {
 	fmt.Println("agentd stopped gracefully")
 }
 
-func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.PairingCodeStore, pairLimiter *ratelimit.Limiter) *http.ServeMux {
+func buildHTTPMux(
+	svc *lifecycle.Service,
+	ready *atomic.Bool,
+	pairStore *api.PairingCodeStore,
+	pairLimiter *ratelimit.Limiter,
+) *http.ServeMux {
+	return buildHTTPMuxWithBaseAgent(svc, nil, ready, pairStore, pairLimiter)
+}
+
+func buildHTTPMuxWithBaseAgent(
+	svc *lifecycle.Service,
+	baseRuntime *baseagent.Runtime,
+	ready *atomic.Bool,
+	pairStore *api.PairingCodeStore,
+	pairLimiter *ratelimit.Limiter,
+) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -289,6 +314,31 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.Pai
 		})
 	})
 
+	register("/api/base-agent/chat", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if baseRuntime == nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "base agent runtime is unavailable")
+			return
+		}
+		var body baseagent.ChatRequest
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		if strings.TrimSpace(body.Message) == "" {
+			writeJSONError(w, http.StatusBadRequest, "message is required")
+			return
+		}
+		resp, err := baseRuntime.Chat(r.Context(), body)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+
 	mux.HandleFunc("/api/v1/agents/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/agents/status" {
 			if r.Method != http.MethodGet {
@@ -368,6 +418,77 @@ func buildHTTPMux(svc *lifecycle.Service, ready *atomic.Bool, pairStore *api.Pai
 	mux.Handle("/", webUIHandler())
 
 	return mux
+}
+
+type lifecycleAgentServiceAdapter struct {
+	svc *lifecycle.Service
+}
+
+func newLifecycleAgentServiceAdapter(svc *lifecycle.Service) *lifecycleAgentServiceAdapter {
+	return &lifecycleAgentServiceAdapter{svc: svc}
+}
+
+func (a *lifecycleAgentServiceAdapter) ListAgents() []baseagent.AgentState {
+	states := a.svc.ListAgents()
+	out := make([]baseagent.AgentState, 0, len(states))
+	for _, s := range states {
+		out = append(out, toBaseAgentState(s))
+	}
+	return out
+}
+
+func (a *lifecycleAgentServiceAdapter) Install(ctx context.Context, agentID string) error {
+	return a.svc.Install(ctx, agentID)
+}
+
+func (a *lifecycleAgentServiceAdapter) Uninstall(ctx context.Context, agentID string) error {
+	return a.svc.Uninstall(ctx, agentID)
+}
+
+func (a *lifecycleAgentServiceAdapter) Start(ctx context.Context, agentID string) error {
+	return a.svc.Start(ctx, agentID)
+}
+
+func (a *lifecycleAgentServiceAdapter) Stop(ctx context.Context, agentID string) error {
+	return a.svc.Stop(ctx, agentID)
+}
+
+func (a *lifecycleAgentServiceAdapter) Status(agentID string) (baseagent.AgentState, error) {
+	state, err := a.svc.Status(agentID)
+	if err != nil {
+		return baseagent.AgentState{}, err
+	}
+	return toBaseAgentState(state), nil
+}
+
+func (a *lifecycleAgentServiceAdapter) Logs(agentID string, tail int) ([]string, error) {
+	return a.svc.Logs(agentID, tail)
+}
+
+func (a *lifecycleAgentServiceAdapter) Upgrade(ctx context.Context, agentID string) (baseagent.UpgradeResult, error) {
+	result, err := a.svc.Upgrade(ctx, agentID)
+	if err != nil {
+		return baseagent.UpgradeResult{}, err
+	}
+	return baseagent.UpgradeResult{
+		AgentID:     result.AgentID,
+		FromVersion: result.FromVersion,
+		ToVersion:   result.ToVersion,
+	}, nil
+}
+
+func (a *lifecycleAgentServiceAdapter) Diagnose(agentID string) (string, error) {
+	return a.svc.Diagnose(agentID)
+}
+
+func toBaseAgentState(s lifecycle.AgentState) baseagent.AgentState {
+	return baseagent.AgentState{
+		ID:           s.ID,
+		Install:      string(s.Install),
+		Runtime:      string(s.Runtime),
+		Health:       string(s.Health),
+		RestartCount: s.RestartCount,
+	}
 }
 
 func extractAgentIDFromBody(w http.ResponseWriter, r *http.Request) (string, bool) {
@@ -777,4 +898,15 @@ func isLoopback(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func defaultMemoryRoot() (string, error) {
+	if raw := strings.TrimSpace(os.Getenv("CARRIER_MEMORY_ROOT")); raw != "" {
+		return raw, nil
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "carrier", "memory"), nil
 }

--- a/docs/Agent_Installation_Platform_PRD.md
+++ b/docs/Agent_Installation_Platform_PRD.md
@@ -1,6 +1,6 @@
 # Agent Installation and Distribution Platform — PRD (Phase 1 / Demo)
 
-> Product form factor: desktop Daemon (Go), no mandatory GUI, controlled through Telegram/Discord/Feishu via Gateway (TypeScript). Runtime is local-first (macOS/Linux host processes, Windows via WSL2). Memory model is Per-Agent, Shared, and Public.
+> Product form factor: desktop Daemon (Go), no mandatory GUI, controlled through Telegram/Discord/Feishu via Gateway (Go). Runtime is local-first (macOS/Linux host processes, Windows via WSL2). Memory model is Per-Agent, Shared, and Public.
 > Runtime baseline authority: `docs/phase1-runtime-adr.md`.
 
 ---
@@ -8,7 +8,7 @@
 ## 0. Document Metadata
 - Product codename: Agent Runtime Manager (Local)
 - Version: PRD v0.2
-- Owner modules: Daemon (Go), Gateway (TS), Memory Platform, Catalog
+- Owner modules: Daemon (Go), Gateway (Go), Memory Platform, Catalog
 - This PRD is the **single source of truth** for product scope/priority. If another document conflicts, PRD wins.
 - Runtime model changes must update this PRD and `docs/phase1-runtime-adr.md` in the same PR.
 
@@ -231,7 +231,7 @@ Mount policy:
 - Public read-only
 - Per-Agent read-write
 
-### 4.4 Gateway (TypeScript)
+### 4.4 Gateway (Go)
 
 #### FR-G-001 Pairing: `/pair <code>` (P0)
 Flow:
@@ -270,10 +270,10 @@ Token properties:
 Default bind:
 - `127.0.0.1`
 
-#### FR-G-004 bun detection (P1)
-- detect bun presence/version for gateway needs
-- if missing: ask user before installing in gateway private directory
-- if declined: keep core adapter path operational where possible
+#### FR-G-004 gateway runtime prerequisite checks (P1)
+- validate required gateway webhook/auth configuration before enabling provider-specific ingress
+- return actionable setup guidance when configuration is incomplete
+- keep `/command` test path operational for local validation
 
 ---
 

--- a/docs/Agent_Installation_Platform_Product_Design.md
+++ b/docs/Agent_Installation_Platform_Product_Design.md
@@ -1,6 +1,6 @@
 # Agent Installation and Distribution Platform (Daemon + Gateway + Memory Platform) — Product Design
 
-> One-line pitch: A desktop Daemon (Go) that installs, runs, repairs, and monitors local Agents, controlled through Telegram/Discord/Feishu via a Gateway (TypeScript), with a unified Memory Platform based on Per-Agent, Shared, and Public memory.
+> One-line pitch: A desktop Daemon (Go) that installs, runs, repairs, and monitors local Agents, controlled through Telegram/Discord/Feishu via a Gateway (Go), with a unified Memory Platform based on Per-Agent, Shared, and Public memory.
 
 ---
 
@@ -59,7 +59,7 @@ Running Agents on desktop environments is fragmented and failure-prone:
 | Agent | Installable and runnable agent application distributed through catalog + manifest |
 | Base Agent | Internal Daemon capability that uses LLM-assisted analysis for installation/runtime issues |
 | Daemon (Go) | Resident service handling policy, execution, state, storage, and runtime control |
-| Gateway (TS) | Telegram/Discord/Feishu adapter + session layer + read-only download endpoint |
+| Gateway (Go) | Telegram/Discord/Feishu adapter + session layer + read-only download endpoint |
 | Manifest | Single source of truth for install, run, health, and memory requirements |
 | Per-Agent Memory | Memory owned by one Agent instance |
 | Shared Memory | Memory explicitly shared by user across local Agents |
@@ -72,13 +72,13 @@ Running Agents on desktop environments is fragmented and failure-prone:
 ### 4.1 Component boundaries
 - Daemon (Go): policy + execution + health + repair + state
 - Base Agent (inside Daemon): LLM-assisted troubleshooting and fix recommendation/execution policy
-- Gateway (TypeScript): Telegram/Discord/Feishu command adapter and session layer
+- Gateway (Go): Telegram/Discord/Feishu command adapter and session layer
 - Memory Platform (local): package and lifecycle management for Per-Agent/Shared/Public memory
 
 ### 4.2 Diagram
 ```mermaid
 flowchart LR
-  TG[Telegram Bot] --> GW[Gateway (TypeScript)]
+  TG[Telegram Bot] --> GW[Gateway (Go)]
   DC[Discord Bot] --> GW
   FSK[Feishu Bot] --> GW
   GW -->|local RPC| D[Daemon (Go)]

--- a/docs/api/agent-state.md
+++ b/docs/api/agent-state.md
@@ -70,4 +70,4 @@ Migration mapping:
 ## Source Definitions
 
 - **Go (daemon):** `daemon/internal/lifecycle/types.go` — `AgentState` struct
-- **TypeScript (gateway):** `gateway/src/daemon/client.ts` — `DaemonAgentState` type
+- **Go (gateway):** `daemon/internal/gateway/daemonclient.go` — `AgentState` struct

--- a/docs/audit-event-dictionary.md
+++ b/docs/audit-event-dictionary.md
@@ -100,7 +100,7 @@ Response envelope:
 
 ## Gateway Test-Harness Audit Notes
 
-`gateway/src/daemon/client.ts` also records in-memory audit events for test flows with fields:
+Gateway tests under `daemon/internal/gateway/` also validate request metadata propagation for test flows with fields:
 
 - `requestId`, `actor`, `action`, `target`, `message`, `timestamp`
 

--- a/docs/ci/flaky-checks.md
+++ b/docs/ci/flaky-checks.md
@@ -37,4 +37,4 @@ If log shows stable Go test failure under `daemon/...`, push a test/code fix.
 gh run view <run-id> --repo Keith-CY/carrier --log-failed
 ```
 
-If log shows repeatable TypeScript error under `gateway/src/...`, push a code fix.
+If log shows repeatable Go test failure under `daemon/internal/gateway/...`, push a code fix.

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -211,7 +211,7 @@ Telegram adapter rendering should preserve response semantics while formatting f
 
 ## Failure Parity Drift Reporting
 
-Failure parity checks are implemented in `gateway/src/parity/failure_parity.ts`.
+Failure parity checks are implemented in gateway contract tests under `daemon/internal/gateway/`.
 
 - `assertFailureParity` validates that all provider responses for a failure scenario:
   - return `result: "error"`
@@ -219,4 +219,4 @@ Failure parity checks are implemented in `gateway/src/parity/failure_parity.ts`.
   - share the same `message`
 - Drift output includes provider + field-level expected/actual values for fast diagnosis.
 
-These checks are exercised by `gateway/src/cross-provider.test.ts` and `gateway/src/parity/failure_parity.test.ts`.
+These checks are exercised by `daemon/internal/gateway/providers_test.go` and `daemon/internal/gateway/server_test.go`.

--- a/docs/daemon-api-contract.md
+++ b/docs/daemon-api-contract.md
@@ -148,7 +148,7 @@ Current daemon behavior is mixed and clients must handle both patterns:
 }
 ```
 
-Gateway transport (`gateway/src/daemon/http_client.ts`) first tries structured codes and falls back to HTTP-status mapping when only string errors are returned.
+Gateway transport (`daemon/internal/gateway/daemonclient.go`) first tries structured codes and falls back to HTTP-status mapping when only string errors are returned.
 
 ## `DaemonAgentState` Field Expectations
 

--- a/docs/e2e-parity-taxonomy.md
+++ b/docs/e2e-parity-taxonomy.md
@@ -3,7 +3,8 @@
 This document defines the parity assertion categories used for Telegram/Discord/Feishu command-path E2E tests.
 
 Reference implementation/tests:
-- `gateway/src/cross-provider.test.ts`
+- `daemon/internal/gateway/providers_test.go`
+- `daemon/internal/gateway/server_test.go`
 - `docs/plans/phase1-e2e-test-matrix.md`
 
 ## Categories

--- a/docs/issue-triage/test-prefix-issues-2026-02-17.md
+++ b/docs/issue-triage/test-prefix-issues-2026-02-17.md
@@ -4,7 +4,7 @@ This document records the pass over all open issues with titles starting with `t
 
 | Issue | Status | Notes |
 | --- | --- | --- |
-| #557 | Already covered on main | `gateway/src/server.test.ts` contains consolidated HTTP method mismatch coverage. |
+| #557 | Already covered on main | `daemon/internal/gateway/server_test.go` contains consolidated HTTP method mismatch coverage. |
 | #566 | Already covered on main | Missing-signature/header validation tests are present across provider/server parser tests. |
 | #569 | Already covered on main | `daemon/internal/lifecycle/service_test.go` includes `loadPersistedState` restoration coverage. |
 | #582 | Already covered on main | Process monitoring and deadlock-regression style coverage exists in lifecycle process/state tests. |
@@ -21,9 +21,9 @@ This document records the pass over all open issues with titles starting with `t
 | #643 | Already covered on main | `daemon/cmd/agentd/main_test.go` covers HTTP mux routes and auth/error branches. |
 | #644 | Already covered on main | `daemon/internal/catalog/manifests_test.go` now covers manifest/install command helpers. |
 | #645 | Already covered on main | Lifecycle option and service API coverage exists across lifecycle test suite. |
-| #646 | Already covered on main | `gateway/src/daemon/http_client.test.ts` covers HttpDaemonClient transport branches. |
-| #647 | Already covered on main | `gateway/src/server.test.ts` has broad route/path/error coverage. |
-| #648 | Already covered on main | `gateway/src/providers/parsers.test.ts` contains extensive edge-case parser coverage. |
+| #646 | Already covered on main | `daemon/internal/gateway/daemonclient_test.go` covers daemon transport branches. |
+| #647 | Already covered on main | `daemon/internal/gateway/server_test.go` has broad route/path/error coverage. |
+| #648 | Already covered on main | `daemon/internal/gateway/providers_test.go` contains extensive edge-case parser coverage. |
 | #649 | Already covered on main | `daemon/internal/api/server_test.go` and `daemon/cmd/agentd/main_test.go` cover API handlers. |
 | #650 | Addressed in this PR | Added rate-limiter boundary and expired-window pruning tests; implemented expired session pruning. |
 | #652 | Addressed in this PR | Added idempotency tests for `startPeriodicCleanup()`/`stopPeriodicCleanup()`. |

--- a/docs/phase1-issues-closure-2026-02-17.md
+++ b/docs/phase1-issues-closure-2026-02-17.md
@@ -6,19 +6,19 @@ This document captures how the open `Phase 1` label issues are resolved in a sin
 
 | Issue | Resolution |
 | --- | --- |
-| #615 | Download HTTP/header helpers were extracted to `gateway/src/downloads/http.ts`; route logic in `gateway/src/server.ts` now focuses on orchestration; table-driven helper tests added in `gateway/src/downloads/http.test.ts`. |
+| #615 | Download HTTP/header helpers were extracted to `daemon/internal/gateway/downloads.go`; route logic in `daemon/internal/gateway/server.go` now focuses on orchestration; table-driven helper tests added in `daemon/internal/gateway/downloads_test.go`. |
 | #626 | README artifact naming updated to real release outputs: `carrier-<commit-sha>-<os>-<arch>.zip` and matching `.zip.sha256`. |
 | #613 | README pairing-code flow now matches runtime behavior: daemon prints `pair-<hex>`, TTL is 5 minutes, and API fallback (`POST /api/v1/pairing/codes`) is documented. |
 | #612 | `.github/workflows/release.yml` now documents least-privilege intent explicitly, with default read-only permissions and release-only write scope. |
-| #295 | Telegram webhook path is now wired in gateway runtime (`POST /webhook/telegram`) with webhook secret verification and command execution/response rendering coverage in `gateway/src/server.test.ts`. |
+| #295 | Telegram webhook path is now wired in gateway runtime (`POST /webhook/telegram`) with webhook secret verification and command execution/response rendering coverage in `daemon/internal/gateway/server_webhook_test.go`. |
 
 ## Already satisfied on current main baseline (validated and documented here)
 
 | Issue | Evidence |
 | --- | --- |
-| #296 | Discord webhook verification, parsing, command normalization, and response rendering are implemented in `gateway/src/server.ts`, `gateway/src/providers/parsers.ts`, and covered by `gateway/src/server.test.ts`. |
-| #297 | Feishu event token verification, parsing, command normalization, and response rendering are implemented in `gateway/src/server.ts`, `gateway/src/providers/parsers.ts`, and covered by `gateway/src/server.test.ts`. |
-| #298 | Cross-provider parity checks exist in `gateway/src/cross-provider.test.ts` and `gateway/src/parity/failure_parity.test.ts`, and are enforced by CI matrix job in `.github/workflows/ci.yml` (`Provider Parity (...)`). |
+| #296 | Discord webhook verification, parsing, command normalization, and response rendering are implemented in `daemon/internal/gateway/server.go`, `daemon/internal/gateway/providers.go`, and covered by `daemon/internal/gateway/server_webhook_test.go`. |
+| #297 | Feishu event token verification, parsing, command normalization, and response rendering are implemented in `daemon/internal/gateway/server.go`, `daemon/internal/gateway/providers.go`, and covered by `daemon/internal/gateway/server_webhook_test.go`. |
+| #298 | Cross-provider parity checks exist in `daemon/internal/gateway/providers_test.go` and `daemon/internal/gateway/server_test.go`, and are enforced by CI matrix job in `.github/workflows/ci.yml` (`Provider Parity (...)`). |
 | #294 | Round-1 three-provider closure objective is represented by provider webhooks/parsers/renderers + parity suite + runbook coverage (`docs/provider-setup-runbook.md`, `docs/command-contract.md`). |
 | #598 | The old pinned-checksum fallback path no longer exists in catalog code. OpenClaw install now uses official installer URL in `daemon/internal/catalog/manifests.go`, with guard tests in `daemon/internal/catalog/manifests_test.go`. |
 | #600 | The previous empty `CHECKSUM` embedded-script failure mode is removed by the same installer architecture change; install command contract is validated in `daemon/internal/catalog/manifests_test.go`. |
@@ -26,4 +26,3 @@ This document captures how the open `Phase 1` label issues are resolved in a sin
 ## Still open
 
 None — all Phase 1 labeled issues are resolved as of this batch.
-

--- a/docs/plans/phase1-exit-gate-review.md
+++ b/docs/plans/phase1-exit-gate-review.md
@@ -39,12 +39,12 @@ Primary blockers:
 | Evidence ID | Description | Pointer |
 |---|---|---|
 | E01 | Daemon lifecycle endpoint/API coverage | `daemon/internal/api/server_test.go` |
-| E02 | Gateway lifecycle E2E flows | `gateway/src/e2e.test.ts` |
+| E02 | Gateway lifecycle E2E flows | `scripts/e2e-integration.sh`, `daemon/internal/gateway/server_webhook_test.go` |
 | E03 | Crash-loop and exponential backoff tests | `daemon/internal/lifecycle/crash_loop_test.go`, `daemon/internal/lifecycle/backoff_test.go` |
 | E04 | Memory lifecycle and policy tests | `daemon/internal/memory/store_test.go`, `daemon/internal/memory/policy_test.go` |
 | E05 | Failure evidence and triage state persistence | `daemon/internal/lifecycle/evidence.go`, `daemon/internal/lifecycle/service.go`, `daemon/internal/lifecycle/service_test.go` |
-| E06 | Diagnose artifact + remote diagnosis consent APIs | `daemon/internal/api/server.go`, `daemon/internal/lifecycle/service.go`, `gateway/src/index.ts` |
-| E07 | Cross-provider parity tests | `gateway/src/cross-provider.test.ts`, `gateway/src/parity/failure_parity.test.ts` |
+| E06 | Diagnose artifact + remote diagnosis consent APIs | `daemon/internal/api/server.go`, `daemon/internal/lifecycle/service.go`, `daemon/internal/gateway/server.go` |
+| E07 | Cross-provider parity tests | `daemon/internal/gateway/providers_test.go`, `daemon/internal/gateway/server_test.go` |
 | E08 | WSL2 support matrix | `docs/WSL2_SUPPORT_MATRIX.md` |
 | E09 | Daemon coverage snapshot (`75.7%`) | `docs/coverage-report.md` |
 | E10 | Open P0 issues snapshot (`5`) | `#294`, `#295`, `#296`, `#297`, `#298` |
@@ -53,8 +53,8 @@ Primary blockers:
 | E13 | Latest CI run on `main` successful | [CI run](https://github.com/Keith-CY/carrier/actions/runs/22097465211) |
 | E14 | Upgrade rollback metadata contract | `daemon/internal/lifecycle/upgrade.go`, `daemon/internal/api/server_test.go` |
 | E15 | Audit schema + query/filter API | `daemon/internal/lifecycle/types.go`, `daemon/internal/api/server.go`, `docs/audit-event-dictionary.md` |
-| E16 | Diagnose-consent command + handoff flow | `gateway/src/e2e.test.ts`, `daemon/internal/api/server.go` |
-| E17 | Redaction baseline + tests | `docs/security/redaction-baseline.md`, `daemon/internal/redact/redact_test.go`, `gateway/src/redact.test.ts` |
+| E16 | Diagnose-consent command + handoff flow | `scripts/e2e-integration.sh`, `daemon/internal/api/server.go` |
+| E17 | Redaction baseline + tests | `docs/security/redaction-baseline.md`, `daemon/internal/redact/redact_test.go`, `daemon/internal/gateway/redact_test.go` |
 
 ## Blockers To Clear For Go
 

--- a/docs/plans/phase1-hardening-evidence-checklist.md
+++ b/docs/plans/phase1-hardening-evidence-checklist.md
@@ -8,8 +8,8 @@
 
 | Scope | Related micro task(s) | Evidence |
 |---|---|---|
-| Secret redaction rules (allowlist/denylist/pattern coverage) | #831, #836 | `docs/security/redaction-baseline.md`, `daemon/internal/redact/redact.go`, `daemon/internal/redact/redact_test.go`, `gateway/src/redact.ts`, `gateway/src/redact.test.ts`, `gateway/src/artifact_root.test.ts` |
-| Artifact/download token lifecycle (issue, single-use consume, cleanup) | #818 | `gateway/src/downloads/token_store.ts`, `gateway/src/downloads/token_store.test.ts`, `gateway/src/server.ts` |
+| Secret redaction rules (allowlist/denylist/pattern coverage) | #831, #836 | `docs/security/redaction-baseline.md`, `daemon/internal/redact/redact.go`, `daemon/internal/redact/redact_test.go`, `daemon/internal/gateway/redact.go`, `daemon/internal/gateway/redact_test.go`, `daemon/internal/gateway/downloads_test.go` |
+| Artifact/download token lifecycle (issue, single-use consume, cleanup) | #818 | `daemon/internal/gateway/downloads.go`, `daemon/internal/gateway/downloads_test.go`, `daemon/internal/gateway/server.go` |
 | Release signing and verification chain | #17, #853 | `docs/release-signing.md`, `docs/ARTIFACT_SIGNING.md`, `scripts/sign-artifacts.sh`, `scripts/verify-signature.sh`, `scripts/test-sign-artifacts.sh`, `scripts/test-verify-signature.sh` |
 
 ## Audit
@@ -28,9 +28,9 @@
 | User-facing recovery status and aligned errors | #843 | `daemon/internal/api/server.go` (`DaemonAgentState` fields), `daemon/internal/api/errors.go`, `docs/api/agent-state.md`, `docs/command-contract.md` |
 | Evidence collector interface (logs/exit/probes/trace) | #844 | `daemon/internal/lifecycle/evidence.go`, `daemon/internal/lifecycle/evidence_test.go` |
 | Structured triage/audit summary per failure cycle | #849 | `daemon/internal/lifecycle/service.go` (`HandleFailure` + audit recording), `daemon/internal/lifecycle/service_test.go`, `docs/audit-event-dictionary.md` |
-| Remote diagnosis package + explicit consent handshake | #848 | `daemon/internal/lifecycle/service.go` (`Diagnose`, `CreateRemoteDiagnosisHandoff`), `daemon/internal/api/server.go` (`/api/v1/diagnosis/handoffs`), `gateway/src/index.ts` (`/diagnose-consent`) |
+| Remote diagnosis package + explicit consent handshake | #848 | `daemon/internal/lifecycle/service.go` (`Diagnose`, `CreateRemoteDiagnosisHandoff`), `daemon/internal/api/server.go` (`/api/v1/diagnosis/handoffs`), `daemon/internal/gateway/commands.go` (`/diagnose-consent`) |
 
 ## Verification snapshot
 
 - `go test ./...` (from `daemon`) passed on 2026-02-17.
-- `bun test` (from `gateway`) currently has pre-existing download path/security expectation failures unrelated to this checklist update.
+- `go test ./internal/gateway/...` (from `daemon`) passed on 2026-02-17.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require carrier/daemon v0.0.0
 
 require (
 	carrier/webui v0.0.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/e2e-integration.sh
+++ b/scripts/e2e-integration.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# End-to-end integration test: boots daemon + gateway and exercises full command flow.
+# End-to-end integration test: boots carrier daemon + gateway and exercises full command flow.
 # Usage: bash scripts/e2e-integration.sh
-# Requires: Go toolchain, Bun
+# Requires: Go toolchain, curl, python3
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
@@ -23,22 +23,21 @@ find_port() {
 
 DAEMON_PORT=$(find_port)
 GATEWAY_PORT=$(find_port)
-PAIR_CODE="e2e-test-$(date +%s)"
 TMPDIR="$(mktemp -d)"
 
 echo "[e2e] Daemon port: $DAEMON_PORT, Gateway port: $GATEWAY_PORT"
 echo "[e2e] Temp dir: $TMPDIR"
 
-# Build and start daemon
-echo "[e2e] Building daemon..."
-cd "$repo_root/daemon"
-go build -o "$TMPDIR/agentd" ./cmd/agentd
+# Build carrier binary
+echo "[e2e] Building carrier binary..."
+cd "$repo_root"
+go build -o "$TMPDIR/carrier" ./cmd/carrier
 
 echo "[e2e] Starting daemon on port $DAEMON_PORT..."
 CARRIER_SERVER_PORT="$DAEMON_PORT" \
 CARRIER_SERVER_HOST="127.0.0.1" \
 CARRIER_DEV_MODE=1 \
-  "$TMPDIR/agentd" &
+  "$TMPDIR/carrier" daemon &
 DAEMON_PID=$!
 cleanup_pids+=("$DAEMON_PID")
 
@@ -56,18 +55,13 @@ for i in $(seq 1 30); do
   sleep 0.5
 done
 
-# Install gateway deps and start gateway
+# Start gateway
 echo "[e2e] Starting gateway on port $GATEWAY_PORT..."
-cd "$repo_root/gateway"
-if [[ ! -d node_modules ]]; then
-  bun install --frozen-lockfile --no-progress
-fi
-
 CARRIER_GATEWAY_PORT="$GATEWAY_PORT" \
 CARRIER_GATEWAY_HOST="127.0.0.1" \
-CARRIER_DAEMON_URL="http://127.0.0.1:$DAEMON_PORT" \
+CARRIER_DAEMON_BASE_URL="http://127.0.0.1:$DAEMON_PORT" \
 SESSION_DATA_DIR="$TMPDIR" \
-  bun run src/server.ts &
+  "$TMPDIR/carrier" gateway &
 GATEWAY_PID=$!
 cleanup_pids+=("$GATEWAY_PID")
 
@@ -88,6 +82,13 @@ done
 # Helper to send commands
 send_cmd() {
   local input="$1"
+  local session_token="${2:-}"
+  if [[ -n "$session_token" ]]; then
+    curl -sf -X POST "http://127.0.0.1:$GATEWAY_PORT/command" \
+      -H "Content-Type: application/json" \
+      -d "{\"input\": \"$input\", \"sessionToken\": \"$session_token\"}"
+    return
+  fi
   curl -sf -X POST "http://127.0.0.1:$GATEWAY_PORT/command" \
     -H "Content-Type: application/json" \
     -d "{\"input\": \"$input\"}"
@@ -121,11 +122,14 @@ assert_error() {
 echo ""
 echo "[e2e] === Running E2E Tests ==="
 
-# Register a pairing code with the daemon
-echo "[e2e] Registering pairing code with daemon..."
-curl -sf -X POST "http://127.0.0.1:$DAEMON_PORT/api/v1/pairing/codes" \
-  -H "Content-Type: application/json" \
-  -d "{\"code\": \"$PAIR_CODE\", \"ttlSeconds\": 300}" >/dev/null
+# Read current pairing code from daemon
+echo "[e2e] Fetching pairing code from daemon..."
+PAIR_CODE=$(curl -sf "http://127.0.0.1:$DAEMON_PORT/api/v1/pairing/codes" | python3 -c 'import json,sys; data=json.load(sys.stdin); codes=data.get("codes") or []; print((codes[0] or {}).get("code","") if codes else "")')
+if [[ -z "$PAIR_CODE" ]]; then
+  echo "[e2e] ERROR: No pairing code available from daemon" >&2
+  exit 1
+fi
+echo "[e2e] Pairing code: ${PAIR_CODE:0:20}..."
 
 # Test: /pair
 RESP=$(send_cmd "telegram test-chat req-1 /pair $PAIR_CODE")
@@ -139,27 +143,27 @@ fi
 echo "[e2e] Session token: ${SESSION_TOKEN:0:20}..."
 
 # Test: /agents
-RESP=$(send_cmd "telegram test-chat req-2 $SESSION_TOKEN /agents")
+RESP=$(send_cmd "telegram test-chat req-2 /agents" "$SESSION_TOKEN")
 assert_ok "/agents" "$RESP"
 
 # Test: /status
-RESP=$(send_cmd "telegram test-chat req-3 $SESSION_TOKEN /status")
+RESP=$(send_cmd "telegram test-chat req-3 /status" "$SESSION_TOKEN")
 assert_ok "/status" "$RESP"
 
 # Test: /install (openclaw agent)
-RESP=$(send_cmd "telegram test-chat req-4 $SESSION_TOKEN /install openclaw")
+RESP=$(send_cmd "telegram test-chat req-4 /install openclaw" "$SESSION_TOKEN")
 assert_ok "/install openclaw" "$RESP"
 
 # Test: /status after install
-RESP=$(send_cmd "telegram test-chat req-5 $SESSION_TOKEN /status openclaw")
+RESP=$(send_cmd "telegram test-chat req-5 /status openclaw" "$SESSION_TOKEN")
 assert_ok "/status after install" "$RESP"
 
 # Test: /logs
-RESP=$(send_cmd "telegram test-chat req-6 $SESSION_TOKEN /logs")
-assert_ok "/logs" "$RESP"
+RESP=$(send_cmd "telegram test-chat req-6 /logs openclaw" "$SESSION_TOKEN")
+assert_ok "/logs openclaw" "$RESP"
 
 # Test: unknown command (should error)
-RESP=$(send_cmd "telegram test-chat req-7 $SESSION_TOKEN /unknown")
+RESP=$(send_cmd "telegram test-chat req-7 /unknown" "$SESSION_TOKEN")
 assert_error "unknown command" "$RESP"
 
 echo ""

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -9,12 +9,10 @@ printf '\n=== Daemon tests ===\n'
   go test ./...
 )
 
-printf '\n=== Gateway checks and tests ===\n'
+printf '\n=== Gateway tests ===\n'
 (
-  cd "$repo_root/gateway"
-  bun install --frozen-lockfile --no-progress
-  bun run check
-  bun test
+  cd "$repo_root/daemon"
+  go test ./internal/gateway/...
 )
 
 printf '\n=== Start script systemd regression test ===\n'

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -6,29 +6,4 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 echo "Running end-to-end test suite..."
-
-if command -v carrier >/dev/null 2>&1; then
-  carrier test e2e --report test-results/
-  exit 0
-fi
-
-echo "carrier CLI is not available in PATH."
-echo "Falling back to gateway e2e smoke tests (bun test src/providers/parsers.e2e.test.ts)."
-
-if ! command -v bun >/dev/null 2>&1; then
-  echo "Error: bun is required to run fallback end-to-end tests."
-  exit 1
-fi
-
-if [[ ! -d "$repo_root/gateway/node_modules" ]]; then
-  echo "gateway/node_modules not found; installing gateway dependencies..."
-  (
-    cd "$repo_root/gateway"
-    bun install --frozen-lockfile --no-progress
-  )
-fi
-
-(
-  cd "$repo_root/gateway"
-  bun test src/providers/parsers.e2e.test.ts
-)
+"$repo_root/scripts/e2e-integration.sh"

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -48,7 +48,7 @@ CI is a hard gate for review decisions:
 
 Optional local verification when needed:
 - **Daemon (Go)**: `cd daemon && go test ./...`
-- **Gateway (TypeScript)**: `cd gateway && bun run check`
+- **Gateway (Go)**: `cd daemon && go test ./internal/gateway/...`
 
 ## Automation Trigger
 This skill is intended to be executed by repository automation (for example cron-driven sweeps). Keep cadence details in the automation configuration/prompt as the source of truth.

--- a/webui/e2e/tests/add-picoclaw.spec.ts
+++ b/webui/e2e/tests/add-picoclaw.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from '@playwright/test';
+import { TEST_TOKEN } from './helpers';
+
+test.describe('Add PicoClaw (WebUI)', () => {
+  test('walks add flow end-to-end and posts /api/v1/add with reused credential', async ({ page }) => {
+    let addRequestBody: any = null;
+    let addRequestAuthHeader = '';
+
+    await page.route('**/healthz', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      }),
+    );
+
+    await page.route('**/api/v1/pairing/sessions?provider=telegram', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          sessions: [
+            {
+              provider: 'telegram',
+              chatId: '418258935',
+              createdAt: '2026-02-21T00:00:00Z',
+              updatedAt: '2026-02-21T00:00:00Z',
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.route('**/api/v1/providers', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          by_category: {
+            builtin: [
+              {
+                id: 'openai',
+                name: 'OpenAI',
+                auth_mode: 'api_key',
+                env_var: 'OPENAI_API_KEY',
+                example_model: 'openai/gpt-5.2',
+              },
+            ],
+            custom: [
+              {
+                id: 'openai-codex',
+                name: 'OpenAI Codex (OAuth)',
+                auth_mode: 'oauth_device_code',
+                env_var: 'OPENAI_CODEX_TOKEN',
+                example_model: 'openai-codex/gpt-5.3-codex',
+              },
+            ],
+            local: [],
+          },
+          carrier_default_provider: {
+            configured: true,
+            available: true,
+            reusable: true,
+            id: 'openai-codex',
+            credential_backend: 'local-file',
+          },
+        }),
+      }),
+    );
+
+    await page.route('**/api/v1/add', async (route) => {
+      addRequestBody = route.request().postDataJSON();
+      addRequestAuthHeader = (await route.request().headerValue('authorization')) || '';
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          requestId: 'req-add-1',
+          result: 'ok',
+          message: 'picoclaw configured, installed, and started',
+          agentId: 'picoclaw',
+          instanceId: 'picoclaw-abcdef01',
+          pairRequired: false,
+          pairedChatId: '418258935',
+          workspacePath: '/tmp/picoclaw/workspace',
+          configPath: '/tmp/picoclaw/config.json',
+          recordPath: '/tmp/picoclaw/record.json',
+        }),
+      });
+    });
+
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('carrier_token', token);
+    }, TEST_TOKEN);
+
+    await page.goto('/#/add/picoclaw');
+
+    await expect(page.locator('#view-setup')).toBeVisible();
+    await expect(page.locator('#setup-title')).toContainText('Step 1');
+    await expect(page.locator('#setup-title')).toContainText('PicoClaw');
+    await expect(page.locator('#setup-pair-msg')).toContainText('Auto-selected Carrier paired Telegram user');
+
+    await page.fill('#provider-token', 'tg-test-token');
+    await page.click('#setup-btn');
+
+    await expect(page).toHaveURL(/#\/provider$/);
+    await expect(page.locator('#view-provider')).toBeVisible();
+    await expect(page.locator('#provider-agent-name')).toContainText('Adding: picoclaw');
+    await expect(page.locator('#provider-default-summary')).toContainText('Using Carrier default');
+    await expect(page.locator('#provider-next')).toBeEnabled();
+
+    await page.click('#provider-next');
+    await expect(page).toHaveURL(/#\/install$/);
+    await expect(page.locator('#view-install')).toBeVisible();
+    await expect(page.locator('#install-summary')).toContainText('Agent: picoclaw');
+    await expect(page.locator('#install-summary')).toContainText('Channel: telegram');
+    await expect(page.locator('#install-summary')).toContainText('Provider: OpenAI Codex (OAuth)');
+
+    await page.click('#install-confirm');
+
+    await expect(page).toHaveURL(/#\/complete$/);
+    await expect(page.locator('#view-complete')).toBeVisible();
+    await expect(page.locator('#complete-title')).toContainText('Setup Complete');
+    await expect(page.locator('#complete-detail')).toContainText('Instance: picoclaw-abcdef01');
+    await expect(page.locator('#complete-detail')).toContainText('Paired chat: 418258935');
+
+    expect(addRequestAuthHeader).toBe(`Bearer ${TEST_TOKEN}`);
+    expect(addRequestBody).toBeTruthy();
+    expect(addRequestBody.agentId).toBe('picoclaw');
+    expect(addRequestBody.channel).toBe('telegram');
+    expect(addRequestBody.channelToken).toBe('tg-test-token');
+    expect(addRequestBody.channelChatId).toBe('418258935');
+    expect(addRequestBody.providerId).toBe('openai-codex');
+    expect(addRequestBody.providerToken).toBe('');
+    expect(addRequestBody.reuseCredential).toBe(true);
+  });
+});

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -10,6 +10,17 @@
   let selectedAgent = '';
   let selectedProvider = null; // { id, name, auth_mode, env_var, example_model }
   let providerApiKey = '';
+  let addTargetAgent = '';
+  let addChannel = '';
+  let addChannelToken = '';
+  let addChannelChatId = '';
+  let addCarrierPairedUser = null;
+  let addCarrierPairedUserCount = 0;
+  let addWebhookSecret = '';
+  let addPairSessionId = '';
+  let addPairCode = '';
+  let addPairPollRunID = 0;
+  let lastAddResult = null;
   let logSource = null; // EventSource for SSE logs
 
   // --- Helpers ---
@@ -31,8 +42,25 @@
         clearToken();
         throw new Error('Unauthorized');
       }
-      const data = await r.json();
-      if (!r.ok) throw new Error(data.error || 'Request failed (' + r.status + ')');
+      const raw = await r.text();
+      let data = {};
+      if (raw) {
+        try {
+          data = JSON.parse(raw);
+        } catch (e) {
+          if (!r.ok) throw new Error(raw || 'Request failed (' + r.status + ')');
+          return raw;
+        }
+      }
+      if (!r.ok) {
+        const errMsg =
+          (data && data.message) ||
+          (data && data.errorCode) ||
+          (data && data.error && (data.error.message || data.error.code)) ||
+          data.error ||
+          ('Request failed (' + r.status + ')');
+        throw new Error(errMsg);
+      }
       return data;
     });
   }
@@ -52,6 +80,69 @@
     p.className = 'msg-' + (type || 'info');
     p.textContent = text;
     el.appendChild(p);
+  }
+
+  function isAddMode() {
+    return !!addTargetAgent;
+  }
+
+  function resetAddMode() {
+    addTargetAgent = '';
+    addChannel = '';
+    addChannelToken = '';
+    addChannelChatId = '';
+    addCarrierPairedUser = null;
+    addCarrierPairedUserCount = 0;
+    addWebhookSecret = '';
+    addPairSessionId = '';
+    addPairCode = '';
+    addPairPollRunID += 1;
+    lastAddResult = null;
+  }
+
+  function currentWizardTotalSteps() {
+    return isAddMode() ? 3 : 5;
+  }
+
+  function collectEnvVars() {
+    const vars = {};
+    $$('#env-fields .env-row').forEach(row => {
+      const inputs = row.querySelectorAll('input');
+      if (inputs.length < 2) return;
+      const key = (inputs[0].value || '').trim();
+      const value = (inputs[1].value || '').trim();
+      if (!key) return;
+      vars[key] = value;
+    });
+    return vars;
+  }
+
+  function normalizeAgentCatalog(data) {
+    if (Array.isArray(data)) return data;
+    if (data && Array.isArray(data.agents)) return data.agents;
+    return [];
+  }
+
+  function normalizeInstances(data) {
+    if (Array.isArray(data)) return data;
+    if (data && Array.isArray(data.instances)) return data.instances;
+    return [];
+  }
+
+  function canContinueWithProvider() {
+    if (!selectedProvider) return false;
+    const mode = selectedProvider.auth_mode;
+    if (mode === 'none') return true;
+    if (providerApiKey) return true;
+    if (isAddMode()) return true;
+    if (mode !== 'api_key') return true;
+    return false;
+  }
+
+  function refreshProviderNextButton() {
+    const nextBtn = $('#provider-next');
+    if (!nextBtn) return;
+    nextBtn.disabled = !canContinueWithProvider();
   }
 
   // --- Health ---
@@ -111,6 +202,29 @@
   function navigate(hash) {
     if (!hash || hash === '#' || hash === '#/') hash = '#/welcome';
     const route = hash.replace('#/', '');
+
+    if (route.startsWith('add/')) {
+      const agent = decodeURIComponent(route.slice(4)).trim().toLowerCase();
+      if (!agent) {
+        location.hash = '#/welcome';
+        return;
+      }
+      addTargetAgent = agent;
+      selectedAgent = agent;
+      lastAddResult = null;
+      initSetup();
+      return;
+    }
+
+    if (isAddMode()) {
+      const keepAddRoutes = new Set(['setup', 'provider', 'install', 'complete']);
+      if (!keepAddRoutes.has(route)) {
+        resetAddMode();
+      }
+    }
+    if (route !== 'dashboard') {
+      closeAddAgentModal();
+    }
 
     // Management views require auth
     const mgmtRoutes = ['dashboard', 'logs', 'chat', 'settings'];
@@ -184,6 +298,7 @@
 
   // --- Welcome ---
   function initWelcome() {
+    resetAddMode();
     showView('welcome');
     const status = $('#welcome-status');
     const btn = $('#welcome-continue');
@@ -211,25 +326,313 @@
   // --- Setup ---
   function initSetup() {
     showView('setup');
-    renderSteps('#steps-indicator', 0, 5);
+    const stepTotal = currentWizardTotalSteps();
+    renderSteps('#steps-indicator', 0, stepTotal);
+
+    const title = $('#setup-title');
+    const providerLabel = $('#setup-provider-label');
+    const tokenLabel = $('#setup-token-label');
+    const providerSelect = $('#provider');
+    const tokenInput = $('#provider-token');
+    const webhookInput = $('#webhook-secret');
+    const webhookLabel = $('label[for="webhook-secret"]');
+    const setupBtn = $('#setup-btn');
+    const pairSection = $('#setup-telegram-pair');
+    const pairInstruction = $('#setup-pair-instruction');
+    const pairUseCarrierBtn = $('#setup-pair-use-carrier');
+    const pairStartBtn = $('#setup-pair-start');
+    tokenInput.value = isAddMode() ? addChannelToken : '';
+    webhookInput.value = isAddMode() ? addWebhookSecret : '';
+    setMsg('#setup-msg', '', 'info');
+    setMsg('#setup-pair-msg', '', 'info');
+
+    function updatePairInstruction() {
+      if (!pairInstruction) return;
+      if (!isAddMode() || providerSelect.value.trim().toLowerCase() !== 'telegram') {
+        pairInstruction.textContent = '';
+        return;
+      }
+      if (addChannelChatId) {
+        pairInstruction.textContent = 'Paired chat id: ' + addChannelChatId;
+        return;
+      }
+      if (addPairCode) {
+        pairInstruction.textContent = 'Send `/pair ' + addPairCode + '` in your Telegram bot chat. Pairing will be detected automatically.';
+        return;
+      }
+      pairInstruction.textContent = 'Click Start Pairing to get a code, then send it in your Telegram bot chat.';
+    }
+
+    function renderCarrierPairShortcut(channel) {
+      if (!pairUseCarrierBtn) return;
+      const isTelegramAdd = isAddMode() && String(channel || '').toLowerCase() === 'telegram';
+      if (!isTelegramAdd || !addCarrierPairedUser || !addCarrierPairedUser.chatId) {
+        pairUseCarrierBtn.classList.add('hidden');
+        pairUseCarrierBtn.textContent = 'Use Carrier paired user (Recommended)';
+        return;
+      }
+      pairUseCarrierBtn.classList.remove('hidden');
+      const chatID = String(addCarrierPairedUser.chatId).trim();
+      if (addCarrierPairedUserCount === 1) {
+        pairUseCarrierBtn.textContent = 'Use Carrier paired user (Recommended): ' + chatID;
+        return;
+      }
+      pairUseCarrierBtn.textContent = 'Use last Carrier paired user (Recommended): ' + chatID;
+    }
+
+    const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    async function autoWaitTelegramPairing(sessionID) {
+      const sid = (sessionID || '').trim();
+      if (!sid) return;
+      const pollRunID = ++addPairPollRunID;
+      setMsg('#setup-pair-msg', 'Pair code ready. Waiting for Telegram `/pair` command…', 'info');
+      for (;;) {
+        if (pollRunID !== addPairPollRunID) return;
+        try {
+          const resp = await api('POST', '/api/v1/telegram/pair/wait', { sessionId: sid });
+          if (pollRunID !== addPairPollRunID) return;
+          if (resp && resp.paired && resp.chatId) {
+            addChannelChatId = String(resp.chatId).trim();
+            addPairSessionId = '';
+            addPairCode = '';
+            updatePairInstruction();
+            refreshSetupContinueState();
+            setMsg('#setup-pair-msg', 'Pairing complete. Chat id: ' + addChannelChatId, 'info');
+            return;
+          }
+          setMsg('#setup-pair-msg', 'Still waiting for Telegram `/pair` command…', 'info');
+          continue;
+        } catch (e) {
+          if (pollRunID !== addPairPollRunID) return;
+          const msg = (e && e.message ? String(e.message) : '').toLowerCase();
+          if (msg.includes('expired') || msg.includes('session') || msg.includes('not found') || msg.includes('invalid')) {
+            setMsg('#setup-pair-msg', 'Pair session expired. Click Start Pairing to generate a new code.', 'error');
+            refreshSetupContinueState();
+            return;
+          }
+          setMsg('#setup-pair-msg', 'Pair check failed, retrying…', 'error');
+          await delay(1500);
+        }
+      }
+    }
+
+    async function loadCarrierPairedUser(channel) {
+      if (!isAddMode() || channel !== 'telegram') {
+        addCarrierPairedUser = null;
+        addCarrierPairedUserCount = 0;
+        renderCarrierPairShortcut(channel);
+        return;
+      }
+      try {
+        const resp = await api('GET', '/api/v1/pairing/sessions?provider=telegram');
+        const sessions = (resp && Array.isArray(resp.sessions)) ? resp.sessions : [];
+        const validSessions = sessions.filter(s => s && s.chatId && /^[0-9]+$/.test(String(s.chatId).trim()));
+        addCarrierPairedUserCount = validSessions.length;
+        if (validSessions.length > 0) {
+          const latest = validSessions[0];
+          addCarrierPairedUser = { chatId: String(latest.chatId).trim() };
+        } else {
+          addCarrierPairedUser = null;
+        }
+        if (validSessions.length === 1 && addCarrierPairedUser && !addChannelChatId) {
+          addChannelChatId = addCarrierPairedUser.chatId;
+          setMsg('#setup-pair-msg', 'Auto-selected Carrier paired Telegram user: ' + addChannelChatId, 'info');
+        }
+      } catch (_e) {
+        addCarrierPairedUser = null;
+        addCarrierPairedUserCount = 0;
+      }
+      renderCarrierPairShortcut(channel);
+      updatePairInstruction();
+      refreshSetupContinueState();
+    }
+
+    function refreshSetupContinueState() {
+      if (!isAddMode()) {
+        setupBtn.disabled = false;
+        return;
+      }
+      const channel = providerSelect.value.trim().toLowerCase();
+      const channelToken = tokenInput.value.trim();
+      if (channel === 'telegram') {
+        setupBtn.disabled = !channelToken || !addChannelChatId;
+        return;
+      }
+      setupBtn.disabled = !channelToken;
+    }
+
+    if (addTargetAgent === 'picoclaw') {
+      title.textContent = 'Step 1 — Choose Chat Channel for PicoClaw';
+      providerLabel.textContent = 'Channel';
+      tokenLabel.textContent = 'Channel Bot Token';
+      providerSelect.value = addChannel || 'telegram';
+      [...providerSelect.options].forEach(opt => {
+        opt.disabled = opt.value !== '' && opt.value !== 'telegram';
+      });
+      webhookInput.disabled = true;
+      webhookInput.placeholder = 'Not required for PicoClaw add flow';
+      webhookInput.classList.add('hidden');
+      if (webhookLabel) webhookLabel.classList.add('hidden');
+      pairSection.classList.remove('hidden');
+      pairStartBtn.disabled = false;
+      renderCarrierPairShortcut('telegram');
+      updatePairInstruction();
+      refreshSetupContinueState();
+      loadCarrierPairedUser((providerSelect.value || '').trim().toLowerCase());
+      if (addPairSessionId && !addChannelChatId) {
+        autoWaitTelegramPairing(addPairSessionId);
+      }
+    } else {
+      title.textContent = 'Step 1 — Configure Chat Channel';
+      providerLabel.textContent = 'Chat Channel';
+      tokenLabel.textContent = 'Channel Bot Token';
+      providerSelect.value = '';
+      [...providerSelect.options].forEach(opt => { opt.disabled = false; });
+      webhookInput.disabled = false;
+      webhookInput.placeholder = 'Webhook verification secret';
+      webhookInput.classList.remove('hidden');
+      if (webhookLabel) webhookLabel.classList.remove('hidden');
+      pairSection.classList.add('hidden');
+      renderCarrierPairShortcut('');
+      setupBtn.disabled = false;
+    }
+
+    providerSelect.onchange = () => {
+      if (!isAddMode()) return;
+      const channel = providerSelect.value.trim().toLowerCase();
+      if (channel !== 'telegram') {
+        addChannelChatId = '';
+        addPairSessionId = '';
+        addPairCode = '';
+        addPairPollRunID += 1;
+      }
+      renderCarrierPairShortcut(channel);
+      loadCarrierPairedUser(channel);
+      updatePairInstruction();
+      refreshSetupContinueState();
+    };
+
+    tokenInput.oninput = () => {
+      if (!isAddMode()) return;
+      const inputToken = tokenInput.value.trim();
+      if (inputToken !== addChannelToken) {
+        addChannelChatId = '';
+        addPairSessionId = '';
+        addPairCode = '';
+        addPairPollRunID += 1;
+        setMsg('#setup-pair-msg', '', 'info');
+      }
+      if (providerSelect.value.trim().toLowerCase() === 'telegram') {
+        renderCarrierPairShortcut('telegram');
+        loadCarrierPairedUser('telegram');
+      }
+      updatePairInstruction();
+      refreshSetupContinueState();
+    };
+
+    if (pairUseCarrierBtn) {
+      pairUseCarrierBtn.onclick = () => {
+        if (!addCarrierPairedUser || !addCarrierPairedUser.chatId) {
+          setMsg('#setup-pair-msg', 'No reusable Carrier paired Telegram user found.', 'error');
+          return;
+        }
+        addPairPollRunID += 1;
+        addChannelChatId = String(addCarrierPairedUser.chatId).trim();
+        addPairSessionId = '';
+        addPairCode = '';
+        updatePairInstruction();
+        refreshSetupContinueState();
+        setMsg('#setup-pair-msg', 'Using Carrier paired Telegram user: ' + addChannelChatId, 'info');
+      };
+    }
+
+    pairStartBtn.onclick = async () => {
+      const channel = providerSelect.value.trim().toLowerCase();
+      const channelToken = tokenInput.value.trim();
+      if (channel !== 'telegram') {
+        setMsg('#setup-pair-msg', 'Pairing is only required for Telegram channel.', 'error');
+        return;
+      }
+      if (!channelToken) {
+        setMsg('#setup-pair-msg', 'Please enter channel bot token first.', 'error');
+        return;
+      }
+      pairStartBtn.disabled = true;
+      addPairPollRunID += 1;
+      setMsg('#setup-pair-msg', 'Creating pair code…', 'info');
+      try {
+        const resp = await api('POST', '/api/v1/telegram/pair/init', { token: channelToken });
+        addChannel = channel;
+        addChannelToken = channelToken;
+        addPairSessionId = (resp && resp.sessionId) || '';
+        addPairCode = (resp && resp.pairCode) || '';
+        addChannelChatId = '';
+        renderCarrierPairShortcut(channel);
+        updatePairInstruction();
+        refreshSetupContinueState();
+        autoWaitTelegramPairing(addPairSessionId);
+      } catch (e) {
+        setMsg('#setup-pair-msg', 'Pair init failed: ' + e.message, 'error');
+      } finally {
+        pairStartBtn.disabled = false;
+        refreshSetupContinueState();
+      }
+    };
 
     $('#setup-btn').onclick = async () => {
-      // Daemon mode: skip provider setup (gateway concept), go to agents.
+      const channel = providerSelect.value.trim().toLowerCase();
+      const channelToken = tokenInput.value.trim();
+      const webhookSecret = webhookInput.value.trim();
+      if (addTargetAgent) {
+        if (!channel) {
+          setMsg('#setup-msg', 'Please choose a channel.', 'error');
+          return;
+        }
+        if (!channelToken) {
+          setMsg('#setup-msg', 'Please enter channel bot token.', 'error');
+          return;
+        }
+        if (channel === 'telegram' && !addChannelChatId) {
+          setMsg('#setup-msg', 'Please complete Telegram pairing first to capture your chat id.', 'error');
+          return;
+        }
+        addChannel = channel;
+        addChannelToken = channelToken;
+        addWebhookSecret = webhookSecret;
+        location.hash = '#/provider';
+        return;
+      }
+
+      if (!channel) {
+        setMsg('#setup-msg', 'Please choose a chat channel.', 'error');
+        return;
+      }
+      if (!channelToken) {
+        setMsg('#setup-msg', 'Please enter channel bot token.', 'error');
+        return;
+      }
+
+      // Reuse channel fields for non-add wizard install path as well.
+      addChannel = channel;
+      addChannelToken = channelToken;
+      addWebhookSecret = webhookSecret;
       location.hash = '#/agents';
     };
   }
 
   // --- Agents selection ---
   async function initAgents() {
+    resetAddMode();
     showView('agents');
-    renderSteps('#steps-indicator-2', 1, 5);
+    renderSteps('#steps-indicator-2', 1, currentWizardTotalSteps());
 
     const list = $('#agent-pick');
     list.textContent = '';
     setMsg('#agents-msg', 'Loading agents…', 'info');
 
     try {
-      const agents = await api('GET', '/api/v1/agents');
+      const agents = normalizeAgentCatalog(await api('GET', '/api/v1/agents'));
       setMsg('#agents-msg', '', 'info');
 
       (agents || []).forEach(a => {
@@ -245,7 +648,7 @@
         list.appendChild(li);
       });
 
-      if (!agents || agents.length === 0) {
+      if (agents.length === 0) {
         setMsg('#agents-msg', 'No agents found.', 'error');
       }
     } catch (e) {
@@ -278,25 +681,88 @@
   // --- Provider selection ---
   async function initProvider() {
     showView('provider');
-    renderSteps('#steps-indicator-p', 2, 6);
+    renderSteps('#steps-indicator-p', isAddMode() ? 1 : 2, currentWizardTotalSteps());
 
-    $('#provider-agent-name').textContent = 'Configuring: ' + selectedAgent;
+    const heading = $('#view-provider h3');
+    if (heading) heading.textContent = isAddMode() ? 'Step 2 — Select LLM Provider' : 'Step 3 — Select LLM Provider';
+    $('#provider-agent-name').textContent = isAddMode() ? ('Adding: ' + selectedAgent) : ('Configuring: ' + selectedAgent);
     selectedProvider = null;
     providerApiKey = '';
-    $('#provider-next').disabled = true;
+    refreshProviderNextButton();
     $('#provider-auth-section').classList.add('hidden');
+
+    const skipBtn = $('#provider-skip');
+    skipBtn.classList.add('hidden');
+
+    const addChoice = $('#provider-add-choice');
+    const defaultSummary = $('#provider-default-summary');
+    const useDefaultContinueBtn = $('#provider-use-default-continue');
+    const otherWrap = $('#provider-other-wrap');
 
     const loading = $('#provider-loading');
     const catEl = $('#provider-categories');
     loading.classList.remove('hidden');
+    addChoice.classList.add('hidden');
+    otherWrap.classList.add('hidden');
     catEl.classList.add('hidden');
     catEl.textContent = '';
     setMsg('#provider-msg', '', 'info');
 
+    const providerById = new Map();
+    const providerItemById = new Map();
+    let carrierDefaultProvider = null;
+
+    function selectProvider(p, opts) {
+      if (!p || !p.id) return;
+      $$('.provider-item').forEach(x => x.classList.remove('selected'));
+      const item = providerItemById.get(p.id);
+      if (item) item.classList.add('selected');
+
+      selectedProvider = p;
+      showProviderAuth(p);
+      refreshProviderNextButton();
+    }
+
+    function renderCarrierDefaultChoice() {
+      if (!isAddMode()) return;
+      addChoice.classList.remove('hidden');
+      useDefaultContinueBtn.classList.add('hidden');
+      useDefaultContinueBtn.disabled = true;
+
+      if (!carrierDefaultProvider || !carrierDefaultProvider.configured) {
+        defaultSummary.textContent = 'Carrier default provider is not configured.';
+        return;
+      }
+      const pid = carrierDefaultProvider.id || '';
+      const providerInfo = carrierDefaultProvider.provider || {};
+      const pname = providerInfo.name || pid || 'unknown';
+
+      if (!carrierDefaultProvider.available) {
+        defaultSummary.textContent = 'Carrier default provider `' + pid + '` is not available in current gateway catalog.';
+        return;
+      }
+      if (carrierDefaultProvider.reusable) {
+        const backend = carrierDefaultProvider.credential_backend || 'saved store';
+        defaultSummary.textContent = 'Using Carrier default: ' + pname + ' (`' + pid + '`) · credential: ' + backend + '.';
+        const mapped = providerById.get(String(pid).trim().toLowerCase());
+        if (mapped) {
+          useDefaultContinueBtn.classList.remove('hidden');
+          useDefaultContinueBtn.disabled = false;
+          useDefaultContinueBtn.textContent = 'Use Carrier Provider (Recommended) →';
+        }
+        return;
+      }
+      if (carrierDefaultProvider.reason) {
+        defaultSummary.textContent = 'Carrier default: ' + pname + ' (`' + pid + '`), but cannot reuse now: ' + carrierDefaultProvider.reason + '.';
+      } else {
+        defaultSummary.textContent = 'Carrier default provider is available but no reusable credential was found.';
+      }
+    }
+
     try {
       const data = await api('GET', '/api/v1/providers');
       loading.classList.add('hidden');
-      catEl.classList.remove('hidden');
+      carrierDefaultProvider = data && data.carrier_default_provider ? data.carrier_default_provider : null;
 
       const categoryOrder = [
         { key: 'builtin', label: '☁️ Built-in (API key)' },
@@ -317,6 +783,7 @@
         const ul = document.createElement('ul');
         ul.className = 'provider-list';
         providers.forEach(p => {
+          providerById.set(p.id, p);
           const li = document.createElement('li');
           li.className = 'provider-item';
 
@@ -329,22 +796,59 @@
           }
 
           li.onclick = () => {
-            $$('.provider-item').forEach(x => x.classList.remove('selected'));
-            li.classList.add('selected');
-            selectedProvider = p;
-            showProviderAuth(p);
+            selectProvider(p, {});
           };
+          providerItemById.set(p.id, li);
           ul.appendChild(li);
         });
         section.appendChild(ul);
         catEl.appendChild(section);
       });
+
+      if (isAddMode()) {
+        renderCarrierDefaultChoice();
+        const defaultProviderID = ((carrierDefaultProvider && carrierDefaultProvider.id) || '').trim().toLowerCase();
+        const canAutoUseDefault = !!(carrierDefaultProvider && carrierDefaultProvider.reusable && defaultProviderID && providerById.has(defaultProviderID));
+        if (canAutoUseDefault) {
+          const p = providerById.get(defaultProviderID);
+          selectProvider(p, {});
+          otherWrap.classList.add('hidden');
+          catEl.classList.add('hidden');
+        } else {
+          otherWrap.classList.remove('hidden');
+          catEl.classList.remove('hidden');
+        }
+      } else {
+        addChoice.classList.add('hidden');
+        otherWrap.classList.remove('hidden');
+        catEl.classList.remove('hidden');
+      }
     } catch (e) {
       loading.classList.add('hidden');
+      addChoice.classList.add('hidden');
+      otherWrap.classList.add('hidden');
       setMsg('#provider-msg', 'Error loading providers: ' + e.message, 'error');
     }
 
-    $('#provider-back').onclick = () => { location.hash = '#/agents'; };
+    if (useDefaultContinueBtn) {
+      useDefaultContinueBtn.onclick = () => {
+        if (!isAddMode()) return;
+        if (!carrierDefaultProvider || !carrierDefaultProvider.reusable) {
+          setMsg('#provider-msg', 'Carrier default provider is not reusable right now.', 'error');
+          return;
+        }
+        const providerID = String(carrierDefaultProvider.id || '').trim().toLowerCase();
+        const p = providerById.get(providerID);
+        if (!p) {
+          setMsg('#provider-msg', 'Carrier default provider is not available in current provider list.', 'error');
+          return;
+        }
+        selectProvider(p, {});
+        location.hash = '#/install';
+      };
+    }
+
+    $('#provider-back').onclick = () => { location.hash = isAddMode() ? '#/setup' : '#/agents'; };
     $('#provider-skip').onclick = () => {
       selectedProvider = null;
       providerApiKey = '';
@@ -352,6 +856,10 @@
     };
     $('#provider-next').onclick = () => {
       if (!selectedProvider) return;
+      if (isAddMode()) {
+        location.hash = '#/install';
+        return;
+      }
       location.hash = '#/config';
     };
   }
@@ -380,32 +888,54 @@
     providerApiKey = '';
 
     if (p.auth_mode === 'api_key') {
-      label.textContent = 'Paste your API key for ' + p.name + ' (' + p.env_var + '):';
+      if (isAddMode()) {
+        label.textContent = 'Paste API key for ' + p.name + ' (' + p.env_var + ') if you are not reusing Carrier credential:';
+      } else {
+        label.textContent = 'Paste your API key for ' + p.name + ' (' + p.env_var + '):';
+      }
       keyInput.classList.remove('hidden');
+      keyInput.placeholder = 'API key';
       keyInput.oninput = () => {
         providerApiKey = keyInput.value.trim();
-        $('#provider-next').disabled = !providerApiKey;
+        refreshProviderNextButton();
       };
-      $('#provider-next').disabled = true;
     } else if (p.auth_mode === 'none') {
       label.textContent = p.name + ' requires no authentication.';
-      $('#provider-next').disabled = false;
+      providerApiKey = '';
     } else {
-      // OAuth or gcloud ADC — show instructions
-      const cmd = 'openclaw models auth login --provider ' + p.id;
-      label.textContent = p.name + ' requires external authentication:';
+      // OAuth / plugin / ADC
+      label.textContent = p.name + ' requires external authentication.';
       instructions.classList.remove('hidden');
-      instructions.innerHTML = 'Run: <code>' + escapeHtml(cmd) + '</code><br>Then click Continue.';
-      $('#provider-next').disabled = false;
+      if (isAddMode()) {
+        instructions.innerHTML =
+          'Paste access token below if you are not reusing Carrier credential.';
+        keyInput.classList.remove('hidden');
+        keyInput.placeholder = 'Access token (optional)';
+        keyInput.oninput = () => {
+          providerApiKey = keyInput.value.trim();
+          refreshProviderNextButton();
+        };
+      } else {
+        const cmd = 'openclaw models auth login --provider ' + p.id;
+        instructions.innerHTML = 'Run: <code>' + escapeHtml(cmd) + '</code><br>Then click Continue.';
+      }
     }
+    refreshProviderNextButton();
   }
 
   // --- Config ---
   function initConfig() {
+    if (isAddMode()) {
+      location.hash = '#/install';
+      return;
+    }
     showView('config');
-    renderSteps('#steps-indicator-3', 3, 6);
+    renderSteps('#steps-indicator-3', isAddMode() ? 2 : 3, currentWizardTotalSteps());
 
-    let agentLabel = 'Configuring: ' + selectedAgent;
+    const heading = $('#view-config h3');
+    if (heading) heading.textContent = isAddMode() ? 'Step 3 — Environment Variables' : 'Step 4 — Environment Variables';
+
+    let agentLabel = (isAddMode() ? 'Adding: ' : 'Configuring: ') + selectedAgent;
     if (selectedProvider) {
       agentLabel += ' · Provider: ' + selectedProvider.name;
     }
@@ -451,17 +981,59 @@
   // --- Install ---
   function initInstall() {
     showView('install');
-    renderSteps('#steps-indicator-4', 4, 6);
+    renderSteps('#steps-indicator-4', isAddMode() ? 2 : 4, currentWizardTotalSteps());
+
+    const heading = $('#view-install h3');
+    if (heading) heading.textContent = isAddMode() ? 'Step 3 — Confirm Installation' : 'Step 5 — Confirm Installation';
 
     let summary = 'Agent: ' + selectedAgent;
+    if (isAddMode()) summary += '\nChannel: ' + addChannel;
     if (selectedProvider) summary += '\nProvider: ' + selectedProvider.name;
     $('#install-summary').textContent = summary;
 
-    $('#install-back').onclick = () => { location.hash = '#/config'; };
+    $('#install-back').onclick = () => { location.hash = isAddMode() ? '#/provider' : '#/config'; };
     $('#install-confirm').onclick = async () => {
       setMsg('#install-msg', 'Installing…', 'info');
       try {
-        await api('POST', '/api/v1/agents/' + encodeURIComponent(selectedAgent) + '/install', {});
+        if (isAddMode()) {
+          if (!selectedProvider) {
+            throw new Error('Please select a provider.');
+          }
+          const envVars = collectEnvVars();
+          if (addWebhookSecret) {
+            envVars.CARRIER_TELEGRAM_WEBHOOK_SECRET = addWebhookSecret;
+          }
+          const resp = await api('POST', '/api/v1/add', {
+            agentId: selectedAgent,
+            channel: addChannel,
+            channelToken: addChannelToken,
+            channelChatId: addChannelChatId,
+            providerId: selectedProvider.id,
+            providerToken: providerApiKey,
+            reuseCredential: providerApiKey ? false : true,
+            envVars,
+          });
+          lastAddResult = resp || null;
+        } else {
+          if (!selectedProvider && selectedAgent === 'picoclaw') {
+            throw new Error('Please select an LLM provider for picoclaw.');
+          }
+          const envVars = collectEnvVars();
+          if (addWebhookSecret) {
+            envVars.CARRIER_TELEGRAM_WEBHOOK_SECRET = addWebhookSecret;
+          }
+          const resp = await api('POST', '/api/v1/add', {
+            agentId: selectedAgent,
+            channel: addChannel,
+            channelToken: addChannelToken,
+            channelChatId: addChannelChatId,
+            providerId: selectedProvider ? selectedProvider.id : '',
+            providerToken: providerApiKey,
+            reuseCredential: true,
+            envVars,
+          });
+          lastAddResult = resp || null;
+        }
         location.hash = '#/complete';
       } catch (e) {
         setMsg('#install-msg', 'Error: ' + e.message, 'error');
@@ -472,65 +1044,170 @@
   // --- Complete ---
   function initComplete() {
     showView('complete');
-    $('#complete-dashboard').onclick = () => { location.hash = '#/dashboard'; };
+    const title = $('#complete-title');
+    const detail = $('#complete-detail');
+    if (title) title.textContent = '✅ Setup Complete!';
+    if (isAddMode() && lastAddResult) {
+      const lines = [];
+      const pairRequired = !!lastAddResult.pairRequired;
+      if (pairRequired) {
+        if (title) title.textContent = '⚠️ One step left: Pair your PicoClaw bot';
+        lines.push('Action required: complete Telegram pairing before first use.');
+      }
+      if (lastAddResult.instanceId) lines.push('Instance: ' + lastAddResult.instanceId);
+      if (lastAddResult.pairCode) lines.push('Pair code: ' + lastAddResult.pairCode);
+      if (pairRequired && lastAddResult.pairCode) {
+        lines.push('Send in your PicoClaw bot chat: /pair ' + lastAddResult.pairCode);
+      }
+      if (lastAddResult.pairedChatId) lines.push('Paired chat: ' + lastAddResult.pairedChatId);
+      if (lastAddResult.workspacePath) lines.push('Workspace: ' + lastAddResult.workspacePath);
+      if (lastAddResult.configPath) lines.push('Config: ' + lastAddResult.configPath);
+      detail.textContent = lines.join('\n');
+    } else {
+      detail.textContent = '';
+    }
+    $('#complete-dashboard').onclick = () => {
+      resetAddMode();
+      location.hash = '#/dashboard';
+    };
   }
 
   // --- Dashboard ---
   async function initDashboard() {
+    resetAddMode();
     showView('dashboard');
     $('#nav').classList.remove('hidden');
-    await refreshAgents();
-    $('#refresh-agents').onclick = refreshAgents;
+    await refreshInstances();
+    $('#refresh-instances').onclick = refreshInstances;
+    $('#dashboard-add-agent').onclick = openAddAgentModal;
+    $('#add-agent-cancel').onclick = closeAddAgentModal;
   }
 
-  async function refreshAgents() {
-    const el = $('#agent-list');
+  async function refreshInstances() {
+    const el = $('#instance-list');
+    const summary = $('#instance-summary');
     el.textContent = 'Loading…';
+    summary.textContent = '';
     try {
-      const agents = await api('GET', '/api/v1/agents');
+      const instances = normalizeInstances(await api('GET', '/api/v1/instances'));
 
       el.textContent = '';
-      if (!agents || agents.length === 0) {
-        el.textContent = 'No agents found.';
+      if (instances.length === 0) {
+        el.textContent = 'No installed agent instances.';
+        summary.textContent = 'Use Add Agent to install and configure a new instance.';
         return;
       }
+      const running = instances.filter(i => {
+        const runtime = (i.runtime_state || i.runtimeState || i.runtime || '').toLowerCase();
+        return runtime === 'running' || runtime === 'healthy';
+      }).length;
+      summary.textContent = 'Total: ' + instances.length + ' · Running: ' + running;
 
-      agents.forEach(a => {
+      instances.forEach(a => {
         const card = document.createElement('div');
         card.className = 'agent-card';
-        card.onclick = () => { location.hash = '#/agents/' + encodeURIComponent(a.id || a.ID); };
+        const instanceID = a.id || a.ID;
+        const agentID = a.agent_id || a.agentID || a.agent || a.type || 'unknown';
+        const runtime = a.runtime_state || a.runtimeState || a.runtime || 'unknown';
+        const provider = a.provider || 'n/a';
+        const channel = a.channel || 'n/a';
+        const pairRequired = !!(a.pair_required || a.pairRequired);
+        const pairedChatId = a.paired_chat_id || a.pairedChatId || '';
 
         const h = document.createElement('h4');
-        h.textContent = a.id || a.ID || a.name;
+        h.textContent = instanceID;
 
-        const runtime = a.runtime || a.Runtime || 'unknown';
         const status = document.createElement('div');
         status.className = 'agent-status';
         status.textContent = statusIcon(runtime) + ' ' + runtime;
+
+        const meta = document.createElement('div');
+        meta.className = 'instance-meta';
+        let metaText = 'Type: ' + agentID + ' · Channel: ' + channel + ' · Provider: ' + provider;
+        if (pairRequired) metaText += ' · Pair: required';
+        else if (pairedChatId) metaText += ' · Paired chat: ' + pairedChatId;
+        meta.textContent = metaText;
 
         const btnRow = document.createElement('div');
         btnRow.className = 'btn-row';
 
         const startBtn = document.createElement('button');
         startBtn.className = 'btn-sm';
-        startBtn.textContent = '▶ Start';
-        startBtn.onclick = (e) => { e.stopPropagation(); agentAction(a.id || a.ID, 'start'); };
+        startBtn.textContent = 'Start';
+        startBtn.onclick = () => { instanceAction(instanceID, 'start'); };
 
         const stopBtn = document.createElement('button');
         stopBtn.className = 'btn-sm btn-secondary';
-        stopBtn.textContent = '⏹ Stop';
-        stopBtn.onclick = (e) => { e.stopPropagation(); agentAction(a.id || a.ID, 'stop'); };
+        stopBtn.textContent = 'Stop';
+        stopBtn.onclick = () => { instanceAction(instanceID, 'stop'); };
+
+        const uninstallBtn = document.createElement('button');
+        uninstallBtn.className = 'btn-sm btn-danger';
+        uninstallBtn.textContent = 'Uninstall';
+        uninstallBtn.onclick = () => { instanceAction(instanceID, 'uninstall'); };
 
         btnRow.appendChild(startBtn);
         btnRow.appendChild(stopBtn);
+        btnRow.appendChild(uninstallBtn);
         card.appendChild(h);
         card.appendChild(status);
+        card.appendChild(meta);
         card.appendChild(btnRow);
         el.appendChild(card);
       });
     } catch (e) {
       el.textContent = 'Error: ' + e.message;
     }
+  }
+
+  async function instanceAction(instanceID, action) {
+    if (action === 'uninstall') {
+      const confirmed = window.confirm('Uninstall instance ' + instanceID + '?');
+      if (!confirmed) return;
+    }
+    try {
+      await api('POST', '/api/v1/instances/' + encodeURIComponent(instanceID) + '/' + action, {});
+      await refreshInstances();
+    } catch (e) {
+      // Keep dashboard responsive and show a simple inline summary on top.
+      const summary = $('#instance-summary');
+      summary.textContent = 'Action failed: ' + e.message;
+    }
+  }
+
+  async function openAddAgentModal() {
+    const overlay = $('#add-agent-overlay');
+    const list = $('#add-agent-options');
+    overlay.classList.remove('hidden');
+    list.textContent = '';
+    setMsg('#add-agent-msg', 'Loading agents…', 'info');
+
+    try {
+      const agents = normalizeAgentCatalog(await api('GET', '/api/v1/agents'));
+      setMsg('#add-agent-msg', '', 'info');
+      if (agents.length === 0) {
+        setMsg('#add-agent-msg', 'No agents available.', 'error');
+        return;
+      }
+      agents.forEach(a => {
+        const id = (a.id || a.ID || a.name || '').toLowerCase();
+        if (!id) return;
+        const li = document.createElement('li');
+        li.innerHTML = '<strong>' + escapeHtml(id) + '</strong>';
+        li.onclick = () => {
+          closeAddAgentModal();
+          location.hash = '#/add/' + encodeURIComponent(id);
+        };
+        list.appendChild(li);
+      });
+    } catch (e) {
+      setMsg('#add-agent-msg', 'Error loading agents: ' + e.message, 'error');
+    }
+  }
+
+  function closeAddAgentModal() {
+    $('#add-agent-overlay').classList.add('hidden');
+    setMsg('#add-agent-msg', '', 'info');
   }
 
   function parseAgentStatus(text) {
@@ -554,7 +1231,7 @@
   async function agentAction(name, action) {
     try {
       await api('POST', '/api/v1/agents/' + encodeURIComponent(name) + '/' + action, {});
-      await refreshAgents();
+      await refreshInstances();
     } catch (e) {
       // silent
     }
@@ -616,13 +1293,16 @@
     const agentSelect = $('#log-agent');
     agentSelect.textContent = '';
 
-    // Populate agent list
-    api('GET', '/api/v1/agents').then(agents => {
-      (agents || []).forEach(a => {
-        const name = a.id || a.ID || a.name;
+    // Populate instance list (mapped to runtime agent id for logs)
+    api('GET', '/api/v1/instances').then(payload => {
+      const instances = normalizeInstances(payload);
+      instances.forEach(a => {
+        const instanceID = a.id || a.ID || '';
+        const name = a.agent_id || a.agentID || a.type || a.id || a.ID || a.name;
+        if (!name) return;
         const opt = document.createElement('option');
         opt.value = name;
-        opt.textContent = name;
+        opt.textContent = instanceID ? (instanceID + ' (' + name + ')') : name;
         agentSelect.appendChild(opt);
       });
     }).catch(() => {});

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -11,7 +11,7 @@
   <!-- Login overlay -->
   <div id="login-overlay" class="overlay hidden">
     <div class="card login-card">
-      <h2>🔐 Carrier</h2>
+      <h2>Carrier</h2>
       <p class="text-dim">Enter your Gateway token to continue.</p>
       <input type="password" id="login-token" placeholder="Gateway Token" autocomplete="off">
       <div id="login-msg"></div>
@@ -21,7 +21,7 @@
 
   <header id="header">
     <div class="header-left">
-      <h1>🚀 Carrier</h1>
+      <h1>Carrier</h1>
       <nav id="nav" class="hidden">
         <a href="#/dashboard" class="nav-link" data-route="dashboard">Dashboard</a>
         <a href="#/logs" class="nav-link" data-route="logs">Logs</a>
@@ -49,18 +49,26 @@
     <section id="view-setup" class="view hidden">
       <div class="steps-indicator" id="steps-indicator"></div>
       <div class="card">
-        <h3>Step 1 — Configure Provider</h3>
-        <label for="provider">Provider</label>
+        <h3 id="setup-title">Step 1 — Configure Provider</h3>
+        <label for="provider" id="setup-provider-label">Provider</label>
         <select id="provider">
           <option value="">Select…</option>
           <option value="telegram">Telegram</option>
           <option value="discord">Discord</option>
           <option value="feishu">Feishu</option>
         </select>
-        <label for="provider-token">Token</label>
+        <label for="provider-token" id="setup-token-label">Token</label>
         <input type="password" id="provider-token" placeholder="Bot token">
         <label for="webhook-secret">Webhook Secret <span class="text-dim">(optional)</span></label>
         <input type="text" id="webhook-secret" placeholder="Webhook verification secret">
+        <div id="setup-telegram-pair" class="hidden">
+          <p class="text-dim" id="setup-pair-instruction"></p>
+          <div class="btn-row">
+            <button id="setup-pair-use-carrier" type="button" class="btn-sm hidden">Use Carrier paired user (Recommended)</button>
+            <button id="setup-pair-start" type="button" class="btn-secondary btn-sm">Start Pairing</button>
+          </div>
+          <div id="setup-pair-msg"></div>
+        </div>
         <div class="btn-row">
           <button id="setup-btn">Continue →</button>
         </div>
@@ -87,7 +95,16 @@
         <h3>Step 3 — Select LLM Provider</h3>
         <p class="text-dim" id="provider-agent-name"></p>
         <div id="provider-loading" class="text-dim">Loading providers…</div>
-        <div id="provider-categories" class="hidden"></div>
+        <div id="provider-add-choice" class="hidden">
+          <h4>Carrier Provider</h4>
+          <p id="provider-default-summary" class="text-dim"></p>
+          <div class="btn-row">
+            <button id="provider-use-default-continue" class="btn-sm hidden">Use Carrier Provider (Recommended) →</button>
+          </div>
+        </div>
+        <div id="provider-other-wrap" class="hidden">
+          <div id="provider-categories" class="hidden"></div>
+        </div>
         <div id="provider-auth-section" class="hidden" style="margin-top:1rem">
           <div id="provider-auth-label" class="text-dim"></div>
           <input type="password" id="provider-api-key" placeholder="Paste API key here…" class="hidden" style="margin-top:0.5rem">
@@ -134,17 +151,24 @@
 
     <section id="view-complete" class="view hidden">
       <div class="card center-card">
-        <h2>✅ Setup Complete!</h2>
+        <h2 id="complete-title">✅ Setup Complete!</h2>
         <p class="text-dim">Your agent is being installed and started.</p>
+        <p class="text-dim" id="complete-detail"></p>
         <button id="complete-dashboard">Go to Dashboard →</button>
       </div>
     </section>
 
     <!-- Management panel -->
     <section id="view-dashboard" class="view hidden">
-      <h2>Agent Dashboard</h2>
-      <div id="agent-list" class="agent-grid"></div>
-      <button id="refresh-agents" class="btn-sm btn-secondary" style="margin-top:1rem">↻ Refresh</button>
+      <div class="section-head">
+        <h2>Installed Agents</h2>
+        <div class="section-actions">
+          <button id="dashboard-add-agent">Add Agent</button>
+          <button id="refresh-instances" class="btn-sm btn-secondary">Refresh</button>
+        </div>
+      </div>
+      <p id="instance-summary" class="text-dim"></p>
+      <div id="instance-list" class="agent-grid"></div>
     </section>
 
     <section id="view-agent-detail" class="view hidden">
@@ -184,6 +208,18 @@
       </div>
     </section>
   </main>
+
+  <div id="add-agent-overlay" class="overlay hidden">
+    <div class="card modal-card">
+      <h3>Select Agent</h3>
+      <p class="text-dim">Choose an agent to configure and install.</p>
+      <ul id="add-agent-options" class="agent-select-list"></ul>
+      <div class="btn-row">
+        <button id="add-agent-cancel" class="btn-secondary">Cancel</button>
+      </div>
+      <div id="add-agent-msg"></div>
+    </div>
+  </div>
 </div>
 <script src="app.js"></script>
 </body>

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -1,269 +1,610 @@
-/* Carrier WebUI — Dark Theme */
 :root {
-  --bg: #1a1a2e;
-  --card: #16213e;
-  --accent: #0f3460;
-  --accent-light: #533483;
-  --accent-hover: #1a4a8a;
-  --text: #e0e0e0;
-  --text-dim: #8b8fa3;
-  --border: #2e3345;
-  --surface: #1e2235;
-  --success: #34d399;
-  --error: #f87171;
-  --warning: #fbbf24;
-  --radius: 8px;
+  --bg-top: #f4f6fb;
+  --bg-bottom: #e9eef8;
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-strong: rgba(255, 255, 255, 0.9);
+  --surface-muted: rgba(246, 248, 252, 0.9);
+  --text: #0f172a;
+  --text-dim: #5f6b7f;
+  --line: rgba(26, 40, 66, 0.12);
+  --line-strong: rgba(26, 40, 66, 0.18);
+  --accent: #0071e3;
+  --accent-press: #005fc1;
+  --success: #15803d;
+  --error: #b42318;
+  --warning: #b45309;
+  --radius-xl: 24px;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --shadow-lg: 0 28px 64px rgba(22, 40, 80, 0.14);
+  --shadow-md: 0 16px 32px rgba(22, 40, 80, 0.1);
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: var(--bg);
+  font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", sans-serif;
   color: var(--text);
   min-height: 100vh;
+  background:
+    radial-gradient(1200px 600px at -5% -20%, rgba(0, 113, 227, 0.14), transparent 70%),
+    radial-gradient(900px 550px at 110% -10%, rgba(49, 130, 206, 0.12), transparent 70%),
+    linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
 }
 
 #app {
-  max-width: 960px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 1rem;
+  padding: 20px;
 }
 
-/* Header */
 header {
+  position: sticky;
+  top: 10px;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 1.5rem;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 14px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, 0.58);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 22px;
 }
-.header-left { display: flex; align-items: center; gap: 1.5rem; }
-.header-right { display: flex; align-items: center; gap: 0.75rem; }
-header h1 { font-size: 1.3rem; white-space: nowrap; }
+
+.header-left,
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+header h1 {
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+  font-weight: 650;
+  white-space: nowrap;
+}
 
 nav {
-  display: flex;
-  gap: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.64);
 }
-.nav-link {
-  padding: 0.4rem 0.75rem;
-  border-radius: var(--radius);
-  color: var(--text-dim);
-  text-decoration: none;
-  font-size: 0.85rem;
-  transition: background 0.15s, color 0.15s;
-}
-.nav-link:hover { background: var(--surface); color: var(--text); }
-.nav-link.active { background: var(--accent); color: #fff; }
 
-/* Badge */
+.nav-link {
+  text-decoration: none;
+  color: var(--text-dim);
+  font-size: 0.84rem;
+  font-weight: 560;
+  padding: 8px 12px;
+  border-radius: 999px;
+  transition: all 140ms ease;
+}
+
+.nav-link:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.nav-link.active {
+  color: #fff;
+  background: linear-gradient(180deg, #2586ec, #006ee2);
+  box-shadow: 0 8px 20px rgba(0, 113, 227, 0.26);
+}
+
 .badge {
-  padding: 0.2rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
   border-radius: 999px;
   font-size: 0.75rem;
-  font-weight: 500;
+  font-weight: 600;
+  border: 1px solid transparent;
 }
-.badge-ok { background: #1a3a2a; color: var(--success); }
-.badge-error { background: #3a1a1a; color: var(--error); }
-.badge-unknown { background: var(--surface); color: var(--text-dim); }
 
-.hidden { display: none !important; }
-.text-dim { color: var(--text-dim); }
+.badge-ok {
+  color: #0f6d34;
+  background: rgba(22, 163, 74, 0.12);
+  border-color: rgba(22, 163, 74, 0.22);
+}
 
-/* Overlay */
+.badge-error {
+  color: #a1121a;
+  background: rgba(239, 68, 68, 0.11);
+  border-color: rgba(239, 68, 68, 0.22);
+}
+
+.badge-unknown {
+  color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.62);
+  border-color: var(--line);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.text-dim {
+  color: var(--text-dim);
+}
+
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.7);
+  z-index: 90;
+  background: rgba(10, 18, 33, 0.36);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  padding: 16px;
 }
-.login-card {
-  width: 100%;
-  max-width: 380px;
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  padding: 22px;
+}
+
+.card h3 {
+  font-size: 1.08rem;
+  margin-bottom: 12px;
+  font-weight: 650;
+}
+
+.center-card {
+  max-width: 600px;
+  margin: 30px auto;
   text-align: center;
 }
-.login-card h2 { margin-bottom: 0.5rem; }
-.login-card p { margin-bottom: 1rem; }
-.login-card input { margin-bottom: 0.75rem; }
-.login-card button { width: 100%; }
 
-/* Steps indicator */
+.login-card {
+  width: min(100%, 420px);
+  text-align: center;
+}
+
+.login-card h2 {
+  margin-bottom: 8px;
+  font-size: 1.3rem;
+}
+
+.login-card p {
+  margin-bottom: 16px;
+}
+
 .steps-indicator {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
   justify-content: center;
+  gap: 8px;
+  margin-bottom: 16px;
 }
+
 .step-dot {
-  width: 3rem;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--border);
-  transition: background 0.2s;
+  width: 48px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(22, 40, 80, 0.16);
+  transition: all 180ms ease;
 }
-.step-dot.active { background: var(--accent-light); }
-.step-dot.done { background: var(--success); }
 
-/* Cards */
-.card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.5rem;
+.step-dot.active {
+  background: rgba(0, 113, 227, 0.86);
 }
-.card h3 { margin-bottom: 1rem; font-size: 1.1rem; }
-.center-card { text-align: center; max-width: 500px; margin: 2rem auto; }
 
-/* Forms */
+.step-dot.done {
+  background: rgba(16, 185, 129, 0.82);
+}
+
 label {
   display: block;
-  font-size: 0.85rem;
+  font-size: 0.84rem;
   color: var(--text-dim);
-  margin-bottom: 0.25rem;
-  margin-top: 0.75rem;
+  font-weight: 560;
+  margin-top: 12px;
+  margin-bottom: 5px;
 }
 
-select, input[type="text"], input[type="password"] {
+input[type="text"],
+input[type="password"],
+select {
   width: 100%;
-  padding: 0.6rem 0.75rem;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
   color: var(--text);
   font-size: 0.95rem;
+  padding: 11px 12px;
   outline: none;
-  transition: border 0.15s;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
-select:focus, input:focus { border-color: var(--accent-light); }
 
-/* Buttons */
-button, .btn {
-  display: inline-block;
-  padding: 0.6rem 1.25rem;
-  border: none;
-  border-radius: var(--radius);
-  font-size: 0.9rem;
-  font-weight: 500;
-  cursor: pointer;
-  background: var(--accent);
+input:focus,
+select:focus {
+  border-color: rgba(0, 113, 227, 0.55);
+  box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.12);
+}
+
+button,
+.btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #1a82eb, #006ee2);
   color: #fff;
-  transition: background 0.15s;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+  box-shadow: 0 8px 16px rgba(0, 113, 227, 0.22);
 }
-button:hover { background: var(--accent-hover); }
-button:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.btn-row { display: flex; gap: 0.5rem; margin-top: 1rem; }
+button:hover,
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+button:active,
+.btn:active {
+  transform: translateY(0);
+  background: linear-gradient(180deg, #1575d4, var(--accent-press));
+}
+
+button:disabled,
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
 
 .btn-secondary {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.74);
   color: var(--text);
+  border-color: var(--line);
+  box-shadow: none;
 }
-.btn-secondary:hover { background: var(--border); }
 
-.btn-danger { background: var(--error); }
-.btn-danger:hover { background: #ef4444; }
+.btn-secondary:hover {
+  background: #fff;
+}
 
-.btn-sm { padding: 0.35rem 0.75rem; font-size: 0.8rem; }
+.btn-danger {
+  background: linear-gradient(180deg, #ef5a5a, #d92f2f);
+  border-color: rgba(180, 35, 24, 0.3);
+  box-shadow: 0 10px 18px rgba(185, 28, 28, 0.2);
+}
 
-/* Agent grid */
+.btn-sm {
+  font-size: 0.78rem;
+  padding: 7px 11px;
+}
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+#setup-telegram-pair {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .agent-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
 }
+
 .agent-card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1rem;
-  cursor: pointer;
-  transition: border-color 0.15s;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: var(--shadow-md);
+  padding: 16px;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
 }
-.agent-card:hover { border-color: var(--accent-light); }
-.agent-card h4 { margin-bottom: 0.5rem; }
-.agent-status { font-size: 0.85rem; color: var(--text-dim); margin-bottom: 0.75rem; }
 
-/* Agent select list */
-.agent-select-list { list-style: none; }
+.agent-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-lg);
+}
+
+.agent-card h4 {
+  font-size: 1rem;
+  font-weight: 650;
+  margin-bottom: 6px;
+  word-break: break-word;
+}
+
+.agent-status {
+  color: var(--text-dim);
+  font-size: 0.86rem;
+  margin-bottom: 8px;
+}
+
+.instance-meta {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  margin-bottom: 10px;
+  line-height: 1.35;
+}
+
+.agent-select-list {
+  list-style: none;
+  margin-top: 10px;
+}
+
 .agent-select-list li {
-  padding: 0.6rem 0.75rem;
-  margin-bottom: 0.25rem;
-  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+  padding: 10px 12px;
+  margin-bottom: 8px;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: border-color 120ms ease, background 120ms ease;
 }
-.agent-select-list li:hover { background: var(--surface); }
-.agent-select-list li.selected { background: var(--accent); color: #fff; }
 
-/* Env rows */
+.agent-select-list li:hover {
+  border-color: rgba(0, 113, 227, 0.45);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.agent-select-list li.selected {
+  border-color: rgba(0, 113, 227, 0.62);
+  background: rgba(0, 113, 227, 0.12);
+}
+
+.provider-category {
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+  margin-top: 10px;
+}
+
+#provider-add-choice {
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted);
+}
+
+#provider-add-choice h4 {
+  margin-bottom: 8px;
+  font-size: 0.9rem;
+  font-weight: 620;
+}
+
+#provider-other-wrap {
+  margin-top: 10px;
+}
+
+.provider-category h4 {
+  margin-bottom: 8px;
+  font-size: 0.88rem;
+  color: var(--text-dim);
+  font-weight: 620;
+}
+
+.provider-list {
+  list-style: none;
+}
+
+.provider-item {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: var(--surface-strong);
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.provider-item:hover {
+  border-color: rgba(0, 113, 227, 0.5);
+}
+
+.provider-item.selected {
+  border-color: rgba(0, 113, 227, 0.66);
+  background: rgba(0, 113, 227, 0.1);
+}
+
+.auth-badge {
+  color: #165eb0;
+  background: rgba(0, 113, 227, 0.12);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  border: 1px solid rgba(0, 113, 227, 0.18);
+}
+
 .env-row {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: 8px;
+  margin-bottom: 8px;
 }
-.env-row input { flex: 1; }
 
-/* Logs */
+.env-row input {
+  flex: 1;
+}
+
 .log-controls {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  margin-bottom: 0.75rem;
   flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
 }
-.log-controls select { width: auto; min-width: 150px; }
-.log-controls label { margin: 0; }
+
+.log-controls label {
+  margin: 0;
+}
+
+.log-controls select {
+  width: auto;
+  min-width: 220px;
+}
 
 .log-box {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1rem;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 0.8rem;
-  min-height: 300px;
-  max-height: 500px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  color: var(--text-dim);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(9, 16, 29, 0.86);
+  color: #e2edff;
+  font-family: "SF Mono", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  min-height: 320px;
+  max-height: 540px;
+  overflow: auto;
+  padding: 12px;
 }
 
-/* Chat */
 .chat-messages {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
   min-height: 300px;
-  max-height: 400px;
-  overflow-y: auto;
-  margin-bottom: 0.75rem;
+  max-height: 420px;
+  overflow: auto;
+  padding: 12px;
+  margin-bottom: 10px;
 }
-.chat-msg { margin-bottom: 0.5rem; font-size: 0.9rem; }
-.chat-msg .sender { font-weight: 600; color: var(--accent-light); }
-.chat-msg .body { color: var(--text); }
 
-.chat-input-row { display: flex; gap: 0.5rem; }
-.chat-input-row input { flex: 1; }
+.chat-msg {
+  margin-bottom: 7px;
+  font-size: 0.92rem;
+}
 
-/* Messages */
-.msg-info { color: var(--accent-light); font-size: 0.85rem; margin-top: 0.5rem; }
-.msg-error { color: var(--error); font-size: 0.85rem; margin-top: 0.5rem; }
-.msg-success { color: var(--success); font-size: 0.85rem; margin-top: 0.5rem; }
+.chat-msg .sender {
+  color: #0b63bd;
+  font-weight: 650;
+}
 
-/* Responsive */
-@media (max-width: 600px) {
-  #app { padding: 0.5rem; }
-  header h1 { font-size: 1.1rem; }
-  .header-left { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
-  .agent-grid { grid-template-columns: 1fr; }
-  nav { flex-wrap: wrap; }
+.chat-msg .body {
+  color: var(--text);
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input-row input {
+  flex: 1;
+}
+
+.msg-info,
+.msg-error,
+.msg-success {
+  margin-top: 9px;
+  font-size: 0.84rem;
+}
+
+.msg-info {
+  color: #0f60b8;
+}
+
+.msg-error {
+  color: var(--error);
+}
+
+.msg-success {
+  color: var(--success);
+}
+
+.modal-card {
+  width: min(100%, 520px);
+}
+
+@media (max-width: 860px) {
+  #app {
+    padding: 14px;
+  }
+
+  header {
+    top: 0;
+    border-radius: 18px;
+    padding: 12px;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .header-left,
+  .header-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav-link {
+    flex: 1;
+    text-align: center;
+    padding: 8px 10px;
+  }
+
+  .section-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .agent-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .env-row,
+  .chat-input-row {
+    flex-direction: column;
+  }
+
+  .btn-row {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- add unified Carrier bootstrap/onboard runtime flow with background daemon+gateway management and clearer TUI guidance
- introduce managed add/install flows for agents (focus on PicoClaw) across TUI and WebUI, including credential reuse and pairing-aware state
- add base-agent runtime capabilities for installed-agent management inside daemon
- extend gateway/webui APIs for add, instances, pairing sessions, and Telegram pairing transport handling
- add e2e coverage for add picoclaw in both backend/API and Playwright WebUI flow

## Validation
- go test ./cmd/carrier
- (cd daemon && go test ./internal/gateway)
- (cd webui/e2e && bun run test tests/add-picoclaw.spec.ts)
