### PR TITLE
ci(release): ship binary-only artifacts named carrier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,19 +199,17 @@ jobs:
         run: |
           set -euo pipefail
           archive_name="${{ needs.prepare.outputs.package_prefix }}-${{ matrix.label }}"
-          binary_name="agentd${{ matrix.ext }}"
-          release_dir="dist/${archive_name}"
+          binary_name="carrier${{ matrix.ext }}"
           package_file="${archive_name}.${{ matrix.archive_ext }}"
 
-          mkdir -p "${release_dir}"
+          mkdir -p dist
 
           (cd daemon && \
             CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
-              go build -tags webui -trimpath -ldflags="-s -w" -o "../${release_dir}/${binary_name}" ./cmd/agentd)
+              go build -tags webui -trimpath -ldflags="-s -w" -o "../dist/${binary_name}" ./cmd/agentd)
 
-          cp -R daemon catalog gateway docs README.md "${release_dir}/"
-
-          (cd dist && zip -r "${package_file}" "${archive_name}")
+          # Release package should contain only the executable binary.
+          (cd dist && zip -j "${package_file}" "${binary_name}")
           (cd dist && sha256sum "${package_file}" > "${package_file}.sha256")
 
           echo "archive_name=${archive_name}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- update release packaging to output binary-only artifacts
- rename packaged executable from `agentd` to `carrier` (and `carrier.exe` on Windows)
- stop copying repository source directories into release archives

## Why
Current CI build artifacts are valid builds, but their package layout does not match the intended distribution shape. This change aligns release artifacts with the desired format: executable-only payload.

## Validation
- local smoke build/package (linux-x64) using workflow-equivalent commands
- verified zip content contains exactly one file: `carrier`
