### PR TITLE
docs: add audit snapshot artifact (preserve canonical index)

### DIFF
--- a/docs/audit-snapshot.md
+++ b/docs/audit-snapshot.md
@@ -2,15 +2,15 @@
 
 > Generated snapshot artifact. This file is audit output and does not replace `docs/current-architecture.md`.
 
-- generated_at_utc: 2026-02-22T05:01:46Z
-- repository: Keith-CY/carrier
-- branch: main
+- **generated_at_utc**: 2026-02-22T05:01:46Z
+- **repository**: Keith-CY/carrier
+- **branch**: main
 
 ## Metrics
-- superseded/diverged docs: 4
-- docs TODO/TBD/FIXME: 0
-- core TODO/FIXME (excluding docs): 1
-- test files discovered: 83
+- **superseded/diverged docs**: 4
+- **docs TODO/TBD/FIXME**: 0
+- **core TODO/FIXME (excluding docs)**: 1
+- **test files discovered**: 83
 
 ## Open Improvement Tracks
-- https://github.com/Keith-CY/carrier/issues/1272
+- [#1272](https://github.com/Keith-CY/carrier/issues/1272)


### PR DESCRIPTION
## Summary
- add `docs/audit-snapshot.md` as generated audit artifact
- keep `docs/current-architecture.md` untouched as curated canonical index

## Why
Prior approach in #1273 overwrote canonical navigation content. This PR preserves canonical docs while still publishing audit metrics.