### PR TITLE
feat(webui): structured logs view with filter/search/pause

### DIFF
--- a/webui/e2e/tests/helpers.ts
+++ b/webui/e2e/tests/helpers.ts
@@ -1,12 +1,26 @@
 import { Page } from '@playwright/test';
 
 export const TEST_TOKEN = 'test-token-valid';
+export const MOCK_LOG_STREAM_LINES = [
+  '{"time":"2026-02-22T10:00:00.000Z","level":"INFO","message":"agent started"}',
+  '[DEBUG] worker heartbeat',
+  '2026-02-22T10:00:01.000Z WARN queue depth high',
+  '2026-02-22T10:00:02.000Z ERROR request failed',
+];
 
 export const MOCK_AGENTS = [
   { id: 'agent-alpha', name: 'agent-alpha', runtime: 'running' },
   { id: 'agent-beta', name: 'agent-beta', runtime: 'error' },
   { id: 'agent-gamma', name: 'agent-gamma', runtime: 'stopped' },
 ];
+
+export const MOCK_INSTANCES = MOCK_AGENTS.map((agent, idx) => ({
+  id: `instance-${idx + 1}`,
+  agent_id: agent.id,
+  runtime_state: agent.runtime,
+  provider: 'openai',
+  channel: 'telegram',
+}));
 
 /** Set up standard API mocks so the app works without a real daemon. */
 export async function mockAPIs(page: Page, opts?: { healthOk?: boolean }) {
@@ -30,6 +44,21 @@ export async function mockAPIs(page: Page, opts?: { healthOk?: boolean }) {
     }
     return route.continue();
   });
+
+  await page.route('**/api/v1/instances', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_INSTANCES),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.route('**/api/v1/instances/*/*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+  );
 
   await page.route('**/api/v1/agents/*/install', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
@@ -78,7 +107,7 @@ export async function mockAPIs(page: Page, opts?: { healthOk?: boolean }) {
     route.fulfill({
       status: 200,
       contentType: 'text/event-stream',
-      body: 'data: [INFO] log line 1\n\ndata: [INFO] log line 2\n\n',
+      body: MOCK_LOG_STREAM_LINES.map((line) => `data: ${line}\n\n`).join(''),
     }),
   );
 }

--- a/webui/e2e/tests/logs.spec.ts
+++ b/webui/e2e/tests/logs.spec.ts
@@ -7,30 +7,87 @@ test.describe('Logs', () => {
     await loginWithToken(page, '/#/logs');
   });
 
-  test('shows agent selector and Connect button', async ({ page }) => {
+  test('shows structured logs controls', async ({ page }) => {
     await expect(page.locator('#log-agent')).toBeVisible();
     await expect(page.locator('#log-connect')).toBeVisible();
+    await expect(page.locator('#log-clear')).toBeVisible();
+    await expect(page.locator('#log-pause')).toBeVisible();
+    await expect(page.locator('#log-search')).toBeVisible();
+    await expect(page.locator('#log-filter-debug')).toBeVisible();
+    await expect(page.locator('#log-filter-info')).toBeVisible();
+    await expect(page.locator('#log-filter-warn')).toBeVisible();
+    await expect(page.locator('#log-filter-error')).toBeVisible();
   });
 
-  test('Connect shows log output', async ({ page }) => {
-    // Wait for agent dropdown to be populated
-    await expect(page.locator('#log-agent option')).not.toHaveCount(0);
-
-    await page.click('#log-connect');
-
-    // Log output should have content (from SSE mock or poll fallback)
-    const logOutput = page.locator('#log-output');
-    await expect(logOutput).not.toBeEmpty();
-  });
-
-  test('Clear button empties log output', async ({ page }) => {
+  test('Connect renders structured log rows', async ({ page }) => {
     await expect(page.locator('#log-agent option')).not.toHaveCount(0);
     await page.click('#log-connect');
 
+    const rows = page.locator('#log-output .log-row-data');
+    await expect(rows.first()).toBeVisible();
+    await expect(page.locator('#log-output .log-row-data .log-cell-time').first()).toContainText('2026-02-22');
+    await expect(page.locator('#log-output .log-row-data[data-level="INFO"] .log-cell-message')).toContainText('agent started');
+  });
+
+  test('level filter hides unchecked levels', async ({ page }) => {
+    await expect(page.locator('#log-agent option')).not.toHaveCount(0);
+    await page.click('#log-connect');
+
+    await expect(page.locator('#log-output')).toContainText('request failed');
+    await page.uncheck('#log-filter-error');
+    await expect(page.locator('#log-output')).not.toContainText('request failed');
+    await expect(page.locator('#log-output')).toContainText('queue depth high');
+  });
+
+  test('search filters rows and highlights matches', async ({ page }) => {
+    await expect(page.locator('#log-agent option')).not.toHaveCount(0);
+    await page.click('#log-connect');
+
+    await page.fill('#log-search', 'failed');
+    await expect(page.locator('#log-output .log-row-data')).toHaveCount(1);
+    await expect(page.locator('#log-output .log-row-data .log-cell-message')).toContainText('request failed');
+    await expect(page.locator('#log-output mark.log-highlight')).toContainText('failed');
+  });
+
+  test('Pause buffers incoming logs and Resume flushes them', async ({ page }) => {
+    await page.route('**/api/v1/logs/stream*', (route) => route.abort('connectionrefused'));
+
+    let pollCount = 0;
+    await page.route('**/api/v1/agents/*/logs', (route) => {
+      pollCount++;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ lines: [`[INFO] poll cycle ${pollCount}`] }),
+      });
+    });
+
+    await expect(page.locator('#log-agent option')).not.toHaveCount(0);
+    await page.click('#log-connect');
+
     const logOutput = page.locator('#log-output');
-    await expect(logOutput).not.toBeEmpty();
+    await expect(logOutput).toContainText('poll cycle 1', { timeout: 5000 });
+
+    await page.click('#log-pause');
+    await expect(page.locator('#log-pause')).toContainText('Resume');
+
+    await page.waitForTimeout(2500);
+    expect(pollCount).toBeGreaterThanOrEqual(2);
+    await expect(logOutput).not.toContainText('poll cycle 2');
+
+    await page.click('#log-pause');
+    await expect(page.locator('#log-pause')).toContainText('Pause');
+    await expect(logOutput).toContainText('poll cycle 2', { timeout: 3000 });
+  });
+
+  test('Clear button empties structured log output', async ({ page }) => {
+    await expect(page.locator('#log-agent option')).not.toHaveCount(0);
+    await page.click('#log-connect');
+
+    await expect(page.locator('#log-output .log-row-data')).not.toHaveCount(0);
 
     await page.click('#log-clear');
-    await expect(logOutput).toBeEmpty();
+    await expect(page.locator('#log-output .log-row-data')).toHaveCount(0);
+    await expect(page.locator('#log-output')).toBeEmpty();
   });
 });

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -22,6 +22,17 @@
   let addPairPollRunID = 0;
   let lastAddResult = null;
   let logSource = null; // EventSource for SSE logs
+  let logEntries = [];
+  let logBuffer = [];
+  let logPaused = false;
+  let logSearchQuery = '';
+  let logHandlersBound = false;
+  let logEntrySeq = 1;
+  let logLastPolledLines = [];
+  let logStatusBase = 'Select an agent and click Connect.';
+  const logLevelFilters = { DEBUG: true, INFO: true, WARN: true, ERROR: true };
+  const LOG_FILTER_LEVELS = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
+  const LOG_ENTRY_LIMIT = 2000;
 
   // --- Helpers ---
   function escapeHtml(s) {
@@ -1290,6 +1301,10 @@
   function initLogs() {
     showView('logs');
     $('#nav').classList.remove('hidden');
+    bindLogsControls();
+    syncLogControls();
+    renderLogRows(false);
+
     const agentSelect = $('#log-agent');
     agentSelect.textContent = '';
 
@@ -1306,24 +1321,73 @@
         agentSelect.appendChild(opt);
       });
     }).catch(() => {});
+  }
 
-    $('#log-clear').onclick = () => {
-      $('#log-output').textContent = '';
-    };
+  function bindLogsControls() {
+    if (logHandlersBound) return;
+    logHandlersBound = true;
 
-    $('#log-connect').onclick = () => {
-      connectLogs(agentSelect.value);
-    };
+    $('#log-clear').addEventListener('click', () => {
+      clearLogs();
+      renderLogRows(true);
+    });
+
+    $('#log-connect').addEventListener('click', () => {
+      connectLogs($('#log-agent').value);
+    });
+
+    $('#log-pause').addEventListener('click', toggleLogPause);
+
+    $('#log-search').addEventListener('input', (e) => {
+      logSearchQuery = (e.target.value || '').trim().toLowerCase();
+      renderLogRows(false);
+    });
+
+    LOG_FILTER_LEVELS.forEach(level => {
+      const input = $('#log-filter-' + level.toLowerCase());
+      if (!input) return;
+      input.addEventListener('change', () => {
+        logLevelFilters[level] = !!input.checked;
+        renderLogRows(false);
+      });
+    });
+  }
+
+  function syncLogControls() {
+    LOG_FILTER_LEVELS.forEach(level => {
+      const input = $('#log-filter-' + level.toLowerCase());
+      if (!input) return;
+      input.checked = !!logLevelFilters[level];
+    });
+    const searchInput = $('#log-search');
+    if (searchInput) searchInput.value = logSearchQuery;
+    updateLogPauseButton();
+    refreshLogStatus(getVisibleLogEntries().length);
+  }
+
+  function clearLogs() {
+    logEntries = [];
+    logBuffer = [];
+    logEntrySeq = 1;
+    logLastPolledLines = [];
   }
 
   function connectLogs(agentId) {
+    if (!agentId) {
+      logStatusBase = 'Select an agent and click Connect.';
+      refreshLogStatus(getVisibleLogEntries().length);
+      return;
+    }
     if (logSource) {
       logSource.close();
       logSource = null;
     }
 
-    const output = $('#log-output');
-    output.textContent = 'Connecting to logs for ' + agentId + '…\n';
+    clearLogs();
+    logPaused = false;
+    updateLogPauseButton();
+    logStatusBase = 'Connecting to ' + agentId + '…';
+    renderLogRows(true);
 
     // Try SSE first
     let sseUrl = '/api/v1/logs/stream?agent=' + encodeURIComponent(agentId);
@@ -1332,45 +1396,259 @@
       const es = new EventSource(sseUrl);
       logSource = es;
 
+      es.onopen = () => {
+        logStatusBase = 'Connected to ' + agentId + ' via SSE.';
+        refreshLogStatus(getVisibleLogEntries().length);
+      };
+
       es.onmessage = (e) => {
-        output.textContent += e.data + '\n';
-        output.scrollTop = output.scrollHeight;
+        ingestLogLines([e.data], true);
       };
 
       es.onerror = () => {
+        if (logSource !== es) return;
         es.close();
         logSource = null;
-        output.textContent += '\n[SSE disconnected, falling back to polling]\n';
+        addSystemLog('SSE disconnected, falling back to polling.', 'WARN');
         pollLogs(agentId);
       };
-    } catch (e) {
+    } catch (_) {
+      addSystemLog('SSE unavailable, using polling.', 'WARN');
       pollLogs(agentId);
     }
   }
 
   function pollLogs(agentId) {
-    const output = $('#log-output');
     let running = true;
 
     // Store cancel function
     const cancel = () => { running = false; };
     logSource = { close: cancel };
+    logStatusBase = 'Connected to ' + agentId + ' via polling.';
+    refreshLogStatus(getVisibleLogEntries().length);
 
     const poll = async () => {
       if (!running) return;
       try {
         const res = await api('GET', '/api/v1/agents/' + encodeURIComponent(agentId) + '/logs');
-        const lines = res.lines || [];
-        if (lines.length) {
-          output.textContent += lines.join('\n') + '\n';
-          output.scrollTop = output.scrollHeight;
-        }
+        const lines = Array.isArray(res.lines) ? res.lines : [];
+        const normalized = normalizeLineList(lines);
+        const appended = diffAppendedLines(logLastPolledLines, normalized);
+        logLastPolledLines = normalized;
+        ingestLogLines(appended, true);
       } catch (e) {
-        output.textContent += '[poll error: ' + e.message + ']\n';
+        addSystemLog('poll error: ' + e.message, 'ERROR');
       }
       if (running) setTimeout(poll, 2000);
     };
     poll();
+  }
+
+  function normalizeLineList(lines) {
+    return lines.map(line => String(line == null ? '' : line)).filter(line => line.trim().length > 0);
+  }
+
+  function diffAppendedLines(previous, next) {
+    if (!next.length) return [];
+    if (!previous.length) return next;
+
+    const maxOverlap = Math.min(previous.length, next.length);
+    for (let overlap = maxOverlap; overlap >= 1; overlap--) {
+      let same = true;
+      for (let i = 0; i < overlap; i++) {
+        if (previous[previous.length - overlap + i] !== next[i]) {
+          same = false;
+          break;
+        }
+      }
+      if (same) return next.slice(overlap);
+    }
+    return next;
+  }
+
+  function normalizeLogLevel(level) {
+    const raw = String(level || '').trim().toUpperCase();
+    if (!raw) return 'UNKNOWN';
+    if (raw === 'WARNING') return 'WARN';
+    if (raw === 'ERR') return 'ERROR';
+    if (raw === 'TRACE') return 'DEBUG';
+    return LOG_FILTER_LEVELS.includes(raw) ? raw : 'UNKNOWN';
+  }
+
+  function createLogEntry(level, message, timestamp) {
+    return {
+      id: logEntrySeq++,
+      timestamp: timestamp && String(timestamp).trim() ? String(timestamp).trim() : new Date().toISOString(),
+      level: normalizeLogLevel(level),
+      message: String(message == null ? '' : message),
+    };
+  }
+
+  function addSystemLog(message, level) {
+    appendLogEntries([createLogEntry(level || 'INFO', message)]);
+  }
+
+  function parseLogLine(line) {
+    const rawLine = String(line == null ? '' : line);
+    const trimmed = rawLine.trim();
+    if (!trimmed) return null;
+    if (/^returned \d+ log lines for /i.test(trimmed)) return null;
+
+    let timestamp = '';
+    let level = 'UNKNOWN';
+    let message = trimmed;
+
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          timestamp = String(parsed.time || parsed.timestamp || parsed.ts || '').trim();
+          level = normalizeLogLevel(parsed.level || parsed.severity || parsed.lvl);
+          const msg = parsed.message !== undefined ? parsed.message : (parsed.msg !== undefined ? parsed.msg : parsed.text);
+          if (msg !== undefined) {
+            message = typeof msg === 'string' ? msg : JSON.stringify(msg);
+          }
+        }
+      } catch (_) {
+        // keep parsing with non-JSON heuristics
+      }
+    }
+
+    if (level === 'UNKNOWN') {
+      const bracketMatch = trimmed.match(/^\[([A-Za-z]+)\]\s*(.*)$/);
+      if (bracketMatch) {
+        level = normalizeLogLevel(bracketMatch[1]);
+        message = (bracketMatch[2] || '').trim();
+      }
+    }
+
+    if (!timestamp) {
+      const timedMatch = trimmed.match(/^([0-9]{4}-[0-9]{2}-[0-9]{2}[T ][^\s]+)\s+([A-Za-z]+)\s*(.*)$/);
+      if (timedMatch) {
+        timestamp = timedMatch[1].trim();
+        level = normalizeLogLevel(timedMatch[2]);
+        message = (timedMatch[3] || '').trim();
+      }
+    }
+
+    return createLogEntry(level, message || trimmed, timestamp);
+  }
+
+  function ingestLogLines(lines, stickToBottom) {
+    if (!lines || !lines.length) return;
+    if (logPaused) {
+      lines.forEach(line => {
+        if (line == null) return;
+        logBuffer.push(String(line));
+      });
+      refreshLogStatus(getVisibleLogEntries().length);
+      return;
+    }
+    const parsed = [];
+    lines.forEach(line => {
+      const entry = parseLogLine(line);
+      if (entry) parsed.push(entry);
+    });
+    appendLogEntries(parsed, stickToBottom);
+  }
+
+  function appendLogEntries(entries, stickToBottom) {
+    if (!entries || !entries.length) return;
+    const output = $('#log-output');
+    if (!output) return;
+    const shouldStick = stickToBottom || (output.scrollHeight - output.scrollTop - output.clientHeight < 24);
+    logEntries = logEntries.concat(entries);
+    if (logEntries.length > LOG_ENTRY_LIMIT) {
+      logEntries = logEntries.slice(logEntries.length - LOG_ENTRY_LIMIT);
+    }
+    renderLogRows(shouldStick);
+  }
+
+  function toggleLogPause() {
+    logPaused = !logPaused;
+    updateLogPauseButton();
+
+    if (!logPaused && logBuffer.length) {
+      const buffered = logBuffer.slice();
+      logBuffer = [];
+      ingestLogLines(buffered, true);
+      return;
+    }
+    refreshLogStatus(getVisibleLogEntries().length);
+  }
+
+  function updateLogPauseButton() {
+    const btn = $('#log-pause');
+    if (!btn) return;
+    btn.textContent = logPaused ? 'Resume' : 'Pause';
+  }
+
+  function getVisibleLogEntries() {
+    return logEntries.filter(entry => {
+      if (Object.prototype.hasOwnProperty.call(logLevelFilters, entry.level) && !logLevelFilters[entry.level]) {
+        return false;
+      }
+      if (!logSearchQuery) return true;
+      const haystack = (entry.timestamp + ' ' + entry.level + ' ' + entry.message).toLowerCase();
+      return haystack.includes(logSearchQuery);
+    });
+  }
+
+  function highlightLogText(text, query) {
+    const source = String(text == null ? '' : text);
+    if (!query) return escapeHtml(source);
+
+    const lower = source.toLowerCase();
+    let i = 0;
+    let html = '';
+    while (i < source.length) {
+      const idx = lower.indexOf(query, i);
+      if (idx === -1) {
+        html += escapeHtml(source.slice(i));
+        break;
+      }
+      html += escapeHtml(source.slice(i, idx));
+      html += '<mark class="log-highlight">' + escapeHtml(source.slice(idx, idx + query.length)) + '</mark>';
+      i = idx + query.length;
+    }
+    return html;
+  }
+
+  function renderLogRows(stickToBottom) {
+    const output = $('#log-output');
+    if (!output) return;
+
+    const visible = getVisibleLogEntries();
+    if (!visible.length) {
+      output.textContent = '';
+      refreshLogStatus(0);
+      return;
+    }
+
+    const query = logSearchQuery;
+    output.innerHTML = visible.map(entry =>
+      '<div class="log-row log-row-data" data-level="' + escapeHtml(entry.level) + '">' +
+        '<span class="log-cell-time">' + highlightLogText(entry.timestamp, query) + '</span>' +
+        '<span class="log-cell-level"><span class="log-level-pill">' + highlightLogText(entry.level, query) + '</span></span>' +
+        '<span class="log-cell-message">' + highlightLogText(entry.message, query) + '</span>' +
+      '</div>'
+    ).join('');
+
+    if (stickToBottom) output.scrollTop = output.scrollHeight;
+    refreshLogStatus(visible.length);
+  }
+
+  function refreshLogStatus(visibleCount) {
+    const status = $('#log-status');
+    if (!status) return;
+    const visible = typeof visibleCount === 'number' ? visibleCount : getVisibleLogEntries().length;
+    const parts = [logStatusBase];
+    if (logEntries.length > 0) {
+      parts.push('showing ' + visible + '/' + logEntries.length);
+    }
+    if (logPaused) parts.push('paused');
+    if (logBuffer.length) parts.push('buffered ' + logBuffer.length);
+    status.textContent = parts.filter(Boolean).join(' · ');
   }
 
   // --- Chat ---

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -181,9 +181,25 @@
         <label for="log-agent">Agent:</label>
         <select id="log-agent"></select>
         <button id="log-connect" class="btn-sm">Connect</button>
-        <button id="log-clear" class="btn-sm btn-secondary">Clear</button>
+        <button id="log-pause" class="btn-sm btn-secondary" type="button">Pause</button>
+        <button id="log-clear" class="btn-sm btn-secondary" type="button">Clear</button>
+        <input id="log-search" type="text" placeholder="Search logs…" autocomplete="off" aria-label="Search logs">
       </div>
-      <pre id="log-output" class="log-box"></pre>
+      <div class="log-filters" role="group" aria-label="Filter log levels">
+        <label class="log-filter-pill"><input id="log-filter-debug" type="checkbox" checked>DEBUG</label>
+        <label class="log-filter-pill"><input id="log-filter-info" type="checkbox" checked>INFO</label>
+        <label class="log-filter-pill"><input id="log-filter-warn" type="checkbox" checked>WARN</label>
+        <label class="log-filter-pill"><input id="log-filter-error" type="checkbox" checked>ERROR</label>
+      </div>
+      <p id="log-status" class="text-dim log-status"></p>
+      <div class="log-table">
+        <div class="log-row log-row-header" aria-hidden="true">
+          <span class="log-cell-time">Timestamp</span>
+          <span class="log-cell-level">Level</span>
+          <span class="log-cell-message">Message</span>
+        </div>
+        <div id="log-output" class="log-rows" role="log" aria-live="polite"></div>
+      </div>
     </section>
 
     <section id="view-chat" class="view hidden">

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -484,6 +484,144 @@ button:disabled,
   min-width: 220px;
 }
 
+.log-controls input[type="text"] {
+  width: min(280px, 100%);
+}
+
+.log-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.log-filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  color: var(--text-dim);
+  font-size: 0.74rem;
+  font-weight: 620;
+  letter-spacing: 0.01em;
+}
+
+.log-filter-pill input {
+  margin: 0;
+}
+
+.log-status {
+  min-height: 1.2em;
+  margin-bottom: 8px;
+  font-size: 0.82rem;
+}
+
+.log-table {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(9, 16, 29, 0.9);
+  color: #e2edff;
+  overflow: hidden;
+}
+
+.log-row {
+  display: grid;
+  grid-template-columns: 188px 86px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 8px 10px;
+  font-family: "SF Mono", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.log-row-header {
+  color: rgba(226, 237, 255, 0.72);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(17, 30, 50, 0.72);
+}
+
+.log-rows {
+  min-height: 320px;
+  max-height: 540px;
+  overflow: auto;
+}
+
+.log-row-data {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.log-row-data:first-child {
+  border-top: 0;
+}
+
+.log-cell-time,
+.log-cell-level {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.log-cell-level {
+  font-weight: 600;
+}
+
+.log-cell-message {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-level-pill {
+  display: inline-block;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 1px 8px;
+}
+
+.log-row-data[data-level="DEBUG"] .log-level-pill {
+  color: #93c5fd;
+  border-color: rgba(59, 130, 246, 0.36);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.log-row-data[data-level="INFO"] .log-level-pill {
+  color: #bbf7d0;
+  border-color: rgba(34, 197, 94, 0.36);
+  background: rgba(22, 163, 74, 0.18);
+}
+
+.log-row-data[data-level="WARN"] .log-level-pill {
+  color: #fde68a;
+  border-color: rgba(245, 158, 11, 0.38);
+  background: rgba(217, 119, 6, 0.2);
+}
+
+.log-row-data[data-level="ERROR"] .log-level-pill {
+  color: #fecaca;
+  border-color: rgba(239, 68, 68, 0.42);
+  background: rgba(220, 38, 38, 0.2);
+}
+
+.log-row-data[data-level="UNKNOWN"] .log-level-pill {
+  color: #cbd5e1;
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(51, 65, 85, 0.24);
+}
+
+.log-highlight {
+  background: rgba(250, 204, 21, 0.35);
+  color: #fff;
+  border-radius: 3px;
+  padding: 0 1px;
+}
+
 .log-box {
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
@@ -602,6 +740,24 @@ button:disabled,
   .env-row,
   .chat-input-row {
     flex-direction: column;
+  }
+
+  .log-controls {
+    align-items: stretch;
+  }
+
+  .log-controls select,
+  .log-controls input[type="text"] {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .log-table {
+    overflow-x: auto;
+  }
+
+  .log-row {
+    min-width: 560px;
   }
 
   .btn-row {


### PR DESCRIPTION
## Summary
- replace raw logs pre block with structured timestamp/level/message rows
- add level filters (DEBUG/INFO/WARN/ERROR), live search, and match highlighting
- add pause/resume buffering so incoming logs are held while paused and flushed on resume
- preserve connect/clear flow and improve logs status feedback
- expand logs e2e coverage for structured rendering, filters, search highlight, pause/resume, and clear behavior

## Verification
- node --check webui/static/app.js
- bunx playwright test tests/logs.spec.ts --config playwright.config.ts --list
- bunx playwright test tests/logs.spec.ts --config playwright.config.ts (fails in sandbox: EPERM listen 0.0.0.0:9090)

Closes #1226