### PR TITLE
ci: package carrier binary and add EC2 TUI validation scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,9 +204,8 @@ jobs:
 
           mkdir -p dist
 
-          (cd daemon && \
-            CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
-              go build -tags webui -trimpath -ldflags="-s -w" -o "../dist/${binary_name}" ./cmd/agentd)
+          CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+            go build -tags webui -trimpath -ldflags="-s -w" -o "dist/${binary_name}" ./cmd/carrier
 
           # Release package should contain only the executable binary.
           (cd dist && zip -j "${package_file}" "${binary_name}")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For product scope/priority decisions, use this order:
 - [Architecture](#architecture)
 - [Repository Map](#repository-map)
 - [Installation and Testing](#installation-and-testing)
+- [EC2 Binary + TUI Validation](#ec2-binary--tui-validation)
 - [Install OpenClaw from Release](#install-openclaw-from-release-package-non-technical-quick-path)
 - [三平台 Bot 管理（中文）](#三平台-bot-管理超详细步骤可直接照做)
 - [Three-Platform Bot Management (English)](#three-platform-bot-management-detailed-step-by-step)
@@ -208,6 +209,23 @@ Target project resolution order:
 Implementation notes:
 - `carrier-kanban-operations.yml` can fall back to the pre-authenticated `github` client from `@actions/github` for repository-scoped calls when an explicit token is not provided.
 - Kanban workflows skip with a warning when `CARRIER_PROJECTS_TOKEN` is missing or project access is unavailable, so unrelated CI checks are not blocked by Kanban configuration gaps.
+
+## EC2 Binary + TUI Validation
+
+- For each push to `main`, release workflow publishes a **pre-release** with tag `main-<full_commit_sha>`.
+- Binary package naming on that tag:
+  - `carrier-main-<full_commit_sha>-linux-x64.zip`
+  - `carrier-main-<full_commit_sha>-windows-x64.zip`
+- Release assets can be downloaded directly from:
+  - `https://github.com/Keith-CY/carrier/releases/download/main-<full_commit_sha>/carrier-main-<full_commit_sha>-<label>.zip`
+- Use TUI flow for onboarding/install on EC2:
+  - `carrier onboard`
+  - `carrier add openclaw`
+- Chat `/install` and `/onboard` are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
+- End-to-end no-rebuild scripts:
+  - Linux: `scripts/ec2-binary-tui-linux.sh`
+  - Windows: `scripts/ec2-binary-tui-windows.ps1`
+- Detailed runbook: `docs/runbooks/ec2-binary-tui-validation.md`
 
 ## Install OpenClaw from release package (non-technical quick path)
 

--- a/docs/ci/release-artifact-retention.md
+++ b/docs/ci/release-artifact-retention.md
@@ -11,10 +11,11 @@ Retention policy is enforced by release workflow and documented here for operato
 
 ## Release Trigger Policy
 
-- Release publication is tag-driven (`v*`) in `.github/workflows/release.yml`.
-- Main-branch pushes do not create GitHub Releases automatically.
+- Published release events (`release.published`) produce release-mode artifacts.
+- Pushes to `main` produce prerelease artifacts under tag `main-<full_commit_sha>`.
+- Pull requests build test packages as workflow artifacts only (no GitHub Release publication).
 
 ## Why this rule
 
 - Time-based retention limits storage for workflow artifacts.
-- Tag-driven releases prevent noisy non-release artifacts on routine main merges.
+- Main push prereleases provide ready-to-test binaries for environments such as EC2.

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -67,6 +67,8 @@ type GatewayResponse = {
 | `E_AUTH_INVALID`                 | Provided session token is invalid                     |
 | `E_PAIR_CODE_INVALID`            | Pairing code is invalid or expired                    |
 | `E_SESSION_REQUIRED`             | Chat is not paired; must run `/pair` first            |
+| `E_INSTALL_GUI_ONLY`            | Chat install is disabled; use Carrier TUI/WebUI       |
+| `E_ONBOARD_GUI_ONLY`            | Chat onboarding is disabled; use Carrier TUI/WebUI    |
 | `E_NOT_INSTALLED`                | Agent is not installed                                |
 | `E_ALREADY_RUNNING`              | Agent is already running                              |
 | `E_ALREADY_STOPPED`              | Agent is already stopped                              |
@@ -107,8 +109,19 @@ Installs an agent.
 
 - **Args:** `agent_id` (required)
 - **Requires session:** yes
-- **Success:** `{ result: "ok", message: "install completed for <agent_id>" }`
-- **Errors:** `E_USAGE`, `E_COMMAND_FAILED`
+- **Current behavior:** chat path is intentionally blocked for credential safety.
+- **Result:** `{ result: "error", errorCode: "E_INSTALL_GUI_ONLY", message: "...Open Carrier GUI to install/onboard agents..." }`
+- **Alternative flows:** `carrier add <agent_id>` (TUI) or WebUI add flow.
+
+### `/onboard`
+
+Starts onboarding.
+
+- **Args:** none
+- **Requires session:** yes
+- **Current behavior:** chat path is intentionally blocked for credential safety.
+- **Result:** `{ result: "error", errorCode: "E_ONBOARD_GUI_ONLY", message: "...Open Carrier GUI..." }`
+- **Alternative flows:** `carrier onboard` (TUI) or `carrier onboard --webui`.
 
 ### `/start <agent_id>`
 

--- a/docs/runbooks/ec2-binary-tui-validation.md
+++ b/docs/runbooks/ec2-binary-tui-validation.md
@@ -1,0 +1,85 @@
+# EC2 Binary + TUI Validation Runbook
+
+Purpose: validate Carrier on EC2 (Linux/Windows) without rebuilding from source, using:
+- `carrier onboard` (TUI)
+- `carrier add openclaw` (TUI)
+
+## 1) Main Push Binary Location
+
+For every push to `main`, `.github/workflows/release.yml` creates a **pre-release**:
+- Tag: `main-<full_commit_sha>`
+- Release name: `main-<full_commit_sha>`
+
+Asset names:
+- `carrier-main-<full_commit_sha>-linux-x64.zip`
+- `carrier-main-<full_commit_sha>-windows-x64.zip`
+- (plus arm64 variants and matching `.sha256/.sig/.sigstore.json`)
+
+Direct download URL pattern:
+
+```text
+https://github.com/Keith-CY/carrier/releases/download/main-<full_commit_sha>/carrier-main-<full_commit_sha>-<label>.zip
+```
+
+Notes:
+- The same workflow also uploads Actions artifacts (retention: 14 days).
+- For EC2 validation, prefer release assets (`releases/download/...`) so no local rebuild is needed.
+
+## 2) Linux EC2 Validation (No Rebuild)
+
+Run on Linux EC2:
+
+```bash
+chmod +x scripts/ec2-binary-tui-linux.sh
+scripts/ec2-binary-tui-linux.sh --sha <full_commit_sha>
+```
+
+Optional non-interactive env:
+
+```bash
+export CARRIER_TELEGRAM_BOT_TOKEN='<telegram bot token>'
+# default provider keeps openai-codex
+# export CARRIER_PROVIDER_OVERRIDE='openai'
+# export CARRIER_PROVIDER_SECRET='<OPENAI_API_KEY>'
+```
+
+If default `openai-codex` is used and no saved credential exists, TUI will print:
+- OAuth URL
+- one-time device code
+
+Complete OAuth in browser while command is waiting.
+
+## 3) Windows EC2 Validation (No Rebuild)
+
+Run in PowerShell (Admin not required):
+
+```powershell
+.\scripts\ec2-binary-tui-windows.ps1 -Sha <full_commit_sha>
+```
+
+Optional non-interactive env:
+
+```powershell
+$env:CARRIER_TELEGRAM_BOT_TOKEN = '<telegram bot token>'
+# default provider keeps openai-codex
+# $env:CARRIER_PROVIDER_OVERRIDE = 'openai'
+# $env:CARRIER_PROVIDER_SECRET = '<OPENAI_API_KEY>'
+```
+
+If default `openai-codex` is used and no saved credential exists, TUI will print device-code login instructions and wait for completion.
+
+## 4) Expected Validation Outputs
+
+Successful flow should include:
+- `carrier onboard` completes and starts/reuses daemon+gateway.
+- `carrier add openclaw` completes install/start for OpenClaw.
+- `carrier list` shows managed instance.
+- `GET /api/v1/agents/openclaw/status` returns OpenClaw status payload.
+
+## 5) Important Behavioral Note
+
+Chat commands `/install` and `/onboard` are intentionally blocked in gateway chat mode (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
+
+Use either:
+- TUI (`carrier onboard`, `carrier add openclaw`), or
+- WebUI (`carrier onboard --webui`, `carrier add openclaw --webui`).

--- a/scripts/ec2-binary-tui-linux.sh
+++ b/scripts/ec2-binary-tui-linux.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Download a main-push Carrier binary from GitHub Releases and validate
+# TUI onboarding + TUI add(openclaw) on Linux.
+#
+# Examples:
+#   scripts/ec2-binary-tui-linux.sh --sha <full_commit_sha>
+#   scripts/ec2-binary-tui-linux.sh --tag main-<full_commit_sha>
+#
+# Optional non-interactive inputs:
+#   CARRIER_TELEGRAM_BOT_TOKEN   Telegram bot token used by TUI prompts.
+#   CARRIER_PROVIDER_OVERRIDE    Provider ID override (default: keep auto-selected openai-codex).
+#   CARRIER_PROVIDER_SECRET      Provider credential input when override needs one.
+#
+# Notes:
+# - Default provider selection is openai-codex; OAuth device-code flow is shown in terminal.
+# - If OAuth is needed, complete it in browser while command waits.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ec2-binary-tui-linux.sh --sha <full_commit_sha> [options]
+  ec2-binary-tui-linux.sh --tag <release_tag> [options]
+
+Options:
+  --sha <sha>          Full commit SHA. Tag becomes main-<sha>.
+  --tag <tag>          Explicit release tag (for example main-<sha>).
+  --label <label>      Asset label (default: linux-x64).
+  --out-dir <dir>      Download/extract directory (default: /tmp/carrier-ec2).
+  --skip-onboard       Skip `carrier onboard`.
+  --skip-add           Skip `carrier add openclaw`.
+  -h, --help           Show this help message.
+
+Environment (optional):
+  CARRIER_TELEGRAM_BOT_TOKEN
+  CARRIER_PROVIDER_OVERRIDE
+  CARRIER_PROVIDER_SECRET
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+TAG=""
+SHA=""
+LABEL="linux-x64"
+OUT_DIR="/tmp/carrier-ec2"
+SKIP_ONBOARD=0
+SKIP_ADD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)
+      SHA="${2:-}"
+      shift 2
+      ;;
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --label)
+      LABEL="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --skip-onboard)
+      SKIP_ONBOARD=1
+      shift
+      ;;
+    --skip-add)
+      SKIP_ADD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  if [[ -z "$SHA" ]]; then
+    echo "ERROR: provide --sha or --tag" >&2
+    usage
+    exit 1
+  fi
+  TAG="main-$SHA"
+fi
+
+require_cmd curl
+require_cmd unzip
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+  echo "ERROR: sha256sum or shasum is required for checksum verification" >&2
+  exit 1
+fi
+
+ZIP_NAME="carrier-${TAG}-${LABEL}.zip"
+BASE_URL="https://github.com/Keith-CY/carrier/releases/download/${TAG}"
+ZIP_PATH="${OUT_DIR}/${ZIP_NAME}"
+SUM_PATH="${OUT_DIR}/${ZIP_NAME}.sha256"
+
+mkdir -p "$OUT_DIR"
+
+echo "[ec2] Downloading release asset: ${BASE_URL}/${ZIP_NAME}"
+curl -fL --retry 3 --retry-delay 2 -o "$ZIP_PATH" "${BASE_URL}/${ZIP_NAME}"
+
+echo "[ec2] Downloading checksum: ${BASE_URL}/${ZIP_NAME}.sha256"
+curl -fL --retry 3 --retry-delay 2 -o "$SUM_PATH" "${BASE_URL}/${ZIP_NAME}.sha256"
+
+echo "[ec2] Verifying checksum"
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$OUT_DIR" && sha256sum -c "${ZIP_NAME}.sha256")
+else
+  expected="$(awk '{print $1}' "$SUM_PATH" | tr '[:upper:]' '[:lower:]')"
+  actual="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "ERROR: checksum mismatch for $ZIP_NAME" >&2
+    echo "expected=$expected" >&2
+    echo "actual=$actual" >&2
+    exit 1
+  fi
+fi
+
+echo "[ec2] Extracting ${ZIP_NAME}"
+unzip -o "$ZIP_PATH" -d "$OUT_DIR" >/dev/null
+
+BIN_PATH="${OUT_DIR}/carrier"
+if [[ ! -x "$BIN_PATH" ]]; then
+  chmod +x "$BIN_PATH" 2>/dev/null || true
+fi
+if [[ ! -x "$BIN_PATH" ]]; then
+  echo "ERROR: extracted binary not found or not executable: $BIN_PATH" >&2
+  exit 1
+fi
+
+echo "[ec2] Binary ready: $BIN_PATH"
+"$BIN_PATH" --help >/dev/null
+
+run_tui() {
+  local token="${CARRIER_TELEGRAM_BOT_TOKEN:-}"
+  local override="${CARRIER_PROVIDER_OVERRIDE:-}"
+  local secret="${CARRIER_PROVIDER_SECRET:-}"
+
+  if [[ -n "$token" ]]; then
+    if [[ -n "$override" && "$override" != "openai-codex" && -z "$secret" ]]; then
+      echo "ERROR: CARRIER_PROVIDER_SECRET is required when CARRIER_PROVIDER_OVERRIDE=$override" >&2
+      exit 1
+    fi
+    if [[ -n "$override" && "$override" != "openai-codex" ]]; then
+      printf '%s\n%s\n%s\n' "$token" "$override" "$secret" | "$BIN_PATH" "$@"
+    else
+      printf '%s\n%s\n' "$token" "$override" | "$BIN_PATH" "$@"
+    fi
+    return
+  fi
+
+  echo "[ec2] CARRIER_TELEGRAM_BOT_TOKEN not set, running interactively for: carrier $*"
+  "$BIN_PATH" "$@"
+}
+
+if [[ "$SKIP_ONBOARD" -eq 0 ]]; then
+  echo "[ec2] Running: carrier onboard (TUI)"
+  run_tui onboard
+fi
+
+if [[ "$SKIP_ADD" -eq 0 ]]; then
+  echo "[ec2] Running: carrier add openclaw (TUI)"
+  run_tui add openclaw
+fi
+
+echo "[ec2] Current managed instances:"
+"$BIN_PATH" list || true
+
+echo "[ec2] OpenClaw status from daemon API (best effort):"
+curl -fsS http://127.0.0.1:9090/api/v1/agents/openclaw/status || true
+echo
+
+echo "[ec2] Done."

--- a/scripts/ec2-binary-tui-windows.ps1
+++ b/scripts/ec2-binary-tui-windows.ps1
@@ -1,0 +1,124 @@
+param(
+  [string]$Sha = "",
+  [string]$Tag = "",
+  [string]$Label = "windows-x64",
+  [string]$OutDir = "C:\Temp\carrier-ec2",
+  [switch]$SkipOnboard,
+  [switch]$SkipAdd
+)
+
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+  @"
+Usage:
+  .\ec2-binary-tui-windows.ps1 -Sha <full_commit_sha> [options]
+  .\ec2-binary-tui-windows.ps1 -Tag <release_tag> [options]
+
+Options:
+  -Sha <sha>          Full commit SHA. Tag becomes main-<sha>.
+  -Tag <tag>          Explicit release tag (for example main-<sha>).
+  -Label <label>      Asset label (default: windows-x64).
+  -OutDir <dir>       Download/extract directory (default: C:\Temp\carrier-ec2).
+  -SkipOnboard        Skip `carrier onboard`.
+  -SkipAdd            Skip `carrier add openclaw`.
+
+Environment (optional):
+  CARRIER_TELEGRAM_BOT_TOKEN
+  CARRIER_PROVIDER_OVERRIDE
+  CARRIER_PROVIDER_SECRET
+
+Notes:
+  - Default provider selection is openai-codex; OAuth device-code flow is shown in terminal.
+  - If OAuth is needed, complete it in browser while command waits.
+"@
+}
+
+if ([string]::IsNullOrWhiteSpace($Tag)) {
+  if ([string]::IsNullOrWhiteSpace($Sha)) {
+    Write-Error "Provide -Sha or -Tag."
+    Show-Usage
+    exit 1
+  }
+  $Tag = "main-$Sha"
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$zipName = "carrier-$Tag-$Label.zip"
+$zipPath = Join-Path $OutDir $zipName
+$sumPath = Join-Path $OutDir "$zipName.sha256"
+$baseUrl = "https://github.com/Keith-CY/carrier/releases/download/$Tag"
+
+Write-Host "[ec2] Downloading release asset: $baseUrl/$zipName"
+Invoke-WebRequest -Uri "$baseUrl/$zipName" -OutFile $zipPath
+
+Write-Host "[ec2] Downloading checksum: $baseUrl/$zipName.sha256"
+Invoke-WebRequest -Uri "$baseUrl/$zipName.sha256" -OutFile $sumPath
+
+Write-Host "[ec2] Verifying checksum"
+$expected = ((Get-Content -Path $sumPath -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+$actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($expected -ne $actual) {
+  throw "Checksum mismatch for $zipName. expected=$expected actual=$actual"
+}
+
+Write-Host "[ec2] Extracting $zipName"
+Expand-Archive -Path $zipPath -DestinationPath $OutDir -Force
+
+$binPath = Join-Path $OutDir "carrier.exe"
+if (-not (Test-Path $binPath)) {
+  throw "Extracted binary not found: $binPath"
+}
+
+Write-Host "[ec2] Binary ready: $binPath"
+& $binPath --help | Out-Null
+
+function Invoke-TuiCommand {
+  param(
+    [string[]]$Args
+  )
+
+  $token = [string]$env:CARRIER_TELEGRAM_BOT_TOKEN
+  $override = [string]$env:CARRIER_PROVIDER_OVERRIDE
+  $secret = [string]$env:CARRIER_PROVIDER_SECRET
+
+  if (-not [string]::IsNullOrWhiteSpace($token)) {
+    if (-not [string]::IsNullOrWhiteSpace($override) -and $override -ne "openai-codex" -and [string]::IsNullOrWhiteSpace($secret)) {
+      throw "CARRIER_PROVIDER_SECRET is required when CARRIER_PROVIDER_OVERRIDE=$override"
+    }
+
+    $lines = @($token, $override)
+    if (-not [string]::IsNullOrWhiteSpace($override) -and $override -ne "openai-codex") {
+      $lines += $secret
+    }
+    $inputText = ($lines -join "`n") + "`n"
+    $inputText | & $binPath @Args
+    return
+  }
+
+  Write-Host "[ec2] CARRIER_TELEGRAM_BOT_TOKEN not set, running interactively for: carrier $($Args -join ' ')"
+  & $binPath @Args
+}
+
+if (-not $SkipOnboard) {
+  Write-Host "[ec2] Running: carrier onboard (TUI)"
+  Invoke-TuiCommand -Args @("onboard")
+}
+
+if (-not $SkipAdd) {
+  Write-Host "[ec2] Running: carrier add openclaw (TUI)"
+  Invoke-TuiCommand -Args @("add", "openclaw")
+}
+
+Write-Host "[ec2] Current managed instances:"
+& $binPath list
+
+Write-Host "[ec2] OpenClaw status from daemon API (best effort):"
+try {
+  Invoke-RestMethod -Uri "http://127.0.0.1:9090/api/v1/agents/openclaw/status" | ConvertTo-Json -Depth 8
+} catch {
+  Write-Warning $_
+}
+
+Write-Host "[ec2] Done."


### PR DESCRIPTION
## Summary
- switch release packaging target from daemon/cmd/agentd to cmd/carrier
- add EC2 binary validation scripts for Linux and Windows (no rebuild flow)
- document main-push prerelease binary location and TUI onboard/add flow
- align command contract and release retention docs with current behavior

## Validation
- go test ./... (repo root)
- go test ./... (daemon module)
- cross-build smoke: cmd/carrier for linux/amd64 and windows/amd64
- script validation: bash -n scripts/ec2-binary-tui-linux.sh