### PR TITLE
fix: avoid carrier add timeout on long openclaw installs

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -1580,7 +1580,7 @@ func daemonAgentAction(agentID, action string) error {
 		return errors.New("agentID and action are required")
 	}
 	path := fmt.Sprintf("/api/v1/agents/%s/%s", neturl.PathEscape(agentID), neturl.PathEscape(action))
-	_, status, err := daemonRequest(http.MethodPost, path, map[string]string{})
+	_, status, err := daemonRequestWithTimeout(http.MethodPost, path, map[string]string{}, daemonActionTimeout(action))
 	if err != nil {
 		reconciled, reconcileErr := reconcileDaemonActionOnEOF(agentID, action, err)
 		if reconciled {
@@ -1713,6 +1713,22 @@ func daemonExtractPairCodeFromLogs(agentID string) (string, error) {
 }
 
 func daemonRequest(method, path string, body any) ([]byte, int, error) {
+	return daemonRequestWithTimeout(method, path, body, 5*time.Minute)
+}
+
+func daemonActionTimeout(action string) time.Duration {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "install":
+		return 20 * time.Minute
+	default:
+		return 5 * time.Minute
+	}
+}
+
+func daemonRequestWithTimeout(method, path string, body any, timeout time.Duration) ([]byte, int, error) {
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
 	base := strings.TrimRight(strings.TrimSpace(daemonProbeBaseURL()), "/")
 	if base == "" {
 		return nil, 0, errors.New("daemon base url is empty")
@@ -1736,7 +1752,7 @@ func daemonRequest(method, path string, body any) ([]byte, int, error) {
 	}
 	addDaemonAuthHeader(req)
 
-	client := &http.Client{Timeout: 5 * time.Minute}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, 0, err

--- a/cmd/carrier/main_daemon_action_test.go
+++ b/cmd/carrier/main_daemon_action_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 )
 
 func TestDaemonAgentActionInstallRecoversEOFWhenStatusInstalled(t *testing.T) {
@@ -87,4 +88,16 @@ func configureDaemonProbeEnvForTest(t *testing.T, serverURL string) {
 	}
 	t.Setenv("CARRIER_SERVER_HOST", host)
 	t.Setenv("CARRIER_SERVER_PORT", port)
+}
+
+func TestDaemonActionTimeoutUsesExtendedInstallWindow(t *testing.T) {
+	if got := daemonActionTimeout("install"); got != 20*time.Minute {
+		t.Fatalf("daemonActionTimeout(install) = %s, want %s", got, 20*time.Minute)
+	}
+	if got := daemonActionTimeout("start"); got != 5*time.Minute {
+		t.Fatalf("daemonActionTimeout(start) = %s, want %s", got, 5*time.Minute)
+	}
+	if got := daemonActionTimeout(" INSTALL "); got != 20*time.Minute {
+		t.Fatalf("daemonActionTimeout( INSTALL ) = %s, want %s", got, 20*time.Minute)
+	}
 }


### PR DESCRIPTION
## Summary
- route managed-agent daemon POSTs through a timeout-aware helper
- extend `install` action timeout from 5 minutes to 20 minutes to handle long `openclaw` install scripts
- keep default daemon request timeout at 5 minutes for non-install actions
- add unit test coverage for timeout selection logic

## Validation
- go test ./cmd/carrier

NBS: add an end-to-end test that exercises a slow install path (>5m) and verifies `carrier add` remains stable.
