### PR TITLE
fix(managed-add): surface daemon failure details and extend install timeout

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -1587,7 +1587,7 @@ func daemonAgentAction(agentID, action string) error {
 			return nil
 		}
 		if reconcileErr != nil {
-			return fmt.Errorf("%w (status reconciliation failed: %v)", err, reconcileErr)
+			return fmt.Errorf("daemon %s %s failed: %v (request error: %w)", action, agentID, reconcileErr, err)
 		}
 		return err
 	}
@@ -1600,6 +1600,7 @@ func daemonAgentAction(agentID, action string) error {
 type daemonAgentStatusSnapshot struct {
 	InstallState string
 	RuntimeState string
+	LastError    string
 }
 
 func reconcileDaemonActionOnEOF(agentID, action string, reqErr error) (bool, error) {
@@ -1617,10 +1618,29 @@ func reconcileDaemonActionOnEOF(agentID, action string, reqErr error) (bool, err
 	}
 	switch action {
 	case "install":
-		return strings.EqualFold(status.InstallState, "installed"), nil
+		switch strings.ToLower(strings.TrimSpace(status.InstallState)) {
+		case "installed":
+			return true, nil
+		case "broken", "failed", "error":
+			if lastErr := strings.TrimSpace(status.LastError); lastErr != "" {
+				return false, fmt.Errorf("install state=%s: %s", strings.TrimSpace(status.InstallState), lastErr)
+			}
+			return false, fmt.Errorf("install state=%s", strings.TrimSpace(status.InstallState))
+		default:
+			return false, nil
+		}
 	case "start":
 		runtimeState := strings.ToLower(strings.TrimSpace(status.RuntimeState))
-		return runtimeState == "running" || runtimeState == "starting", nil
+		if runtimeState == "running" || runtimeState == "starting" {
+			return true, nil
+		}
+		if runtimeState == "stopped" || runtimeState == "error" || runtimeState == "crashed" || runtimeState == "broken" {
+			if lastErr := strings.TrimSpace(status.LastError); lastErr != "" {
+				return false, fmt.Errorf("runtime state=%s: %s", strings.TrimSpace(status.RuntimeState), lastErr)
+			}
+			return false, fmt.Errorf("runtime state=%s", strings.TrimSpace(status.RuntimeState))
+		}
+		return false, nil
 	default:
 		return false, nil
 	}
@@ -1639,6 +1659,7 @@ func daemonFetchAgentStatus(agentID string) (daemonAgentStatusSnapshot, error) {
 		RuntimeState string `json:"runtimeState"`
 		Install      string `json:"install"`
 		Runtime      string `json:"runtime"`
+		LastError    string `json:"lastError"`
 	}
 	if err := json.Unmarshal(raw, &direct); err == nil {
 		installState := firstNonEmpty(direct.InstallState, direct.Install)
@@ -1647,6 +1668,7 @@ func daemonFetchAgentStatus(agentID string) (daemonAgentStatusSnapshot, error) {
 			return daemonAgentStatusSnapshot{
 				InstallState: installState,
 				RuntimeState: runtimeState,
+				LastError:    strings.TrimSpace(direct.LastError),
 			}, nil
 		}
 	}
@@ -1656,6 +1678,7 @@ func daemonFetchAgentStatus(agentID string) (daemonAgentStatusSnapshot, error) {
 			RuntimeState string `json:"runtimeState"`
 			Install      string `json:"install"`
 			Runtime      string `json:"runtime"`
+			LastError    string `json:"lastError"`
 		} `json:"statuses"`
 	}
 	if err := json.Unmarshal(raw, &wrapped); err != nil {
@@ -1668,6 +1691,7 @@ func daemonFetchAgentStatus(agentID string) (daemonAgentStatusSnapshot, error) {
 	return daemonAgentStatusSnapshot{
 		InstallState: firstNonEmpty(first.InstallState, first.Install),
 		RuntimeState: firstNonEmpty(first.RuntimeState, first.Runtime),
+		LastError:    strings.TrimSpace(first.LastError),
 	}, nil
 }
 

--- a/cmd/carrier/main_daemon_action_test.go
+++ b/cmd/carrier/main_daemon_action_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -73,6 +74,82 @@ func TestDaemonAgentActionInstallKeepsEOFFailureWhenStatusMismatch(t *testing.T)
 	}
 	if !isDaemonEOFError(err) {
 		t.Fatalf("daemonAgentAction install error = %v, want EOF-like error", err)
+	}
+}
+
+func TestDaemonAgentActionInstallReportsDaemonLastErrorOnEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agents/openclaw/install":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatalf("response writer does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack connection: %v", err)
+			}
+			_ = conn.Close()
+			return
+		case "/api/v1/agents/openclaw/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"openclaw","installState":"broken","runtimeState":"stopped","lastError":"signal: killed"}`))
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer server.Close()
+	configureDaemonProbeEnvForTest(t, server.URL)
+
+	err := daemonAgentAction("openclaw", "install")
+	if err == nil {
+		t.Fatal("daemonAgentAction install should fail when daemon status is broken")
+	}
+	if !strings.Contains(err.Error(), "install state=broken: signal: killed") {
+		t.Fatalf("daemonAgentAction install error = %q, want daemon lastError details", err.Error())
+	}
+	if !strings.Contains(err.Error(), "request error:") {
+		t.Fatalf("daemonAgentAction install error = %q, want request error context", err.Error())
+	}
+}
+
+func TestDaemonAgentActionStartReportsDaemonLastErrorOnEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agents/openclaw/start":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatalf("response writer does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack connection: %v", err)
+			}
+			_ = conn.Close()
+			return
+		case "/api/v1/agents/openclaw/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"statuses":[{"id":"openclaw","installState":"installed","runtimeState":"error","lastError":"failed to bind port"}]}`))
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer server.Close()
+	configureDaemonProbeEnvForTest(t, server.URL)
+
+	err := daemonAgentAction("openclaw", "start")
+	if err == nil {
+		t.Fatal("daemonAgentAction start should fail when daemon runtime state is error")
+	}
+	if !strings.Contains(err.Error(), "runtime state=error: failed to bind port") {
+		t.Fatalf("daemonAgentAction start error = %q, want daemon lastError details", err.Error())
+	}
+	if !strings.Contains(err.Error(), "request error:") {
+		t.Fatalf("daemonAgentAction start error = %q, want request error context", err.Error())
 	}
 }
 

--- a/daemon/internal/lifecycle/service.go
+++ b/daemon/internal/lifecycle/service.go
@@ -41,7 +41,7 @@ const (
 	defaultCrashLoopThreshold = 3
 	defaultCrashLoopWindow    = 5 * time.Minute
 	defaultCrashLoopCooldown  = 5 * time.Minute
-	defaultCommandTimeout     = 5 * time.Minute
+	defaultCommandTimeout     = 20 * time.Minute
 )
 
 var (

--- a/daemon/internal/lifecycle/service_command_timeout_test.go
+++ b/daemon/internal/lifecycle/service_command_timeout_test.go
@@ -1,0 +1,29 @@
+package lifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadCommandTimeoutFromEnv_DefaultsToTwentyMinutes(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"", "not-a-duration", "-1m", "0s"}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if got := loadCommandTimeoutFromEnv(raw); got != 20*time.Minute {
+				t.Fatalf("loadCommandTimeoutFromEnv(%q) = %s, want %s", raw, got, 20*time.Minute)
+			}
+		})
+	}
+}
+
+func TestLoadCommandTimeoutFromEnv_UsesValidDuration(t *testing.T) {
+	t.Parallel()
+
+	if got := loadCommandTimeoutFromEnv("45m"); got != 45*time.Minute {
+		t.Fatalf("loadCommandTimeoutFromEnv(%q) = %s, want %s", "45m", got, 45*time.Minute)
+	}
+}


### PR DESCRIPTION
## Summary
- surface daemon `lastError` when install/start request hits EOF so TUI no longer only reports opaque EOF
- treat broken/error install/runtime states as terminal reconciliation failures with actionable messages
- raise daemon lifecycle command timeout default from 5m to 20m for long EC2 OpenClaw builds
- add regression tests for EOF reconciliation and timeout env/default behavior

## Verification
- `go test ./cmd/carrier`
- `(cd daemon && go test ./internal/lifecycle)`

## Context
EC2 TUI validation showed `carrier add openclaw` on low-resource hosts can exceed 5m during git+pnpm build; daemon returned `signal: killed` while CLI surfaced only EOF. This patch keeps the actionable daemon error and avoids premature timeout.
