### PR TITLE
fix(timeout): avoid EOF during long agent install flows

### DIFF
--- a/daemon/internal/gateway/daemonclient.go
+++ b/daemon/internal/gateway/daemonclient.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	defaultDaemonBaseURL  = "http://127.0.0.1:9090"
-	defaultDaemonTimeout  = 30 * time.Second
+	defaultDaemonBaseURL = "http://127.0.0.1:9090"
+	// Install/upgrade actions may run for many minutes on cold hosts.
+	defaultDaemonTimeout  = 30 * time.Minute
 	maxDaemonResponseSize = 32 * 1024 * 1024 // 32 MB
 )
 

--- a/daemon/internal/gateway/gateway.go
+++ b/daemon/internal/gateway/gateway.go
@@ -57,7 +57,7 @@ func LoadGatewayConfigFromEnv() *GatewayConfig {
 		APIToken:                strings.TrimSpace(os.Getenv("CARRIER_GATEWAY_API_TOKEN")),
 		DaemonBaseURL:           strings.TrimRight(strings.TrimSpace(envOrDefault("CARRIER_DAEMON_BASE_URL", "http://127.0.0.1:9090")), "/"),
 		DaemonToken:             strings.TrimSpace(os.Getenv("CARRIER_SERVER_API_TOKEN")),
-		DaemonTimeout:           time.Duration(parseEnvInt("CARRIER_DAEMON_TIMEOUT_MS", 30000)) * time.Millisecond,
+		DaemonTimeout:           time.Duration(parseEnvInt("CARRIER_DAEMON_TIMEOUT_MS", int(defaultDaemonTimeout/time.Millisecond))) * time.Millisecond,
 		DiscordPublicKey:        strings.TrimSpace(os.Getenv("CARRIER_DISCORD_PUBLIC_KEY")),
 		FeishuVerificationToken: strings.TrimSpace(os.Getenv("CARRIER_FEISHU_VERIFICATION_TOKEN")),
 		TelegramWebhookSecret:   strings.TrimSpace(os.Getenv("CARRIER_TELEGRAM_WEBHOOK_SECRET")),

--- a/daemon/internal/gateway/server.go
+++ b/daemon/internal/gateway/server.go
@@ -22,8 +22,9 @@ const (
 	discordMaxAgeSec           = 300
 	gatewayReadHeaderTimeout   = 10 * time.Second
 	gatewayReadTimeout         = 60 * time.Second
-	gatewayWriteTimeout        = 90 * time.Second
-	gatewayIdleTimeout         = 120 * time.Second
+	// Gateway can proxy long-running install/start operations from WebUI/TUI flows.
+	gatewayWriteTimeout = 30 * time.Minute
+	gatewayIdleTimeout  = 120 * time.Second
 )
 
 // requestIDKey is the context key for the request ID.

--- a/daemon/internal/gateway/server_test.go
+++ b/daemon/internal/gateway/server_test.go
@@ -574,6 +574,9 @@ func TestNewGatewayHTTPServer(t *testing.T) {
 	if srv.ReadHeaderTimeout != gatewayReadHeaderTimeout {
 		t.Errorf("unexpected ReadHeaderTimeout: %v", srv.ReadHeaderTimeout)
 	}
+	if srv.WriteTimeout != gatewayWriteTimeout {
+		t.Errorf("unexpected WriteTimeout: %v", srv.WriteTimeout)
+	}
 	if srv.IdleTimeout != gatewayIdleTimeout {
 		t.Errorf("unexpected IdleTimeout: %v", srv.IdleTimeout)
 	}

--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -41,11 +41,13 @@ const (
 	shutdownTimeout          = 30 * time.Second
 	defaultReadHeaderTimeout = 10 * time.Second
 	defaultReadTimeout       = 30 * time.Second
-	defaultWriteTimeout      = 60 * time.Second
-	defaultIdleTimeout       = 120 * time.Second
-	defaultLogsTail          = 200
-	maxLogsTail              = 1000
-	maxBodySize              = 1 << 20
+	// Long-running install/start requests can take several minutes on cold machines.
+	// Keep write timeout above those command windows so clients do not get EOF mid-flight.
+	defaultWriteTimeout = 30 * time.Minute
+	defaultIdleTimeout  = 120 * time.Second
+	defaultLogsTail     = 200
+	maxLogsTail         = 1000
+	maxBodySize         = 1 << 20
 )
 
 var agentIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)

--- a/daemon/server/server_test.go
+++ b/daemon/server/server_test.go
@@ -576,6 +576,9 @@ func TestNewHTTPServer(t *testing.T) {
 	if srv.ReadHeaderTimeout != defaultReadHeaderTimeout {
 		t.Errorf("unexpected ReadHeaderTimeout: %v", srv.ReadHeaderTimeout)
 	}
+	if srv.WriteTimeout != defaultWriteTimeout {
+		t.Errorf("unexpected WriteTimeout: %v", srv.WriteTimeout)
+	}
 	if srv.IdleTimeout != defaultIdleTimeout {
 		t.Errorf("unexpected IdleTimeout: %v", srv.IdleTimeout)
 	}


### PR DESCRIPTION
## Summary
- increase daemon HTTP write timeout to 30 minutes so long-running install/start actions don't get cut off at 60s
- increase gateway HTTP write timeout and default gateway->daemon client timeout to 30 minutes for WebUI/TUI add flows
- align CARRIER_DAEMON_TIMEOUT_MS default with the new long-running timeout
- add timeout assertions in daemon/gateway server tests

## Root Cause
carrier add openclaw can run installation commands for multiple minutes on free-tier hosts.
Daemon HTTP write timeout was 60s, so the server closed the connection mid-install and CLI saw EOF, even while install work continued in background.

## Verification
- go test ./cmd/carrier
- cd daemon && go test ./server ./internal/gateway
