### PR TITLE
fix(catalog): fallback OpenClaw install on low-memory EC2

### DIFF
--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -38,6 +38,9 @@ const (
 	defaultDaemonHealthzPath = "/healthz"
 	defaultDaemonHealthURL   = "http://localhost:9090/healthz"
 
+	openClawInstallMethodEnv          = "CARRIER_OPENCLAW_INSTALL_METHOD"
+	openClawDisableInstallFallbackEnv = "CARRIER_OPENCLAW_DISABLE_INSTALL_FALLBACK"
+
 	// Official OpenClaw installer URLs
 	installScriptURL = "https://openclaw.ai/install.sh"
 	installPS1URL    = "https://openclaw.ai/install.ps1"
@@ -48,8 +51,10 @@ const (
 )
 
 // getInstallCommand returns the platform-appropriate install command.
-// In managed daemon installs, force source install from git and skip onboarding
-// to avoid interactive prompts that can block the API request.
+// In managed daemon installs, skip onboarding prompts to avoid blocking the API request.
+// Default behavior prefers git source install for freshness; on Unix-like systems,
+// we automatically retry with upstream default install mode if the git path fails
+// (useful on low-memory hosts). Operators can override install method via env.
 // - Linux/macOS/WSL: curl | bash (official install.sh) with args
 // - Windows: PowerShell script invocation with args
 // - Dev mode: creates a long-running placeholder script
@@ -58,12 +63,60 @@ func getInstallCommand() string {
 		return getDevInstallCommand()
 	}
 
+	method, explicitMethod := resolveOpenClawInstallMethod()
+	allowFallback := !explicitMethod && method == "git" && !isTruthyEnv(openClawDisableInstallFallbackEnv)
+
 	switch runtime.GOOS {
 	case "windows":
-		return fmt.Sprintf(`powershell -NoProfile -Command "& ([scriptblock]::Create((irm '%s'))) -InstallMethod git -NoOnboard"`, installPS1URL)
+		if allowFallback {
+			// Keep git as first choice, then retry with installer default mode.
+			return fmt.Sprintf(`powershell -NoProfile -Command "$ErrorActionPreference='Stop';$installer=(irm '%s');$script=[scriptblock]::Create($installer);$env:CARGO_BUILD_JOBS='1';try { & $script -InstallMethod 'git' -NoOnboard; if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw 'git install failed' } } catch { & $script -NoOnboard }"`, installPS1URL)
+		}
+		return fmt.Sprintf(`powershell -NoProfile -Command "& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, installPS1URL, method)
 	default:
-		// Linux, macOS, and anything else that has sh + curl
-		return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --install-method git --no-onboard'`, installScriptURL)
+		// Linux, macOS, and anything else that has sh + curl.
+		if allowFallback {
+			// On small instances, the git build path can be OOM-killed; fallback keeps installs unblocked.
+			return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | CARGO_BUILD_JOBS=1 bash -s -- --install-method git --no-onboard || curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --no-onboard'`, installScriptURL, installScriptURL)
+		}
+		return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --install-method %s --no-onboard'`, installScriptURL, method)
+	}
+}
+
+func resolveOpenClawInstallMethod() (method string, explicit bool) {
+	raw := strings.TrimSpace(os.Getenv(openClawInstallMethodEnv))
+	if raw == "" {
+		return "git", false
+	}
+	if !isSafeInstallerToken(raw) {
+		return "git", false
+	}
+	return strings.ToLower(raw), true
+}
+
+func isSafeInstallerToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isTruthyEnv(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -158,9 +158,11 @@ func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
 // Install-command shell-contract tests
 // ---------------------------------------------------------------------------
 
-func TestGetInstallCommand_Unix(t *testing.T) {
+func TestGetInstallCommand_Default(t *testing.T) {
 	// Ensure dev mode is off so we get the production command.
 	t.Setenv("CARRIER_DEV_MODE", "")
+	t.Setenv(openClawInstallMethodEnv, "")
+	t.Setenv(openClawDisableInstallFallbackEnv, "")
 
 	cmd := getInstallCommand()
 
@@ -170,13 +172,73 @@ func TestGetInstallCommand_Unix(t *testing.T) {
 		`--proto "=https"`,
 		"--tlsv1.2",
 		installScriptURL,
-		"| bash -s --",
 		"--install-method git",
 		"--no-onboard",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("install command missing %q\ngot: %s", want, cmd)
 		}
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		if !strings.Contains(cmd, "try {") {
+			t.Errorf("windows default command should include fallback try/catch\ngot: %s", cmd)
+		}
+	default:
+		for _, want := range []string{
+			"CARGO_BUILD_JOBS=1",
+			"||",
+			"| bash -s -- --no-onboard",
+		} {
+			if !strings.Contains(cmd, want) {
+				t.Errorf("unix default command should include fallback token %q\ngot: %s", want, cmd)
+			}
+		}
+	}
+}
+
+func TestGetInstallCommand_ExplicitMethodDisablesFallback(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+	t.Setenv(openClawInstallMethodEnv, "npm")
+
+	cmd := getInstallCommand()
+
+	if !strings.Contains(cmd, "--install-method") || !strings.Contains(cmd, "npm") {
+		t.Fatalf("expected explicit install method in command, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "||") || strings.Contains(cmd, "try {") {
+		t.Fatalf("explicit install method should not auto-fallback, got: %s", cmd)
+	}
+}
+
+func TestGetInstallCommand_DisableFallback(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+	t.Setenv(openClawInstallMethodEnv, "")
+	t.Setenv(openClawDisableInstallFallbackEnv, "1")
+
+	cmd := getInstallCommand()
+
+	if !strings.Contains(cmd, "--install-method git") {
+		t.Fatalf("expected strict git install command, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "||") || strings.Contains(cmd, "try {") {
+		t.Fatalf("fallback should be disabled, got: %s", cmd)
+	}
+}
+
+func TestGetInstallCommand_UnsafeMethodFallsBackToDefault(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+	t.Setenv(openClawInstallMethodEnv, "git;rm -rf /")
+	t.Setenv(openClawDisableInstallFallbackEnv, "")
+
+	cmd := getInstallCommand()
+
+	if strings.Contains(cmd, "rm -rf") {
+		t.Fatalf("unsafe install method must not be interpolated into command: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--install-method git") {
+		t.Fatalf("unsafe value should fall back to git command, got: %s", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep managed OpenClaw installs git-first by default
- add automatic fallback to upstream default install mode when git path fails on low-memory hosts
- allow operator override via CARRIER_OPENCLAW_INSTALL_METHOD and strict mode via CARRIER_OPENCLAW_DISABLE_INSTALL_FALLBACK
- harden install-method interpolation with token sanitization

## Testing
- go test ./internal/catalog -count=1