### PR TITLE
fix(catalog): make OpenClaw fallback path non-interactive

### DIFF
--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -69,15 +69,15 @@ func getInstallCommand() string {
 	switch runtime.GOOS {
 	case "windows":
 		if allowFallback {
-			// Keep git as first choice, then retry with installer default mode.
-			return fmt.Sprintf(`powershell -NoProfile -Command "$ErrorActionPreference='Stop';$installer=(irm '%s');$script=[scriptblock]::Create($installer);$env:CARGO_BUILD_JOBS='1';try { & $script -InstallMethod 'git' -NoOnboard; if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw 'git install failed' } } catch { & $script -NoOnboard }"`, installPS1URL)
+			// Keep git as first choice, then retry with non-interactive npm install.
+			return fmt.Sprintf(`powershell -NoProfile -Command "$ErrorActionPreference='Stop';$installer=(irm '%s');$script=[scriptblock]::Create($installer);$env:CARGO_BUILD_JOBS='1';try { & $script -InstallMethod 'git' -NoOnboard; if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw 'git install failed' } } catch { & $script -InstallMethod 'npm' -NoOnboard }"`, installPS1URL)
 		}
 		return fmt.Sprintf(`powershell -NoProfile -Command "& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, installPS1URL, method)
 	default:
 		// Linux, macOS, and anything else that has sh + curl.
 		if allowFallback {
 			// On small instances, the git build path can be OOM-killed; fallback keeps installs unblocked.
-			return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | CARGO_BUILD_JOBS=1 bash -s -- --install-method git --no-onboard || curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --no-onboard'`, installScriptURL, installScriptURL)
+			return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | CARGO_BUILD_JOBS=1 bash -s -- --install-method git --no-onboard || curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --install-method npm --no-onboard'`, installScriptURL, installScriptURL)
 		}
 		return fmt.Sprintf(`sh -c 'curl -fsSL --proto "=https" --tlsv1.2 "%s" | bash -s -- --install-method %s --no-onboard'`, installScriptURL, method)
 	}

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -189,7 +189,7 @@ func TestGetInstallCommand_Default(t *testing.T) {
 		for _, want := range []string{
 			"CARGO_BUILD_JOBS=1",
 			"||",
-			"| bash -s -- --no-onboard",
+			"| bash -s -- --install-method npm --no-onboard",
 		} {
 			if !strings.Contains(cmd, want) {
 				t.Errorf("unix default command should include fallback token %q\ngot: %s", want, cmd)


### PR DESCRIPTION
## Summary\n- change OpenClaw fallback path from implicit installer default to explicit npm mode\n- keep git-first behavior for managed installs, but avoid interactive prompt hangs when fallback triggers\n- preserve no-onboard behavior in both primary and fallback paths\n\n## Testing\n- go test ./internal/catalog -count=1