### PR TITLE
fix(catalog): remove openclaw preflight blockers

### DIFF
--- a/catalog/openclaw.manifest.json
+++ b/catalog/openclaw.manifest.json
@@ -24,25 +24,14 @@
     }
   },
   "network": {
-    "ports": [
-      {
-        "name": "http",
-        "port": 9090
-      }
-    ],
+    "ports": [],
     "healthcheck": {
       "type": "http",
       "url": "http://localhost:9090/healthz"
     }
   },
   "env": {
-    "required": [
-      {
-        "name": "OPENAI_API_KEY",
-        "secret": true,
-        "description": "OpenAI API key for LLM access"
-      }
-    ],
+    "required": [],
     "optional": [
       {
         "name": "LOG_LEVEL",

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -156,12 +156,10 @@ func getStartCommand() string {
 	case "windows":
 		return "openclaw gateway start"
 	default:
-		// Use absolute path to avoid PATH shadowing on Unix
-		home, err := os.UserHomeDir()
-		if err != nil {
-			home = os.Getenv("HOME")
-		}
-		return filepath.Join(home, ".local", "bin", "openclaw") + " gateway start"
+		// Git installs create a ~/.local/bin wrapper, while npm installs may
+		// place openclaw in npm's global bin dir. Resolve both without forcing
+		// pre-flight to depend on a single hardcoded absolute path.
+		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway start; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway start; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw and PATH)" >&2; exit 127; fi'`
 	}
 }
 
@@ -171,26 +169,17 @@ func getStopCommand() string {
 	case "windows":
 		return "openclaw gateway stop"
 	default:
-		home, err := os.UserHomeDir()
-		if err != nil {
-			home = os.Getenv("HOME")
-		}
-		return filepath.Join(home, ".local", "bin", "openclaw") + " gateway stop"
+		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway stop; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway stop; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw and PATH)" >&2; exit 127; fi'`
 	}
 }
 
 func getNetworkSpec() manifest.NetworkSpec {
-	spec := manifest.NetworkSpec{
+	return manifest.NetworkSpec{
 		Healthcheck: manifest.HealthcheckSpec{
 			Type: "http",
 			URL:  defaultDaemonHealthURL,
 		},
 	}
-	// Skip port declarations in dev mode to avoid port conflict with the daemon itself
-	if os.Getenv("CARRIER_DEV_MODE") != "1" {
-		spec.Ports = []manifest.PortSpec{{Name: "http", Port: defaultDaemonPort}}
-	}
-	return spec
 }
 
 // getZeroClawInstallCommand returns the install command for ZeroClaw.
@@ -543,7 +532,7 @@ func OpenClawManifest() manifest.Manifest {
 		},
 		Network: getNetworkSpec(),
 		Env: manifest.EnvSpec{
-			Required: []manifest.EnvVar{{Name: "OPENAI_API_KEY", Secret: true, Description: "OpenAI API key for LLM access"}},
+			Required: []manifest.EnvVar{},
 			Optional: []manifest.EnvVar{{Name: "LOG_LEVEL", Default: "info", Description: "Logging verbosity level"}},
 		},
 		Memory: manifest.MemorySpec{

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -12,11 +12,10 @@ import (
 func TestOpenClawManifestUsesDaemonHealthContract(t *testing.T) {
 	m := OpenClawManifest()
 
-	if len(m.Network.Ports) == 0 {
-		t.Fatal("expected at least one network port in manifest")
-	}
-	if got := m.Network.Ports[0].Port; got != defaultDaemonPort {
-		t.Fatalf("network port = %d, want %d", got, defaultDaemonPort)
+	// OpenClaw runs alongside carrier daemon; declaring daemon's own fixed port
+	// in agent pre-flight causes false-positive conflict failures.
+	if got := len(m.Network.Ports); got != 0 {
+		t.Fatalf("expected no declared network ports, got %d", got)
 	}
 	if got := m.Network.Healthcheck.URL; got != defaultDaemonHealthURL {
 		t.Fatalf("healthcheck url = %q, want %q", got, defaultDaemonHealthURL)
@@ -146,11 +145,8 @@ func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
 	if fileManifest.Network.Healthcheck.URL != generated.Network.Healthcheck.URL {
 		t.Fatalf("catalog healthcheck url = %q, generated = %q", fileManifest.Network.Healthcheck.URL, generated.Network.Healthcheck.URL)
 	}
-	if len(fileManifest.Network.Ports) == 0 || len(generated.Network.Ports) == 0 {
-		t.Fatal("expected network ports in both manifests")
-	}
-	if fileManifest.Network.Ports[0].Port != generated.Network.Ports[0].Port {
-		t.Fatalf("catalog port = %d, generated = %d", fileManifest.Network.Ports[0].Port, generated.Network.Ports[0].Port)
+	if len(fileManifest.Network.Ports) != len(generated.Network.Ports) {
+		t.Fatalf("catalog port count = %d, generated = %d", len(fileManifest.Network.Ports), len(generated.Network.Ports))
 	}
 }
 
@@ -284,51 +280,54 @@ func TestGetInstallCommand_DevMode(t *testing.T) {
 func TestGetStartCommand_Unix(t *testing.T) {
 	cmd := getStartCommand()
 
-	home, _ := os.UserHomeDir()
-	wantPrefix := filepath.Join(home, ".local", "bin", "openclaw")
-
-	if !strings.HasPrefix(cmd, wantPrefix) {
-		t.Errorf("start command should use absolute path\ngot: %s\nwant prefix: %s", cmd, wantPrefix)
+	for _, want := range []string{
+		`$HOME/.local/bin/openclaw`,
+		"command -v openclaw",
+		"gateway start",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("start command missing %q\ngot: %s", want, cmd)
+		}
 	}
-	if !strings.HasSuffix(cmd, "gateway start") {
-		t.Errorf("start command should end with 'gateway start'\ngot: %s", cmd)
+	if !strings.HasPrefix(cmd, "sh -c") {
+		t.Errorf("start command should use shell resolver wrapper\ngot: %s", cmd)
 	}
 }
 
 func TestGetStopCommand_Unix(t *testing.T) {
 	cmd := getStopCommand()
 
-	home, _ := os.UserHomeDir()
-	wantPrefix := filepath.Join(home, ".local", "bin", "openclaw")
-
-	if !strings.HasPrefix(cmd, wantPrefix) {
-		t.Errorf("stop command should use absolute path\ngot: %s\nwant prefix: %s", cmd, wantPrefix)
+	for _, want := range []string{
+		`$HOME/.local/bin/openclaw`,
+		"command -v openclaw",
+		"gateway stop",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("stop command missing %q\ngot: %s", want, cmd)
+		}
 	}
-	if !strings.HasSuffix(cmd, "gateway stop") {
-		t.Errorf("stop command should end with 'gateway stop'\ngot: %s", cmd)
+	if !strings.HasPrefix(cmd, "sh -c") {
+		t.Errorf("stop command should use shell resolver wrapper\ngot: %s", cmd)
 	}
 }
 
-func TestGetNetworkSpec_ProductionIncludesPorts(t *testing.T) {
+func TestGetNetworkSpec_ProductionOmitsPorts(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "")
 
 	spec := getNetworkSpec()
 
-	if len(spec.Ports) == 0 {
-		t.Fatal("production network spec must declare ports")
-	}
-	if spec.Ports[0].Port != defaultDaemonPort {
-		t.Fatalf("port = %d, want %d", spec.Ports[0].Port, defaultDaemonPort)
+	if len(spec.Ports) != 0 {
+		t.Fatalf("production network spec should not declare fixed ports, got %d", len(spec.Ports))
 	}
 }
 
-func TestGetNetworkSpec_DevModeSkipsPorts(t *testing.T) {
+func TestGetNetworkSpec_DevModeAlsoOmitsPorts(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "1")
 
 	spec := getNetworkSpec()
 
 	if len(spec.Ports) != 0 {
-		t.Fatalf("dev mode should skip ports, got %d", len(spec.Ports))
+		t.Fatalf("dev mode should not declare ports, got %d", len(spec.Ports))
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop requiring `OPENAI_API_KEY` at OpenClaw manifest preflight time (managed onboarding still wires provider creds)
- remove fixed `9090` port declaration from OpenClaw network spec to avoid guaranteed daemon self-conflict
- make Unix start/stop commands resolve OpenClaw from both `~/.local/bin` (git install) and PATH (npm install fallback)
- sync `catalog/openclaw.manifest.json` and catalog tests with the new manifest contract

## Validation
- `cd daemon && go test ./internal/catalog -count=1`
- `cd daemon && go test ./... -count=1`
