### PR TITLE
fix: add debug log when isDaemonEOFError string-match fallback is hit

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -1711,7 +1711,7 @@ func isDaemonEOFError(err error) bool {
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
-	if strings.Contains(strings.ToLower(err.Error()), "eof") {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "eof") {
 		fmt.Fprintf(os.Stderr, "[debug] isDaemonEOFError: string-match fallback hit for error: %v\n", err)
 		return true
 	}


### PR DESCRIPTION
Adds a debug log to stderr when `isDaemonEOFError` falls back to string matching instead of `errors.Is(err, io.EOF)`. This makes unexpected matches visible in debug output.

Closes #1334