### PR TITLE
fix(ec2): auto-resolve main release tag for binary validation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,14 @@ Implementation notes:
   - `carrier-main-<full_commit_sha>-windows-x64.zip`
 - Release assets can be downloaded directly from:
   - `https://github.com/Keith-CY/carrier/releases/download/main-<full_commit_sha>/carrier-main-<full_commit_sha>-<label>.zip`
+- Do not infer latest by taking the first `/releases` entry; resolve `main` HEAD SHA and use `main-<full_commit_sha>`.
 - Use TUI flow for onboarding/install on EC2:
   - `carrier onboard`
   - `carrier add openclaw`
 - Chat `/install` and `/onboard` are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
 - End-to-end no-rebuild scripts:
-  - Linux: `scripts/ec2-binary-tui-linux.sh`
-  - Windows: `scripts/ec2-binary-tui-windows.ps1`
+  - Linux: `scripts/ec2-binary-tui-linux.sh` (no args defaults to latest `main` push release)
+  - Windows: `scripts/ec2-binary-tui-windows.ps1` (no args defaults to latest `main` push release)
 - Detailed runbook: `docs/runbooks/ec2-binary-tui-validation.md`
 
 ## Install OpenClaw from release package (non-technical quick path)

--- a/docs/runbooks/ec2-binary-tui-validation.md
+++ b/docs/runbooks/ec2-binary-tui-validation.md
@@ -24,6 +24,7 @@ https://github.com/Keith-CY/carrier/releases/download/main-<full_commit_sha>/car
 Notes:
 - The same workflow also uploads Actions artifacts (retention: 14 days).
 - For EC2 validation, prefer release assets (`releases/download/...`) so no local rebuild is needed.
+- Do not infer "latest" by picking the first item from `/releases`; resolve `main` HEAD SHA first, then use `main-<sha>`.
 
 ## 2) Linux EC2 Validation (No Rebuild)
 
@@ -31,8 +32,13 @@ Run on Linux EC2:
 
 ```bash
 chmod +x scripts/ec2-binary-tui-linux.sh
-scripts/ec2-binary-tui-linux.sh --sha <full_commit_sha>
+scripts/ec2-binary-tui-linux.sh
 ```
+
+Behavior:
+- With no `--sha/--tag`, script resolves `Keith-CY/carrier` `main` HEAD automatically.
+- It waits up to 600s for `main-<sha>` release asset to appear (use `--wait-seconds 0` to disable).
+- You can still pin an exact build with `--sha <full_commit_sha>` or `--tag main-<full_commit_sha>`.
 
 Optional non-interactive env:
 
@@ -54,8 +60,13 @@ Complete OAuth in browser while command is waiting.
 Run in PowerShell (Admin not required):
 
 ```powershell
-.\scripts\ec2-binary-tui-windows.ps1 -Sha <full_commit_sha>
+.\scripts\ec2-binary-tui-windows.ps1
 ```
+
+Behavior:
+- With no `-Sha/-Tag`, script resolves `Keith-CY/carrier` `main` HEAD automatically.
+- It waits up to 600s for `main-<sha>` release asset to appear (use `-WaitSeconds 0` to disable).
+- You can still pin an exact build with `-Sha <full_commit_sha>` or `-Tag main-<full_commit_sha>`.
 
 Optional non-interactive env:
 

--- a/scripts/ec2-binary-tui-linux.sh
+++ b/scripts/ec2-binary-tui-linux.sh
@@ -5,6 +5,8 @@
 # Examples:
 #   scripts/ec2-binary-tui-linux.sh --sha <full_commit_sha>
 #   scripts/ec2-binary-tui-linux.sh --tag main-<full_commit_sha>
+#   scripts/ec2-binary-tui-linux.sh --main
+#   scripts/ec2-binary-tui-linux.sh
 #
 # Optional non-interactive inputs:
 #   CARRIER_TELEGRAM_BOT_TOKEN   Telegram bot token used by TUI prompts.
@@ -22,10 +24,15 @@ usage() {
 Usage:
   ec2-binary-tui-linux.sh --sha <full_commit_sha> [options]
   ec2-binary-tui-linux.sh --tag <release_tag> [options]
+  ec2-binary-tui-linux.sh --main [options]
+  ec2-binary-tui-linux.sh [options]
 
 Options:
   --sha <sha>          Full commit SHA. Tag becomes main-<sha>.
   --tag <tag>          Explicit release tag (for example main-<sha>).
+  --main               Resolve SHA from repository main HEAD.
+  --repo <owner/repo>  GitHub repository (default: Keith-CY/carrier).
+  --wait-seconds <n>   Wait up to n seconds for release asset (default: 600 with --main, else 0).
   --label <label>      Asset label (default: linux-x64).
   --out-dir <dir>      Download/extract directory (default: /tmp/carrier-ec2).
   --skip-onboard       Skip `carrier onboard`.
@@ -46,12 +53,54 @@ require_cmd() {
   fi
 }
 
+is_non_negative_integer() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+resolve_main_sha() {
+  local repo="$1"
+  local api_url="https://api.github.com/repos/${repo}/commits/main"
+  local json sha
+
+  json="$(curl -fsSL --retry 3 --retry-delay 2 "$api_url")" || return 1
+  sha="$(printf '%s\n' "$json" | sed -nE 's/^[[:space:]]*"sha":[[:space:]]*"([0-9a-f]{40})".*/\1/p' | head -n 1)"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+  printf '%s\n' "$sha"
+}
+
+wait_for_release_asset() {
+  local url="$1"
+  local timeout="$2"
+  local deadline code
+
+  (( timeout > 0 )) || return 0
+  deadline=$((SECONDS + timeout))
+
+  while :; do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' -L "$url" || true)"
+    if [[ "$code" == "200" ]]; then
+      echo "[ec2] Release asset is ready: $url"
+      return 0
+    fi
+    if (( SECONDS >= deadline )); then
+      echo "ERROR: release asset not ready after ${timeout}s: $url (last HTTP $code)" >&2
+      echo "Hint: wait for Release workflow on main push to finish, then retry." >&2
+      return 1
+    fi
+    echo "[ec2] Waiting for release asset (HTTP $code), retrying in 10s..."
+    sleep 10
+  done
+}
+
 TAG=""
 SHA=""
 LABEL="linux-x64"
 OUT_DIR="/tmp/carrier-ec2"
 SKIP_ONBOARD=0
 SKIP_ADD=0
+REPO="Keith-CY/carrier"
+USE_MAIN=0
+WAIT_SECONDS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +110,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tag)
       TAG="${2:-}"
+      shift 2
+      ;;
+    --main)
+      USE_MAIN=1
+      shift
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --wait-seconds)
+      WAIT_SECONDS="${2:-}"
       shift 2
       ;;
     --label)
@@ -91,13 +152,46 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "$TAG" && -n "$SHA" ]]; then
+  echo "ERROR: --tag and --sha cannot be used together" >&2
+  usage
+  exit 1
+fi
+
+if [[ -n "$WAIT_SECONDS" ]] && ! is_non_negative_integer "$WAIT_SECONDS"; then
+  echo "ERROR: --wait-seconds must be a non-negative integer" >&2
+  usage
+  exit 1
+fi
+
+if [[ -z "$TAG" && -z "$SHA" ]]; then
+  USE_MAIN=1
+fi
+
+if [[ "$USE_MAIN" -eq 1 && -z "$SHA" && -z "$TAG" ]]; then
+  echo "[ec2] Resolving main HEAD SHA from ${REPO}"
+  SHA="$(resolve_main_sha "$REPO")" || {
+    echo "ERROR: failed to resolve main HEAD SHA from ${REPO}" >&2
+    exit 1
+  }
+  echo "[ec2] Resolved main SHA: ${SHA}"
+fi
+
 if [[ -z "$TAG" ]]; then
   if [[ -z "$SHA" ]]; then
-    echo "ERROR: provide --sha or --tag" >&2
+    echo "ERROR: provide --sha or --tag (or use --main)" >&2
     usage
     exit 1
   fi
   TAG="main-$SHA"
+fi
+
+if [[ -z "$WAIT_SECONDS" ]]; then
+  if [[ "$USE_MAIN" -eq 1 ]]; then
+    WAIT_SECONDS=600
+  else
+    WAIT_SECONDS=0
+  fi
 fi
 
 require_cmd curl
@@ -108,17 +202,21 @@ if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1
 fi
 
 ZIP_NAME="carrier-${TAG}-${LABEL}.zip"
-BASE_URL="https://github.com/Keith-CY/carrier/releases/download/${TAG}"
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 ZIP_PATH="${OUT_DIR}/${ZIP_NAME}"
 SUM_PATH="${OUT_DIR}/${ZIP_NAME}.sha256"
+ASSET_URL="${BASE_URL}/${ZIP_NAME}"
+SUM_URL="${BASE_URL}/${ZIP_NAME}.sha256"
 
 mkdir -p "$OUT_DIR"
 
-echo "[ec2] Downloading release asset: ${BASE_URL}/${ZIP_NAME}"
-curl -fL --retry 3 --retry-delay 2 -o "$ZIP_PATH" "${BASE_URL}/${ZIP_NAME}"
+wait_for_release_asset "$ASSET_URL" "$WAIT_SECONDS"
 
-echo "[ec2] Downloading checksum: ${BASE_URL}/${ZIP_NAME}.sha256"
-curl -fL --retry 3 --retry-delay 2 -o "$SUM_PATH" "${BASE_URL}/${ZIP_NAME}.sha256"
+echo "[ec2] Downloading release asset: ${ASSET_URL}"
+curl -fL --retry 3 --retry-delay 2 -o "$ZIP_PATH" "$ASSET_URL"
+
+echo "[ec2] Downloading checksum: ${SUM_URL}"
+curl -fL --retry 3 --retry-delay 2 -o "$SUM_PATH" "$SUM_URL"
 
 echo "[ec2] Verifying checksum"
 if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/ec2-binary-tui-windows.ps1
+++ b/scripts/ec2-binary-tui-windows.ps1
@@ -1,6 +1,9 @@
 param(
   [string]$Sha = "",
   [string]$Tag = "",
+  [switch]$Main,
+  [string]$Repo = "Keith-CY/carrier",
+  [int]$WaitSeconds = -1,
   [string]$Label = "windows-x64",
   [string]$OutDir = "C:\Temp\carrier-ec2",
   [switch]$SkipOnboard,
@@ -14,10 +17,15 @@ function Show-Usage {
 Usage:
   .\ec2-binary-tui-windows.ps1 -Sha <full_commit_sha> [options]
   .\ec2-binary-tui-windows.ps1 -Tag <release_tag> [options]
+  .\ec2-binary-tui-windows.ps1 -Main [options]
+  .\ec2-binary-tui-windows.ps1 [options]
 
 Options:
   -Sha <sha>          Full commit SHA. Tag becomes main-<sha>.
   -Tag <tag>          Explicit release tag (for example main-<sha>).
+  -Main               Resolve SHA from repository main HEAD.
+  -Repo <owner/repo>  GitHub repository (default: Keith-CY/carrier).
+  -WaitSeconds <n>    Wait up to n seconds for release asset (default: 600 with -Main, else 0).
   -Label <label>      Asset label (default: windows-x64).
   -OutDir <dir>       Download/extract directory (default: C:\Temp\carrier-ec2).
   -SkipOnboard        Skip `carrier onboard`.
@@ -34,13 +42,87 @@ Notes:
 "@
 }
 
+function Wait-ReleaseAsset {
+  param(
+    [string]$Uri,
+    [int]$TimeoutSeconds
+  )
+
+  if ($TimeoutSeconds -le 0) {
+    return
+  }
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ($true) {
+    $ready = $false
+    $statusCode = 0
+    try {
+      $response = Invoke-WebRequest -Uri $Uri -Method Head -MaximumRedirection 5
+      $statusCode = [int]$response.StatusCode
+      if ($statusCode -ge 200 -and $statusCode -lt 400) {
+        $ready = $true
+      }
+    } catch {
+      if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+        $statusCode = [int]$_.Exception.Response.StatusCode.value__
+      }
+    }
+
+    if ($ready) {
+      Write-Host "[ec2] Release asset is ready: $Uri"
+      return
+    }
+
+    if ((Get-Date) -ge $deadline) {
+      throw "Release asset not ready after $TimeoutSeconds seconds: $Uri (last HTTP $statusCode)"
+    }
+
+    Write-Host "[ec2] Waiting for release asset (HTTP $statusCode), retrying in 10s..."
+    Start-Sleep -Seconds 10
+  }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($Tag) -and -not [string]::IsNullOrWhiteSpace($Sha)) {
+  Write-Error "-Tag and -Sha cannot be used together."
+  Show-Usage
+  exit 1
+}
+
+if ($WaitSeconds -lt -1) {
+  Write-Error "-WaitSeconds must be -1 or a non-negative integer."
+  Show-Usage
+  exit 1
+}
+
+if ([string]::IsNullOrWhiteSpace($Tag) -and [string]::IsNullOrWhiteSpace($Sha)) {
+  $Main = $true
+}
+
+if ($Main -and [string]::IsNullOrWhiteSpace($Tag) -and [string]::IsNullOrWhiteSpace($Sha)) {
+  Write-Host "[ec2] Resolving main HEAD SHA from $Repo"
+  $mainHead = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/commits/main"
+  $Sha = [string]$mainHead.sha
+  if ([string]::IsNullOrWhiteSpace($Sha) -or $Sha.Length -ne 40) {
+    throw "Failed to resolve main HEAD SHA from $Repo"
+  }
+  Write-Host "[ec2] Resolved main SHA: $Sha"
+}
+
 if ([string]::IsNullOrWhiteSpace($Tag)) {
   if ([string]::IsNullOrWhiteSpace($Sha)) {
-    Write-Error "Provide -Sha or -Tag."
+    Write-Error "Provide -Sha or -Tag (or use -Main)."
     Show-Usage
     exit 1
   }
   $Tag = "main-$Sha"
+}
+
+if ($WaitSeconds -eq -1) {
+  if ($Main) {
+    $WaitSeconds = 600
+  } else {
+    $WaitSeconds = 0
+  }
 }
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
@@ -48,7 +130,9 @@ New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 $zipName = "carrier-$Tag-$Label.zip"
 $zipPath = Join-Path $OutDir $zipName
 $sumPath = Join-Path $OutDir "$zipName.sha256"
-$baseUrl = "https://github.com/Keith-CY/carrier/releases/download/$Tag"
+$baseUrl = "https://github.com/$Repo/releases/download/$Tag"
+
+Wait-ReleaseAsset -Uri "$baseUrl/$zipName" -TimeoutSeconds $WaitSeconds
 
 Write-Host "[ec2] Downloading release asset: $baseUrl/$zipName"
 Invoke-WebRequest -Uri "$baseUrl/$zipName" -OutFile $zipPath


### PR DESCRIPTION
## Summary
- make Linux/Windows EC2 validation scripts default to resolve `main` HEAD SHA from `Keith-CY/carrier`
- add optional wait loop for release asset availability to avoid race right after merge
- document that `/releases` list order is not a safe way to pick latest binary

## Validation
- `bash -n scripts/ec2-binary-tui-linux.sh`
- `scripts/ec2-binary-tui-linux.sh --help`
- `git diff --check`
- `scripts/check-doc-command-sync.sh` (no sync markers in repo)
