### PR TITLE
feat(openclaw): auto-repair install failures via base-agent triage

### DIFF
--- a/daemon/internal/baseagent/llm.go
+++ b/daemon/internal/baseagent/llm.go
@@ -41,6 +41,10 @@ type llmRuntimeConfig struct {
 }
 
 func (r *Runtime) replyWithLLM(ctx context.Context, userMessage string) (string, error) {
+	return requestLLMCompletion(ctx, baseAgentSystemPrompt, userMessage)
+}
+
+func requestLLMCompletion(ctx context.Context, systemPrompt, userMessage string) (string, error) {
 	cfg, err := resolveLLMRuntimeConfig()
 	if err != nil {
 		return "", err
@@ -51,11 +55,11 @@ func (r *Runtime) replyWithLLM(ctx context.Context, userMessage string) (string,
 	}
 
 	path := "/chat/completions"
-	reqBody := buildOpenAICompatibleChatRequest(modelID, userMessage)
+	reqBody := buildOpenAICompatibleChatRequest(modelID, systemPrompt, userMessage)
 	parseResponse := parseOpenAICompatibleChatResponse
 	if isOpenAICodexProvider(cfg.ProviderID) {
 		path = "/codex/responses"
-		reqBody = buildOpenAICodexResponsesRequest(modelID, userMessage)
+		reqBody = buildOpenAICodexResponsesRequest(modelID, systemPrompt, userMessage)
 		parseResponse = parseOpenAICodexResponses
 	}
 
@@ -119,23 +123,23 @@ func (r *Runtime) replyWithLLM(ctx context.Context, userMessage string) (string,
 	return text, nil
 }
 
-func buildOpenAICompatibleChatRequest(modelID, userMessage string) map[string]interface{} {
+func buildOpenAICompatibleChatRequest(modelID, systemPrompt, userMessage string) map[string]interface{} {
 	return map[string]interface{}{
 		"model": modelID,
 		"messages": []map[string]string{
-			{"role": "system", "content": baseAgentSystemPrompt},
+			{"role": "system", "content": systemPrompt},
 			{"role": "user", "content": userMessage},
 		},
 		"temperature": 0.2,
 	}
 }
 
-func buildOpenAICodexResponsesRequest(modelID, userMessage string) map[string]interface{} {
+func buildOpenAICodexResponsesRequest(modelID, systemPrompt, userMessage string) map[string]interface{} {
 	return map[string]interface{}{
 		"model":        modelID,
 		"store":        false,
 		"stream":       true,
-		"instructions": baseAgentSystemPrompt,
+		"instructions": systemPrompt,
 		"input": []map[string]interface{}{
 			{
 				"role": "user",

--- a/daemon/internal/baseagent/triager_llm.go
+++ b/daemon/internal/baseagent/triager_llm.go
@@ -1,0 +1,167 @@
+package baseagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"carrier/daemon/internal/redact"
+)
+
+const installFailureTriagerSystemPrompt = "You are Carrier's install-failure triage engine. " +
+	"Return JSON only. " +
+	"Never ask for secrets. Never emit destructive commands. " +
+	"Only suggest a repairAction when a single low-risk command can help recover install failures. " +
+	"Allowed command values: " +
+	"`npm cache clean --force`, `pnpm install`, `npm install`, `yarn install`, `pip cache purge`, `pip install -r requirements.txt`, `go mod download`. " +
+	"If unsure, set repairAction to null and requiresRemoteDiagnosis=true."
+
+type LLMTriager struct {
+	fallback Triager
+}
+
+type llmRepairAction struct {
+	Command    string `json:"command"`
+	TargetPath string `json:"targetPath"`
+	RiskLevel  string `json:"riskLevel"`
+}
+
+type llmTriageResponse struct {
+	Resolved                bool             `json:"resolved"`
+	Summary                 string           `json:"summary"`
+	SuggestedActions        []string         `json:"suggestedActions"`
+	RequiresRemoteDiagnosis bool             `json:"requiresRemoteDiagnosis"`
+	RepairAction            *llmRepairAction `json:"repairAction"`
+}
+
+func NewLLMTriager(fallback Triager) *LLMTriager {
+	if fallback == nil {
+		fallback = NoopTriager{}
+	}
+	return &LLMTriager{fallback: fallback}
+}
+
+func (t *LLMTriager) Analyze(ctx context.Context, e Evidence) (TriageResult, error) {
+	prompt := buildInstallFailurePrompt(e)
+	raw, err := requestLLMCompletion(ctx, installFailureTriagerSystemPrompt, prompt)
+	if err != nil {
+		return t.fallbackResult(ctx, e, err), nil
+	}
+
+	parsed, err := parseLLMTriageResponse(raw)
+	if err != nil {
+		return t.fallbackResult(ctx, e, err), nil
+	}
+
+	result := TriageResult{
+		Resolved:                parsed.Resolved,
+		Summary:                 strings.TrimSpace(parsed.Summary),
+		SuggestedActions:        compactNonEmpty(parsed.SuggestedActions, 8),
+		RequiresRemoteDiagnosis: parsed.RequiresRemoteDiagnosis,
+	}
+	if parsed.RepairAction != nil {
+		command := strings.TrimSpace(parsed.RepairAction.Command)
+		if command != "" {
+			result.RepairAction = &RepairAction{
+				Command:    command,
+				TargetPath: strings.TrimSpace(parsed.RepairAction.TargetPath),
+				RiskLevel:  RiskLevel(strings.ToLower(strings.TrimSpace(parsed.RepairAction.RiskLevel))),
+			}
+		}
+	}
+	if result.Summary == "" {
+		result.Summary = "LLM triage produced no summary; using fallback guidance."
+	}
+	return result, nil
+}
+
+func (t *LLMTriager) fallbackResult(ctx context.Context, e Evidence, cause error) TriageResult {
+	base, _ := t.fallback.Analyze(ctx, e)
+	reason := strings.TrimSpace(strings.ReplaceAll(cause.Error(), "\n", " "))
+	if len(reason) > 240 {
+		reason = reason[:240] + "..."
+	}
+	if base.Summary == "" {
+		base.Summary = "Base Agent fallback triage activated."
+	}
+	base.Summary = fmt.Sprintf("%s (LLM unavailable: %s)", base.Summary, reason)
+	base.RepairAction = nil
+	base.RequiresRemoteDiagnosis = true
+	if len(base.SuggestedActions) == 0 {
+		base.SuggestedActions = []string{"Run /diagnose", "Review latest logs"}
+	}
+	return base
+}
+
+func buildInstallFailurePrompt(e Evidence) string {
+	const maxTail = 40
+	logTail := e.LogTail
+	if len(logTail) > maxTail {
+		logTail = logTail[len(logTail)-maxTail:]
+	}
+	redactedLogs := make([]string, 0, len(logTail))
+	for _, line := range logTail {
+		redactedLogs = append(redactedLogs, redact.RedactText(line))
+	}
+
+	payload := map[string]interface{}{
+		"agentId":     strings.TrimSpace(e.AgentID),
+		"lastError":   redact.RedactText(strings.TrimSpace(e.LastError)),
+		"exitCode":    e.ExitCode,
+		"logTail":     redactedLogs,
+		"healthProbe": redact.RedactText(strings.TrimSpace(e.HealthProbe)),
+		"outputSchema": map[string]interface{}{
+			"resolved":                "boolean",
+			"summary":                 "string",
+			"suggestedActions":        []string{},
+			"requiresRemoteDiagnosis": "boolean",
+			"repairAction": map[string]string{
+				"command":    "string (must be in allowlist) or empty",
+				"targetPath": "string (optional)",
+				"riskLevel":  "low",
+			},
+		},
+	}
+	raw, _ := json.Marshal(payload)
+	return "Analyze the install failure evidence and return exactly one JSON object matching outputSchema.\n" + string(raw)
+}
+
+func parseLLMTriageResponse(raw string) (*llmTriageResponse, error) {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return nil, fmt.Errorf("empty model response")
+	}
+
+	// Tolerate markdown wrappers and extra narration by extracting the JSON object.
+	start := strings.Index(candidate, "{")
+	end := strings.LastIndex(candidate, "}")
+	if start < 0 || end < start {
+		return nil, fmt.Errorf("triage response did not contain JSON object")
+	}
+	candidate = candidate[start : end+1]
+
+	var parsed llmTriageResponse
+	if err := json.Unmarshal([]byte(candidate), &parsed); err != nil {
+		return nil, fmt.Errorf("decode triage json: %w", err)
+	}
+	return &parsed, nil
+}
+
+func compactNonEmpty(items []string, limit int) []string {
+	if limit <= 0 {
+		limit = len(items)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}

--- a/daemon/internal/baseagent/triager_llm_test.go
+++ b/daemon/internal/baseagent/triager_llm_test.go
@@ -1,0 +1,66 @@
+package baseagent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseLLMTriageResponse_JSONObject(t *testing.T) {
+	raw := `{
+		"resolved": false,
+		"summary": "Dependency cache issue",
+		"suggestedActions": ["clean npm cache", "retry install"],
+		"requiresRemoteDiagnosis": false,
+		"repairAction": {
+			"command": "npm cache clean --force",
+			"targetPath": "",
+			"riskLevel": "low"
+		}
+	}`
+
+	parsed, err := parseLLMTriageResponse(raw)
+	if err != nil {
+		t.Fatalf("parseLLMTriageResponse() error = %v", err)
+	}
+	if parsed == nil || parsed.RepairAction == nil {
+		t.Fatal("expected parsed repair action")
+	}
+	if parsed.RepairAction.Command != "npm cache clean --force" {
+		t.Fatalf("repair command = %q", parsed.RepairAction.Command)
+	}
+}
+
+func TestParseLLMTriageResponse_WithMarkdownWrapper(t *testing.T) {
+	raw := "```json\n{\"resolved\":false,\"summary\":\"wrapped\",\"suggestedActions\":[],\"requiresRemoteDiagnosis\":true,\"repairAction\":null}\n```"
+	parsed, err := parseLLMTriageResponse(raw)
+	if err != nil {
+		t.Fatalf("parseLLMTriageResponse() error = %v", err)
+	}
+	if parsed.Summary != "wrapped" {
+		t.Fatalf("summary = %q, want wrapped", parsed.Summary)
+	}
+}
+
+func TestLLMTriagerAnalyze_FallbackWhenLLMUnavailable(t *testing.T) {
+	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "")
+	t.Setenv("CARRIER_DEFAULT_MODEL_ID", "")
+
+	triager := NewLLMTriager(NoopTriager{})
+	result, err := triager.Analyze(context.Background(), Evidence{
+		AgentID:   "openclaw",
+		LastError: "install failed",
+		LogTail:   []string{"line 1"},
+	})
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if !result.RequiresRemoteDiagnosis {
+		t.Fatal("expected RequiresRemoteDiagnosis=true on fallback")
+	}
+	if result.RepairAction != nil {
+		t.Fatalf("expected no repair action on fallback, got %+v", result.RepairAction)
+	}
+	if result.Summary == "" {
+		t.Fatal("expected fallback summary")
+	}
+}

--- a/daemon/internal/baseagent/types.go
+++ b/daemon/internal/baseagent/types.go
@@ -15,6 +15,7 @@ type TriageResult struct {
 	Summary                 string
 	SuggestedActions        []string
 	RequiresRemoteDiagnosis bool
+	RepairAction            *RepairAction
 }
 
 type Triager interface {

--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -40,6 +41,10 @@ const (
 
 	openClawInstallMethodEnv          = "CARRIER_OPENCLAW_INSTALL_METHOD"
 	openClawDisableInstallFallbackEnv = "CARRIER_OPENCLAW_DISABLE_INSTALL_FALLBACK"
+	openClawInstallMemInfoPathEnv     = "CARRIER_OPENCLAW_MEMINFO_PATH"
+
+	openClawNodeMaxOldSpaceMB   = 384
+	openClawLowMemoryThresholdK = 1536 * 1024 // 1.5 GiB in KiB
 
 	// Official OpenClaw installer URLs
 	installScriptURL = "https://openclaw.ai/install.sh"
@@ -72,34 +77,66 @@ func getInstallCommand() string {
 			// Keep git as first choice, then retry with installer default mode.
 			// Run installer in child PowerShell processes so script-level `exit`
 			// does not terminate fallback orchestration.
-			return fmt.Sprintf(`powershell -NoProfile -Command "$ErrorActionPreference='Stop';$tmp=[System.IO.Path]::GetTempFileName();$ps1="$tmp.ps1";Move-Item -LiteralPath $tmp -Destination $ps1 -Force;irm '%s' | Out-File -LiteralPath $ps1 -Encoding utf8;try {$env:CARGO_BUILD_JOBS='1';powershell -NoProfile -ExecutionPolicy Bypass -File $ps1 -InstallMethod 'git' -NoOnboard; if ($LASTEXITCODE -ne 0) { powershell -NoProfile -ExecutionPolicy Bypass -File $ps1 -NoOnboard; exit $LASTEXITCODE }} finally { Remove-Item -LiteralPath $ps1 -ErrorAction SilentlyContinue }"`, installPS1URL)
+			return fmt.Sprintf(`powershell -NoProfile -Command "$ErrorActionPreference='Stop';$tmp=[System.IO.Path]::GetTempFileName();$ps1="$tmp.ps1";Move-Item -LiteralPath $tmp -Destination $ps1 -Force;irm '%s' | Out-File -LiteralPath $ps1 -Encoding utf8;try {$env:CARGO_BUILD_JOBS='1';$env:NODE_OPTIONS='--max-old-space-size=%d';$env:OPENCLAW_NPM_LOGLEVEL='warn';$env:SHARP_IGNORE_GLOBAL_LIBVIPS='1';powershell -NoProfile -ExecutionPolicy Bypass -File $ps1 -InstallMethod 'git' -NoOnboard; if ($LASTEXITCODE -ne 0) { $env:NODE_OPTIONS='--max-old-space-size=%d';$env:OPENCLAW_NPM_LOGLEVEL='warn';$env:SHARP_IGNORE_GLOBAL_LIBVIPS='1';powershell -NoProfile -ExecutionPolicy Bypass -File $ps1 -InstallMethod 'npm' -NoOnboard; exit $LASTEXITCODE }} finally { Remove-Item -LiteralPath $ps1 -ErrorAction SilentlyContinue }"`, installPS1URL, openClawNodeMaxOldSpaceMB, openClawNodeMaxOldSpaceMB)
 		}
 		if method == "git" {
-			return fmt.Sprintf(`powershell -NoProfile -Command "$env:CARGO_BUILD_JOBS='1';& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, installPS1URL, method)
+			return fmt.Sprintf(`powershell -NoProfile -Command "$env:CARGO_BUILD_JOBS='1';$env:NODE_OPTIONS='--max-old-space-size=%d';$env:OPENCLAW_NPM_LOGLEVEL='warn';$env:SHARP_IGNORE_GLOBAL_LIBVIPS='1';& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, openClawNodeMaxOldSpaceMB, installPS1URL, method)
 		}
-		return fmt.Sprintf(`powershell -NoProfile -Command "& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, installPS1URL, method)
+		return fmt.Sprintf(`powershell -NoProfile -Command "$env:NODE_OPTIONS='--max-old-space-size=%d';$env:OPENCLAW_NPM_LOGLEVEL='warn';$env:SHARP_IGNORE_GLOBAL_LIBVIPS='1';& ([scriptblock]::Create((irm '%s'))) -InstallMethod '%s' -NoOnboard"`, openClawNodeMaxOldSpaceMB, installPS1URL, method)
 	default:
 		// Linux, macOS, and anything else that has sh + curl.
 		if allowFallback {
 			// On small instances, the git build path can be OOM-killed; fallback keeps installs unblocked.
-			return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; CARGO_BUILD_JOBS=1 bash "$tmp" --install-method git --no-onboard || bash "$tmp" --no-onboard'`, installScriptURL)
+			return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; CARGO_BUILD_JOBS=1 NODE_OPTIONS="--max-old-space-size=%d" OPENCLAW_NPM_LOGLEVEL=warn SHARP_IGNORE_GLOBAL_LIBVIPS=1 bash "$tmp" --install-method git --no-onboard || NODE_OPTIONS="--max-old-space-size=%d" OPENCLAW_NPM_LOGLEVEL=warn SHARP_IGNORE_GLOBAL_LIBVIPS=1 bash "$tmp" --install-method npm --no-onboard'`, installScriptURL, openClawNodeMaxOldSpaceMB, openClawNodeMaxOldSpaceMB)
 		}
 		if method == "git" {
-			return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; CARGO_BUILD_JOBS=1 bash "$tmp" --install-method %s --no-onboard'`, installScriptURL, method)
+			return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; CARGO_BUILD_JOBS=1 NODE_OPTIONS="--max-old-space-size=%d" OPENCLAW_NPM_LOGLEVEL=warn SHARP_IGNORE_GLOBAL_LIBVIPS=1 bash "$tmp" --install-method %s --no-onboard'`, installScriptURL, openClawNodeMaxOldSpaceMB, method)
 		}
-		return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; bash "$tmp" --install-method %s --no-onboard'`, installScriptURL, method)
+		return fmt.Sprintf(`sh -c 'set -e; tmp=$(mktemp); trap "rm -f $tmp" EXIT; curl -fsSL --proto "=https" --tlsv1.2 "%s" -o "$tmp"; NODE_OPTIONS="--max-old-space-size=%d" OPENCLAW_NPM_LOGLEVEL=warn SHARP_IGNORE_GLOBAL_LIBVIPS=1 bash "$tmp" --install-method %s --no-onboard'`, installScriptURL, openClawNodeMaxOldSpaceMB, method)
 	}
 }
 
 func resolveOpenClawInstallMethod() (method string, explicit bool) {
 	raw := strings.TrimSpace(os.Getenv(openClawInstallMethodEnv))
 	if raw == "" {
+		if shouldPreferNPMInstallOnLowMemoryHost() {
+			return "npm", false
+		}
 		return "git", false
 	}
 	if !isSafeInstallerToken(raw) {
+		if shouldPreferNPMInstallOnLowMemoryHost() {
+			return "npm", false
+		}
 		return "git", false
 	}
 	return strings.ToLower(raw), true
+}
+
+func shouldPreferNPMInstallOnLowMemoryHost() bool {
+	memInfoPath := strings.TrimSpace(os.Getenv(openClawInstallMemInfoPathEnv))
+	if memInfoPath == "" {
+		memInfoPath = "/proc/meminfo"
+	}
+	raw, err := os.ReadFile(memInfoPath)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return false
+		}
+		memKB, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return false
+		}
+		return memKB > 0 && memKB <= openClawLowMemoryThresholdK
+	}
+	return false
 }
 
 func isSafeInstallerToken(value string) bool {

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"carrier/daemon/internal/manifest"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -134,6 +135,16 @@ func searchSubstring(s, substr string) bool {
 	return false
 }
 
+func writeMemInfoFixture(t *testing.T, memKB int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "meminfo")
+	content := fmt.Sprintf("MemTotal:       %d kB\n", memKB)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write meminfo fixture: %v", err)
+	}
+	return path
+}
+
 func TestCatalogJSONHealthcheckMatchesGeneratedManifest(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "catalog", "openclaw.manifest.json")
 	fileManifest, err := manifest.LoadFile(path)
@@ -159,6 +170,7 @@ func TestGetInstallCommand_Default(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "")
 	t.Setenv(openClawInstallMethodEnv, "")
 	t.Setenv(openClawDisableInstallFallbackEnv, "")
+	t.Setenv(openClawInstallMemInfoPathEnv, writeMemInfoFixture(t, 8*1024*1024))
 
 	cmd := getInstallCommand()
 
@@ -184,6 +196,8 @@ func TestGetInstallCommand_Default(t *testing.T) {
 			".ps1",
 			"Move-Item",
 			"powershell -NoProfile -ExecutionPolicy Bypass -File",
+			"InstallMethod 'npm'",
+			"$env:NODE_OPTIONS='--max-old-space-size=384'",
 		} {
 			t.Run(want, func(t *testing.T) {
 				if !strings.Contains(cmd, want) {
@@ -194,9 +208,12 @@ func TestGetInstallCommand_Default(t *testing.T) {
 	default:
 		for _, want := range []string{
 			"CARGO_BUILD_JOBS=1",
+			`NODE_OPTIONS="--max-old-space-size=384"`,
+			"OPENCLAW_NPM_LOGLEVEL=warn",
+			"SHARP_IGNORE_GLOBAL_LIBVIPS=1",
 			"mktemp",
 			"curl -fsSL",
-			"|| bash \"$tmp\" --no-onboard",
+			"--install-method npm --no-onboard",
 		} {
 			if !strings.Contains(cmd, want) {
 				t.Errorf("unix default command should include fallback token %q\ngot: %s", want, cmd)
@@ -223,6 +240,7 @@ func TestGetInstallCommand_DisableFallback(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "")
 	t.Setenv(openClawInstallMethodEnv, "")
 	t.Setenv(openClawDisableInstallFallbackEnv, "1")
+	t.Setenv(openClawInstallMemInfoPathEnv, writeMemInfoFixture(t, 8*1024*1024))
 
 	cmd := getInstallCommand()
 
@@ -238,6 +256,7 @@ func TestGetInstallCommand_UnsafeMethodFallsBackToDefault(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "")
 	t.Setenv(openClawInstallMethodEnv, "git;rm -rf /")
 	t.Setenv(openClawDisableInstallFallbackEnv, "")
+	t.Setenv(openClawInstallMemInfoPathEnv, writeMemInfoFixture(t, 8*1024*1024))
 
 	cmd := getInstallCommand()
 
@@ -261,6 +280,27 @@ func TestGetInstallCommand_ExplicitGitUsesCargoBuildJobs(t *testing.T) {
 	}
 	if !strings.Contains(cmd, "CARGO_BUILD_JOBS=1") {
 		t.Fatalf("expected explicit git path to include CARGO_BUILD_JOBS=1, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--max-old-space-size=384") {
+		t.Fatalf("expected explicit git path to include NODE_OPTIONS max-old-space-size, got: %s", cmd)
+	}
+}
+
+func TestGetInstallCommand_LowMemoryDefaultsToNPM(t *testing.T) {
+	t.Setenv("CARRIER_DEV_MODE", "")
+	t.Setenv(openClawInstallMethodEnv, "")
+	t.Setenv(openClawDisableInstallFallbackEnv, "")
+	t.Setenv(openClawInstallMemInfoPathEnv, writeMemInfoFixture(t, 938840))
+
+	cmd := getInstallCommand()
+	if !strings.Contains(cmd, "--install-method npm") {
+		t.Fatalf("expected low-memory default to npm install method, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--install-method git") {
+		t.Fatalf("low-memory default should not keep git as primary method, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "||") || strings.Contains(cmd, "try {") {
+		t.Fatalf("low-memory npm path should not include git fallback orchestration, got: %s", cmd)
 	}
 }
 

--- a/daemon/internal/lifecycle/install.go
+++ b/daemon/internal/lifecycle/install.go
@@ -2,10 +2,15 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"carrier/daemon/internal/baseagent"
 )
 
 func (s *Service) Install(ctx context.Context, agentID string) error {
-	m, state, err := s.getManifestAndState(agentID)
+	m, _, err := s.getManifestAndState(agentID)
 	if err != nil {
 		return err
 	}
@@ -22,13 +27,53 @@ func (s *Service) Install(ctx context.Context, agentID string) error {
 	result, runErr := s.runner.Run(opCtx, m.Runtime.Install.Command)
 	s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
 	if runErr != nil {
+		triage, triageErr := s.HandleFailure(ctx, agentID, runErr.Error())
+		if triageErr != nil {
+			s.appendLog(agentID, fmt.Sprintf("triage error: %v", triageErr))
+		} else if triage.Summary != "" {
+			s.appendLog(agentID, fmt.Sprintf("triage summary: %s", triage.Summary))
+		}
+
+		repaired := false
+		if triageErr == nil {
+			repaired, err = s.tryAutoRepairInstallFailure(opCtx, agentID, triage)
+			if err != nil {
+				s.appendLog(agentID, fmt.Sprintf("auto-repair skipped: %v", err))
+			}
+		}
+		if repaired {
+			retryResult, retryErr := s.runner.Run(opCtx, m.Runtime.Install.Command)
+			s.appendCommandLog(agentID, "install-retry", m.Runtime.Install.Command, retryResult, retryErr)
+			if retryErr == nil {
+				s.markInstallSuccess(agentID)
+				s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed after auto-repair")
+				s.saveState()
+				return nil
+			}
+			runErr = fmt.Errorf("install failed after auto-repair: %w", retryErr)
+		}
+
 		s.updateStateOnInstallError(agentID, runErr)
 		s.recordAudit("", "system", "install", agentID, AuditResultFailure, "E_INSTALL_FAILED", runErr.Error())
 		return runErr
 	}
 
+	s.markInstallSuccess(agentID)
+	s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed")
+
+	s.saveState()
+
+	return nil
+}
+
+func (s *Service) markInstallSuccess(agentID string) {
 	s.mu.Lock()
-	state = s.states[agentID]
+	defer s.mu.Unlock()
+
+	state, ok := s.states[agentID]
+	if !ok {
+		return
+	}
 	state.Install = InstallStateInstalled
 	state.Runtime = RuntimeStateStopped
 	state.Health = HealthStateUnknown
@@ -37,10 +82,46 @@ func (s *Service) Install(ctx context.Context, agentID string) error {
 	state.NeedsRemoteDiagnosis = false
 	state.UpdatedAt = s.now()
 	s.states[agentID] = state
-	s.mu.Unlock()
-	s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed")
+}
 
-	s.saveState()
+func (s *Service) tryAutoRepairInstallFailure(ctx context.Context, agentID string, triage baseagent.TriageResult) (bool, error) {
+	if !strings.EqualFold(agentID, "openclaw") {
+		return false, nil
+	}
+	if triage.RepairAction == nil {
+		return false, nil
+	}
 
-	return nil
+	action, err := baseagent.ValidateRepairAction(*triage.RepairAction, false)
+	if err != nil {
+		if errors.Is(err, baseagent.ErrRepairActionNeedsConfirmation) || errors.Is(err, baseagent.ErrRepairActionNotAllowed) {
+			s.recordAudit("", "base-agent", "repair", agentID, AuditResultFailure, "E_REPAIR_POLICY", err.Error())
+		}
+		return false, err
+	}
+
+	repairCommand := strings.TrimSpace(action.Command)
+	targetPath := strings.TrimSpace(action.TargetPath)
+	if repairCommand == "" {
+		return false, nil
+	}
+	if targetPath != "" {
+		repairCommand = fmt.Sprintf("cd %s && %s", shellSingleQuote(targetPath), repairCommand)
+	}
+
+	result, repairErr := s.runner.Run(ctx, repairCommand)
+	s.appendCommandLog(agentID, "repair", repairCommand, result, repairErr)
+	if repairErr != nil {
+		s.recordAudit("", "base-agent", "repair", agentID, AuditResultFailure, "E_REPAIR_FAILED", repairErr.Error())
+		return false, repairErr
+	}
+	s.recordAudit("", "base-agent", "repair", agentID, AuditResultSuccess, "", fmt.Sprintf("auto-repair command succeeded: %s", action.Command))
+	return true, nil
+}
+
+func shellSingleQuote(input string) string {
+	if input == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(input, "'", `'"'"'`) + "'"
 }

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -24,8 +24,11 @@ import (
 )
 
 type fakeRunner struct {
-	calls   []string
-	results map[string]runResult
+	calls    []string
+	results  map[string]runResult
+	sequence map[string][]runResult
+	onRun    func(command string, call int) (runResult, bool)
+	counts   map[string]int
 }
 
 type runResult struct {
@@ -35,6 +38,22 @@ type runResult struct {
 
 func (f *fakeRunner) Run(_ context.Context, command string) (commandexec.Result, error) {
 	f.calls = append(f.calls, command)
+	if f.counts == nil {
+		f.counts = make(map[string]int)
+	}
+	f.counts[command]++
+	call := f.counts[command]
+
+	if f.onRun != nil {
+		if res, ok := f.onRun(command, call); ok {
+			return res.result, res.err
+		}
+	}
+	if seq, ok := f.sequence[command]; ok && len(seq) > 0 {
+		res := seq[0]
+		f.sequence[command] = seq[1:]
+		return res.result, res.err
+	}
 	if f.results == nil {
 		return commandexec.Result{}, nil
 	}
@@ -389,6 +408,112 @@ func TestInstallFailsWhenPrerequisiteCheckFails(t *testing.T) {
 	}
 	if status.Install != InstallStateBroken {
 		t.Fatalf("expected install state broken, got %s", status.Install)
+	}
+}
+
+func TestInstallRetriesAfterLLMRepairAction(t *testing.T) {
+	runner := &fakeRunner{
+		sequence: map[string][]runResult{
+			"install-openclaw": {
+				{result: commandexec.Result{ExitCode: 1, CombinedOutput: "npm install failed"}, err: errors.New("install attempt 1 failed")},
+				{result: commandexec.Result{ExitCode: 0, CombinedOutput: "ok"}, err: nil},
+			},
+		},
+		results: map[string]runResult{
+			"cd '/tmp/openclaw-workspace' && pnpm install": {result: commandexec.Result{ExitCode: 0, CombinedOutput: "pnpm repaired"}, err: nil},
+		},
+	}
+	checker := &fakeChecker{}
+	svc := newServiceForTest(t, runner, checker)
+	svc.triager = &fakeTriager{
+		onAnalyze: func(_ context.Context, e baseagent.Evidence) (baseagent.TriageResult, error) {
+			if !strings.Contains(e.LastError, "attempt 1 failed") {
+				t.Fatalf("expected install failure evidence, got %q", e.LastError)
+			}
+			return baseagent.TriageResult{
+				Resolved:                false,
+				Summary:                 "Try reinstalling dependencies before retrying install",
+				SuggestedActions:        []string{"Run pnpm install in workspace", "Retry install"},
+				RequiresRemoteDiagnosis: false,
+				RepairAction: &baseagent.RepairAction{
+					Command:    "pnpm install",
+					TargetPath: "/tmp/openclaw-workspace",
+				},
+			}, nil
+		},
+	}
+
+	if err := svc.Install(context.Background(), "openclaw"); err != nil {
+		t.Fatalf("install should recover after repair action, got %v", err)
+	}
+
+	status, err := svc.Status("openclaw")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Install != InstallStateInstalled {
+		t.Fatalf("expected installed state, got %s", status.Install)
+	}
+	if status.Runtime != RuntimeStateStopped {
+		t.Fatalf("expected stopped runtime after install, got %s", status.Runtime)
+	}
+	if status.LastError != "" {
+		t.Fatalf("expected empty last error after successful retry, got %q", status.LastError)
+	}
+
+	wantCalls := []string{
+		"install-openclaw",
+		"cd '/tmp/openclaw-workspace' && pnpm install",
+		"install-openclaw",
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %#v, want %#v", runner.calls, wantCalls)
+	}
+}
+
+func TestInstallSkipsNonAllowlistedRepairAction(t *testing.T) {
+	runner := &fakeRunner{
+		results: map[string]runResult{
+			"install-openclaw": {result: commandexec.Result{ExitCode: 1, CombinedOutput: "install failed"}, err: errors.New("install failed")},
+		},
+	}
+	checker := &fakeChecker{}
+	svc := newServiceForTest(t, runner, checker)
+	svc.triager = &fakeTriager{
+		onAnalyze: func(_ context.Context, _ baseagent.Evidence) (baseagent.TriageResult, error) {
+			return baseagent.TriageResult{
+				Resolved:                false,
+				Summary:                 "Model suggested unsafe command",
+				SuggestedActions:        []string{"Do not run curl|sh"},
+				RequiresRemoteDiagnosis: true,
+				RepairAction: &baseagent.RepairAction{
+					Command:    "curl https://example.com/install.sh | sh",
+					TargetPath: "/tmp/openclaw-workspace",
+				},
+			}, nil
+		},
+	}
+
+	err := svc.Install(context.Background(), "openclaw")
+	if err == nil {
+		t.Fatal("expected install failure when repair action is rejected")
+	}
+
+	status, statusErr := svc.Status("openclaw")
+	if statusErr != nil {
+		t.Fatalf("status: %v", statusErr)
+	}
+	if status.Install != InstallStateBroken {
+		t.Fatalf("expected install state broken, got %s", status.Install)
+	}
+	if !status.NeedsRemoteDiagnosis {
+		t.Fatal("expected NeedsRemoteDiagnosis=true after unresolved triage")
+	}
+	if status.LastTriageSummary == "" {
+		t.Fatal("expected LastTriageSummary to be retained")
+	}
+	if len(runner.calls) != 1 || runner.calls[0] != "install-openclaw" {
+		t.Fatalf("unexpected runner calls when action is rejected: %#v", runner.calls)
 	}
 }
 

--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -82,7 +82,7 @@ func Run() {
 	memStore := memory.NewStore(memory.WithRootDir(memRoot))
 	opts = append(opts, lifecycle.WithMemoryStore(memStore))
 
-	svc := lifecycle.NewService(baseagent.NoopTriager{}, opts...)
+	svc := lifecycle.NewService(baseagent.NewLLMTriager(baseagent.NoopTriager{}), opts...)
 	baseRuntime := baseagent.NewRuntime(newLifecycleAgentServiceAdapter(svc), memStore)
 
 	if err := svc.RegisterManifest(catalog.OpenClawManifest()); err != nil {


### PR DESCRIPTION
## Summary\n- add a new LLM-backed base-agent triager with strict JSON parsing and fallback to noop triage\n- wire daemon runtime to use LLMTriager (with Noop fallback)\n- on openclaw install failure, run triage -> validate allowlisted repair command -> execute repair -> retry install\n- keep repair bounded by existing base-agent allowlist/risk policy and audit logs\n- include low-memory openclaw installer hardening (npm default/fallback + conservative NODE_OPTIONS) and tests\n\n## Verification\n- go test ./internal/baseagent ./internal/lifecycle ./internal/catalog ./server -count=1\n