### PR TITLE
docs: add core architecture doc links to audit snapshot

### DIFF
--- a/docs/audit-snapshot.md
+++ b/docs/audit-snapshot.md
@@ -13,11 +13,11 @@
 - **test files discovered**: 85
 
 ## Core Architecture Docs
-- [PRD](Agent_Installation_Platform_PRD.md)
-- [Product Design](Agent_Installation_Platform_Product_Design.md)
-- [Implementation Plan](Agent_Installation_Platform_Implementation_Plan.md)
-- [Phase-1 Runtime ADR](phase1-runtime-adr.md)
-- [Current Architecture](current-architecture.md)
+- [PRD](./Agent_Installation_Platform_PRD.md)
+- [Product Design](./Agent_Installation_Platform_Product_Design.md)
+- [Implementation Plan](./Agent_Installation_Platform_Implementation_Plan.md)
+- [Phase-1 Runtime ADR](./phase1-runtime-adr.md)
+- [Current Architecture](./current-architecture.md)
 
 ## Open Improvement Tracks
 - [#1325](https://github.com/Keith-CY/carrier/issues/1325)


### PR DESCRIPTION
Adds a Core Architecture Docs section to `docs/audit-snapshot.md` with links to PRD, Product Design, Implementation Plan, Phase-1 ADR, and Current Architecture — so the snapshot works as a navigation hub.

Closes #1363