### PR TITLE
chore(ec2): include picoclaw + main release download fix for TUI validation

### DIFF
--- a/docs/runbooks/ec2-binary-tui-validation.md
+++ b/docs/runbooks/ec2-binary-tui-validation.md
@@ -2,7 +2,7 @@
 
 Purpose: validate Carrier on EC2 (Linux/Windows) without rebuilding from source, using:
 - `carrier onboard` (TUI)
-- `carrier add openclaw` (TUI)
+- `carrier add picoclaw` + `carrier add openclaw` (TUI)
 
 ## 1) Main Push Binary Location
 
@@ -39,6 +39,7 @@ Behavior:
 - With no `--sha/--tag`, script resolves `Keith-CY/carrier` `main` HEAD automatically.
 - It waits up to 600s for `main-<sha>` release asset to appear (use `--wait-seconds 0` to disable).
 - You can still pin an exact build with `--sha <full_commit_sha>` or `--tag main-<full_commit_sha>`.
+- Script installs `picoclaw` then `openclaw`, printing `/api/v1/agents/<id>/status` for each.
 
 Optional non-interactive env:
 
@@ -67,6 +68,7 @@ Behavior:
 - With no `-Sha/-Tag`, script resolves `Keith-CY/carrier` `main` HEAD automatically.
 - It waits up to 600s for `main-<sha>` release asset to appear (use `-WaitSeconds 0` to disable).
 - You can still pin an exact build with `-Sha <full_commit_sha>` or `-Tag main-<full_commit_sha>`.
+- Script installs `picoclaw` then `openclaw`, printing `/api/v1/agents/<id>/status` for each.
 
 Optional non-interactive env:
 
@@ -83,14 +85,15 @@ If default `openai-codex` is used and no saved credential exists, TUI will print
 
 Successful flow should include:
 - `carrier onboard` completes and starts/reuses daemon+gateway.
+- `carrier add picoclaw` completes install/start for PicoClaw.
 - `carrier add openclaw` completes install/start for OpenClaw.
 - `carrier list` shows managed instance.
-- `GET /api/v1/agents/openclaw/status` returns OpenClaw status payload.
+- `GET /api/v1/agents/picoclaw/status` and `/api/v1/agents/openclaw/status` return status payloads.
 
 ## 5) Important Behavioral Note
 
 Chat commands `/install` and `/onboard` are intentionally blocked in gateway chat mode (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
 
 Use either:
-- TUI (`carrier onboard`, `carrier add openclaw`), or
-- WebUI (`carrier onboard --webui`, `carrier add openclaw --webui`).
+- TUI (`carrier onboard`, `carrier add picoclaw`, `carrier add openclaw`), or
+- WebUI (`carrier onboard --webui`, `carrier add picoclaw --webui`, `carrier add openclaw --webui`).

--- a/scripts/ec2-binary-tui-linux.sh
+++ b/scripts/ec2-binary-tui-linux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Download a main-push Carrier binary from GitHub Releases and validate
-# TUI onboarding + TUI add(openclaw) on Linux.
+# TUI onboarding + TUI add(picoclaw/openclaw) on Linux.
 #
 # Examples:
 #   scripts/ec2-binary-tui-linux.sh --sha <full_commit_sha>
@@ -16,6 +16,7 @@
 # Notes:
 # - Default provider selection is openai-codex; OAuth device-code flow is shown in terminal.
 # - If OAuth is needed, complete it in browser while command waits.
+# - By default this installs picoclaw first, then openclaw.
 
 set -euo pipefail
 
@@ -37,6 +38,8 @@ Options:
   --out-dir <dir>      Download/extract directory (default: /tmp/carrier-ec2).
   --skip-onboard       Skip `carrier onboard`.
   --skip-add           Skip `carrier add openclaw`.
+  --skip-picoclaw      Skip `carrier add picoclaw`.
+  --skip-openclaw      Skip `carrier add openclaw`.
   -h, --help           Show this help message.
 
 Environment (optional):
@@ -97,7 +100,8 @@ SHA=""
 LABEL="linux-x64"
 OUT_DIR="/tmp/carrier-ec2"
 SKIP_ONBOARD=0
-SKIP_ADD=0
+SKIP_PICOCLAW=0
+SKIP_OPENCLAW=0
 REPO="Keith-CY/carrier"
 USE_MAIN=0
 WAIT_SECONDS=""
@@ -137,7 +141,15 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --skip-add)
-      SKIP_ADD=1
+      SKIP_OPENCLAW=1
+      shift
+      ;;
+    --skip-picoclaw)
+      SKIP_PICOCLAW=1
+      shift
+      ;;
+    --skip-openclaw)
+      SKIP_OPENCLAW=1
       shift
       ;;
     -h|--help)
@@ -201,8 +213,18 @@ if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1
   exit 1
 fi
 
-ZIP_NAME="carrier-${TAG}-${LABEL}.zip"
+ZIP_ARTIFACT_TAG="${TAG:-$SHA}"
+ZIP_NAME="carrier-${ZIP_ARTIFACT_TAG}-${LABEL}.zip"
 BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+if ! curl -sS -L -o /dev/null -w '%{http_code}' "${BASE_URL}/${ZIP_NAME}" | grep -q '^200$'; then
+  if [[ "$TAG" == main-* && -n "$SHA" && "${ZIP_ARTIFACT_TAG}" != "$SHA" ]]; then
+    echo "[ec2] Primary asset name not found; falling back to legacy carrier-${SHA}-${LABEL}.zip"
+    ZIP_ARTIFACT_TAG="${SHA}"
+    ZIP_NAME="carrier-${ZIP_ARTIFACT_TAG}-${LABEL}.zip"
+  fi
+fi
+
 ZIP_PATH="${OUT_DIR}/${ZIP_NAME}"
 SUM_PATH="${OUT_DIR}/${ZIP_NAME}.sha256"
 ASSET_URL="${BASE_URL}/${ZIP_NAME}"
@@ -274,16 +296,23 @@ if [[ "$SKIP_ONBOARD" -eq 0 ]]; then
   run_tui onboard
 fi
 
-if [[ "$SKIP_ADD" -eq 0 ]]; then
+if [[ "$SKIP_PICOCLAW" -eq 0 ]]; then
+  echo "[ec2] Running: carrier add picoclaw (TUI)"
+  run_tui add picoclaw
+  echo "[ec2] PicoClaw status from daemon API (best effort):"
+  curl -fsS http://127.0.0.1:9090/api/v1/agents/picoclaw/status || true
+  echo
+fi
+
+if [[ "$SKIP_OPENCLAW" -eq 0 ]]; then
   echo "[ec2] Running: carrier add openclaw (TUI)"
   run_tui add openclaw
+  echo "[ec2] OpenClaw status from daemon API (best effort):"
+  curl -fsS http://127.0.0.1:9090/api/v1/agents/openclaw/status || true
+  echo
 fi
 
 echo "[ec2] Current managed instances:"
 "$BIN_PATH" list || true
-
-echo "[ec2] OpenClaw status from daemon API (best effort):"
-curl -fsS http://127.0.0.1:9090/api/v1/agents/openclaw/status || true
-echo
 
 echo "[ec2] Done."

--- a/scripts/ec2-binary-tui-windows.ps1
+++ b/scripts/ec2-binary-tui-windows.ps1
@@ -7,7 +7,9 @@ param(
   [string]$Label = "windows-x64",
   [string]$OutDir = "C:\Temp\carrier-ec2",
   [switch]$SkipOnboard,
-  [switch]$SkipAdd
+  [switch]$SkipAdd,
+  [switch]$SkipPicoclaw,
+  [switch]$SkipOpenclaw
 )
 
 $ErrorActionPreference = "Stop"
@@ -30,6 +32,8 @@ Options:
   -OutDir <dir>       Download/extract directory (default: C:\Temp\carrier-ec2).
   -SkipOnboard        Skip `carrier onboard`.
   -SkipAdd            Skip `carrier add openclaw`.
+  -SkipPicoclaw       Skip `carrier add picoclaw`.
+  -SkipOpenclaw       Skip `carrier add openclaw`.
 
 Environment (optional):
   CARRIER_TELEGRAM_BOT_TOKEN
@@ -125,20 +129,51 @@ if ($WaitSeconds -eq -1) {
   }
 }
 
+if ($SkipAdd) {
+  $SkipOpenclaw = $true
+}
+
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
-$zipName = "carrier-$Tag-$Label.zip"
+$artifactTag = $Tag
+if ([string]::IsNullOrWhiteSpace($artifactTag)) {
+  $artifactTag = $Sha
+}
+
+$zipName = "carrier-$artifactTag-$Label.zip"
 $zipPath = Join-Path $OutDir $zipName
 $sumPath = Join-Path $OutDir "$zipName.sha256"
 $baseUrl = "https://github.com/$Repo/releases/download/$Tag"
 
-Wait-ReleaseAsset -Uri "$baseUrl/$zipName" -TimeoutSeconds $WaitSeconds
+$downloadZip = { param([string]$uri, [string]$outPath)
+  Invoke-WebRequest -Uri $uri -OutFile $outPath
+}
 
-Write-Host "[ec2] Downloading release asset: $baseUrl/$zipName"
-Invoke-WebRequest -Uri "$baseUrl/$zipName" -OutFile $zipPath
-
-Write-Host "[ec2] Downloading checksum: $baseUrl/$zipName.sha256"
-Invoke-WebRequest -Uri "$baseUrl/$zipName.sha256" -OutFile $sumPath
+try {
+  Wait-ReleaseAsset -Uri "$baseUrl/$zipName" -TimeoutSeconds $WaitSeconds
+  Write-Host "[ec2] Downloading release asset: $baseUrl/$zipName"
+  &$downloadZip "$baseUrl/$zipName" $zipPath
+  Write-Host "[ec2] Downloading checksum: $baseUrl/$zipName.sha256"
+  &$downloadZip "$baseUrl/$zipName.sha256" $sumPath
+} catch {
+  $legacyTag = $Sha
+  if ($baseUrl -like "*main-*" -and -not [string]::IsNullOrWhiteSpace($legacyTag) -and $artifactTag -ne $legacyTag) {
+    $legacyZipName = "carrier-$legacyTag-$Label.zip"
+    $legacyZipPath = Join-Path $OutDir $legacyZipName
+    $legacySumPath = Join-Path $OutDir "$legacyZipName.sha256"
+    Write-Host "[ec2] Primary asset name not found; falling back to legacy carrier-$legacyTag-$Label.zip"
+    $zipName = $legacyZipName
+    $zipPath = $legacyZipPath
+    $sumPath = $legacySumPath
+    Wait-ReleaseAsset -Uri "$baseUrl/$zipName" -TimeoutSeconds $WaitSeconds
+    Write-Host "[ec2] Downloading fallback release asset: $baseUrl/$zipName"
+    &$downloadZip "$baseUrl/$zipName" $zipPath
+    Write-Host "[ec2] Downloading fallback checksum: $baseUrl/$zipName.sha256"
+    &$downloadZip "$baseUrl/$zipName.sha256" $sumPath
+  } else {
+    throw
+  }
+}
 
 Write-Host "[ec2] Verifying checksum"
 $expected = ((Get-Content -Path $sumPath -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
@@ -190,7 +225,19 @@ if (-not $SkipOnboard) {
   Invoke-TuiCommand -CarrierArgs @("onboard")
 }
 
-if (-not $SkipAdd) {
+if (-not $SkipPicoclaw) {
+  Write-Host "[ec2] Running: carrier add picoclaw (TUI)"
+  Invoke-TuiCommand -CarrierArgs @("add", "picoclaw")
+}
+
+Write-Host "[ec2] PicoClaw status from daemon API (best effort):"
+try {
+  Invoke-RestMethod -Uri "http://127.0.0.1:9090/api/v1/agents/picoclaw/status" | ConvertTo-Json -Depth 8
+} catch {
+  Write-Warning $_
+}
+
+if (-not $SkipOpenclaw) {
   Write-Host "[ec2] Running: carrier add openclaw (TUI)"
   Invoke-TuiCommand -CarrierArgs @("add", "openclaw")
 }


### PR DESCRIPTION
This PR updates EC2 validation scripts and docs to:\n- install picoclaw then openclaw in TUI\n- correctly target main-preleases release asset naming from release workflow\n- keep compatibility fallback to legacy non-prefix naming.