### PR TITLE
fix(openclaw): resolve npm-global binary path for start/stop

### DIFF
--- a/daemon/internal/catalog/manifests.go
+++ b/daemon/internal/catalog/manifests.go
@@ -196,7 +196,7 @@ func getStartCommand() string {
 		// Git installs create a ~/.local/bin wrapper, while npm installs may
 		// place openclaw in npm's global bin dir. Resolve both without forcing
 		// pre-flight to depend on a single hardcoded absolute path.
-		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw and PATH)" >&2; exit 127; fi'`
+		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway; elif [ -x "$HOME/.npm-global/bin/openclaw" ]; then exec "$HOME/.npm-global/bin/openclaw" gateway; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw, $HOME/.npm-global/bin/openclaw, and PATH)" >&2; exit 127; fi'`
 	}
 }
 
@@ -206,7 +206,7 @@ func getStopCommand() string {
 	case "windows":
 		return "openclaw gateway stop"
 	default:
-		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway stop; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway stop; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw and PATH)" >&2; exit 127; fi'`
+		return `sh -c 'if [ -x "$HOME/.local/bin/openclaw" ]; then exec "$HOME/.local/bin/openclaw" gateway stop; elif [ -x "$HOME/.npm-global/bin/openclaw" ]; then exec "$HOME/.npm-global/bin/openclaw" gateway stop; elif command -v openclaw >/dev/null 2>&1; then exec "$(command -v openclaw)" gateway stop; else echo "openclaw executable not found (checked $HOME/.local/bin/openclaw, $HOME/.npm-global/bin/openclaw, and PATH)" >&2; exit 127; fi'`
 	}
 }
 

--- a/daemon/internal/catalog/manifests_test.go
+++ b/daemon/internal/catalog/manifests_test.go
@@ -268,7 +268,6 @@ func TestGetInstallCommand_UnsafeMethodFallsBackToDefault(t *testing.T) {
 	}
 }
 
-
 func TestGetInstallCommand_ExplicitGitUsesCargoBuildJobs(t *testing.T) {
 	t.Setenv("CARRIER_DEV_MODE", "")
 	t.Setenv(openClawInstallMethodEnv, "git")
@@ -341,6 +340,7 @@ func TestGetStartCommand_Unix(t *testing.T) {
 		want string
 	}{
 		{"home bin path", `$HOME/.local/bin/openclaw`},
+		{"npm-global path", `$HOME/.npm-global/bin/openclaw`},
 		{"path lookup", "command -v openclaw"},
 		{"subcommand", "gateway"},
 	} {
@@ -366,6 +366,7 @@ func TestGetStopCommand_Unix(t *testing.T) {
 		want string
 	}{
 		{"home bin path", `$HOME/.local/bin/openclaw`},
+		{"npm-global path", `$HOME/.npm-global/bin/openclaw`},
 		{"path lookup", "command -v openclaw"},
 		{"subcommand", "gateway stop"},
 	} {


### PR DESCRIPTION
## Summary
- add OpenClaw start/stop command fallback for npm-global installs ()
- keep existing local and PATH resolution checks\n- add catalog tests to lock this behavior
- sync catalog/openclaw.manifest.json with the same command behavior

## Verification
- go test ./internal/catalog
- go test ./internal/manifest