### PR TITLE
docs: align onboarding/install docs with carrier CLI flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For product scope/priority decisions, use this order:
 
 ## Task-first docs quick links
 - `docs/task-first-quickstart.md`
+- `docs/carrier-cli.md`
 - `docs/runbooks/pairing-lifecycle.md`
 - `docs/ci/first-response-playbook.md`
 - `docs/runbooks/go-live-rollback.md`
@@ -42,6 +43,7 @@ For product scope/priority decisions, use this order:
 - [Architecture](#architecture)
 - [Repository Map](#repository-map)
 - [Installation and Testing](#installation-and-testing)
+- [Carrier CLI Flow](#carrier-cli-flow-recommended-bootstrap--onboard--add)
 - [EC2 Binary + TUI Validation](#ec2-binary--tui-validation)
 - [Install OpenClaw from Release](#install-openclaw-from-release-package-non-technical-quick-path)
 - [三平台 Bot 管理（中文）](#三平台-bot-管理超详细步骤可直接照做)
@@ -109,6 +111,28 @@ See `CONTRIBUTING.md` for command examples and required process. For security vu
 | P1 | Important priority after P0 |
 
 ## Installation and testing
+
+### Carrier CLI flow (recommended: bootstrap → onboard → add)
+
+Carrier CLI is now the recommended first path:
+
+1. `carrier` (bootstrap)
+   - If no onboarding config exists, it starts onboarding automatically.
+   - If already onboarded, it starts/reuses daemon + gateway and exits.
+2. `carrier onboard` (interactive TUI)
+   - This flow is Telegram-first today.
+   - For Discord/Feishu onboarding, use `carrier onboard --webui` (or provider/manual setup) and run add flow through WebUI where needed.
+3. `carrier add <agent_id>` (managed or direct)
+   - `openclaw`, `picoclaw`, and `zeroclaw`: managed-agent flow with provider/channel setup, then install/start plus instance tracking.
+   - Other agent IDs: direct install + start for the daemon.
+4. `carrier add <agent_id> --webui` (browser-assisted for all managed flows)
+
+For full command coverage, see [`docs/carrier-cli.md`](./docs/carrier-cli.md).
+
+Notes:
+
+- Chat `/install` and `/onboard` command names still exist, but onboarding/install in chat mode are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) to protect credentials; use Carrier CLI/WebUI instead.
+- Release/package flows below are still valid and useful for non-CLI deployment scenarios.
 
 ### Prerequisites
 - Go toolchain (see `daemon/go.mod` for the required version)
@@ -225,7 +249,7 @@ Implementation notes:
 - Use TUI flow for onboarding/install on EC2:
   - `carrier onboard`
   - `carrier add openclaw`
-- Chat `/install` and `/onboard` are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
+- Chat `/install` and `/onboard` are intentionally blocked in gateway chat mode (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) for credential safety.
 - End-to-end no-rebuild scripts:
   - Linux: `scripts/ec2-binary-tui-linux.sh` (no args defaults to latest `main` push release)
   - Windows: `scripts/ec2-binary-tui-windows.ps1` (no args defaults to latest `main` push release)

--- a/docs/carrier-cli.md
+++ b/docs/carrier-cli.md
@@ -1,0 +1,89 @@
+# Carrier CLI reference
+
+This page summarizes the implemented CLI command surface and the recommended usage flow.
+
+## Command surface
+
+- `carrier`
+  - Bootstrap command.
+  - If no onboard config exists, it runs `carrier onboard`.
+  - If already onboarded, it ensures daemon and gateway are running and then exits.
+- `carrier onboard`
+  - Interactive onboarding flow (TUI).
+- `carrier onboard --webui`
+  - Browser/WebUI onboarding flow.
+- `carrier add <agent_id>`
+  - Add/install agent via TUI flow.
+  - Managed agents (`openclaw`, `picoclaw`, `zeroclaw`) use managed-agent setup and instance tracking.
+  - Non-managed agent IDs run direct daemon install + start.
+- `carrier add <agent_id> --webui`
+  - Browser/WebUI add flow.
+- `carrier list`
+  - Lists running managed agent instances.
+- `carrier stop`
+  - Stops background services started by Carrier: daemon and gateway.
+- `carrier stop <instance_id>`
+  - Stops one managed agent instance.
+- `carrier uninstall <instance_id>`
+  - Uninstalls and removes a managed agent instance.
+- `carrier daemon`
+  - Starts Carrier daemon in the foreground.
+- `carrier gateway`
+  - Starts Carrier gateway in the foreground.
+
+## Recommended flow (bootstrap-first)
+
+1. `carrier`
+2. `carrier onboard` (Telegram-first TUI flow)
+3. `carrier add <agent_id>`
+
+Use `--webui` when interactive terminal access is unavailable or when onboarding needs a browser-assisted path.
+
+## TUI vs WebUI vs chat commands
+
+- Use TUI when:
+  - You are running from terminal and can complete setup interactively.
+  - Provider setup is comfortable in terminal.
+- Use WebUI when:
+  - You are doing Telegram-less onboarding (Discord/Feishu) or using managed agents from a browser flow.
+  - Manual setup of provider credentials is needed outside the TUI path.
+- Use chat commands when:
+  - You are already paired in chat and need quick operational commands.
+  - You are not relying on primary CLI onboarding/install flow.
+
+`/install` and `/onboard` chat commands still parse at gateway level, but onboarding/install actions in chat mode are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) to avoid credential handling in chat.
+
+## Concise example flows
+
+- Local CLI bootstrap + managed TUI add
+
+```bash
+carrier
+carrier onboard
+carrier add openclaw
+carrier list
+```
+
+- Browser/WebUI onboarding + managed add (Discord/Feishu recommended)
+
+```bash
+carrier onboard --webui
+carrier add openclaw --webui
+carrier list
+```
+
+- Direct add flow for non-managed agents
+
+```bash
+carrier add <agent_id>
+carrier stop
+# For managed-instance flows:
+carrier stop <instance_id>
+carrier uninstall <instance_id>
+```
+
+## Daemon and gateway helpers
+
+- `carrier stop` only manages background carrier services and does not remove instance metadata.
+- `carrier stop <instance_id>` and `carrier uninstall <instance_id>` require a managed instance ID from `carrier list`.
+- `carrier daemon` and `carrier gateway` are foreground commands and keep process running until interrupted.

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -14,6 +14,7 @@ Use this before reading historical planning notes.
 
 ## Task-Oriented Entry Points
 
+- Carrier CLI command reference: [`docs/carrier-cli.md`](./carrier-cli.md)
 - 5-minute first setup: [`docs/task-first-quickstart.md`](./task-first-quickstart.md)
 - Pairing and command readiness: [`docs/runbooks/pairing-lifecycle.md`](./runbooks/pairing-lifecycle.md)
 - Post-merge smoke checklist: [`docs/runbooks/post-merge-smoke-checklist.md`](./runbooks/post-merge-smoke-checklist.md)


### PR DESCRIPTION
## Summary
This PR aligns docs with current `origin/main` Carrier CLI onboarding and add flows.

### What changed
- Added new doc: `docs/carrier-cli.md`
  - command reference for `carrier`, `onboard`, `add`, `list`, `stop`, `uninstall`, `daemon`, `gateway`
  - decision guide: when to use TUI vs WebUI vs chat commands
  - concise example flows
- Updated `README.md`
  - added a dedicated **Carrier CLI flow** section (bootstrap -> onboard -> add)
  - clarified that TUI onboarding is currently Telegram-first
  - clarified managed vs non-managed add behavior
  - linked to `docs/carrier-cli.md`
  - corrected chat onboarding/install wording to reflect current behavior (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`)
- Updated `docs/current-architecture.md`
  - added `docs/carrier-cli.md` into task-oriented entry points

## Validation
- `bash scripts/check-doc-command-sync.sh`
  - result: `No sync markers found. Nothing to check.`
- markdown local link target check on changed files
  - result: `OK`

## Why
The repo now has clearer CLI-first onboarding/install behavior in code (`cmd/carrier/main.go`), and docs should guide users through the current primary path while still preserving release/package and chat management context.
