### PR TITLE
feat(carrier): support --version and inject build metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,21 @@ jobs:
       - name: Build headless (default, no WebUI)
         run: go build -o carrier-headless ./cmd/carrier/
 
+      - name: Version command smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$(./carrier --version)"
+          echo "${out}"
+          grep -E '^carrier ' <<<"${out}"
+          grep -E '^commit: ' <<<"${out}"
+          grep -E '^build date: ' <<<"${out}"
+
+          sub_out="$(./carrier version)"
+          short_out="$(./carrier -v)"
+          [[ "${sub_out}" == "${out}" ]]
+          [[ "${short_out}" == "${out}" ]]
+
       - name: Cross-compile WebUI (Windows amd64)
         run: GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags webui -o carrier-windows.exe ./cmd/carrier/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,8 +204,22 @@ jobs:
 
           mkdir -p dist
 
+          carrier_version="${{ needs.prepare.outputs.release_tag }}"
+          if [[ -z "${carrier_version}" ]]; then
+            carrier_version="dev"
+          fi
+          carrier_commit="${GITHUB_SHA}"
+          carrier_build_date="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          ldflags=(
+            "-s"
+            "-w"
+            "-X=main.carrierVersion=${carrier_version}"
+            "-X=main.carrierCommit=${carrier_commit}"
+            "-X=main.carrierBuildDate=${carrier_build_date}"
+          )
+
           CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
-            go build -tags webui -trimpath -ldflags="-s -w" -o "dist/${binary_name}" ./cmd/carrier
+            go build -tags webui -trimpath -ldflags="${ldflags[*]}" -o "dist/${binary_name}" ./cmd/carrier
 
           # Release package should contain only the executable binary.
           (cd dist && zip -j "${package_file}" "${binary_name}")


### PR DESCRIPTION
## Summary

- [x] Briefly describe the change and why it is needed.
- Add release-time build metadata injection for `carrier` so `--version` reports meaningful `version/commit/build date` on packaged binaries.
- Add CI smoke check for `carrier --version` output shape and alias parity (`version`, `-v`).
- After rebasing to latest `origin/main`, version command implementation conflicts were resolved by keeping upstream behavior (already present on main).

## Milestone

- [x] `Phase 1`
- [ ] `Phase 2`

## Scope Confirmation

- [x] This PR stays within the selected milestone scope.
- [x] If marked `Phase 1`, this work is limited to OpenClaw full lifecycle delivery.
- [x] Candidate agent work is not introduced before Phase 1 exit criteria pass.
- [x] Does this PR change runtime model assumptions? If yes, update `docs/phase1-runtime-adr.md` and linked docs in the same PR.

## Audit Traceability

- [x] PR description includes a "Commit highlights" section summarizing key commit-level deltas (for post-merge audit follow-up).

### Commit highlights

- `cadd601` `feat(carrier): add version command and build metadata`
  - Update `.github/workflows/release.yml` to inject build metadata via `-ldflags -X`:
    - `main.carrierVersion`
    - `main.carrierCommit`
    - `main.carrierBuildDate`
  - Update `.github/workflows/ci.yml` with `carrier --version` smoke check and alias parity checks.

## Review Readiness Checklist

Local verification (run the checks relevant to your change type):

- [x] `go test ./cmd/carrier/...`
- [x] `go build -tags webui -o /tmp/carrier-test ./cmd/carrier && /tmp/carrier-test --version && /tmp/carrier-test version && /tmp/carrier-test -v`
- [x] `go build -tags webui -ldflags "-X=main.carrierVersion=v9.9.9 -X=main.carrierCommit=deadbeef -X=main.carrierBuildDate=2026-02-23T23:59:59Z" -o /tmp/carrier-test-meta ./cmd/carrier && /tmp/carrier-test-meta --version`
- [ ] **Full suite:** `./scripts/run-all-tests.sh` (not run in this PR)

CI checks (must be green before merge):

- [ ] Daemon Tests (`daemon-tests`)
- [ ] Gateway Check (`gateway-check`)

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidance.
