### PR TITLE
feat(carrier): stream install logs and add quiet mode

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -73,6 +73,7 @@ const (
 type addCommandOptions struct {
 	AgentID string
 	WebUI   bool
+	Quiet   bool
 }
 
 type picoclawChannel struct {
@@ -232,6 +233,8 @@ var openBrowserFunc = openBrowserURL
 var runOnboardFlow = runOnboard
 var ensureWebUIServicesFlow = ensureWebUIServices
 var procFSRoot = "/proc"
+var daemonActionLogPollInterval = 2 * time.Second
+var daemonActionHeartbeatInterval = 15 * time.Second
 
 const usage = `Carrier — unified agent platform binary
 
@@ -246,10 +249,8 @@ Usage:
   carrier onboard        Interactive onboarding (channel/provider -> keep gateway running in background)
   carrier onboard --webui
                         Launch WebUI onboarding (start/reuse daemon+gateway)
-  carrier add <agent_id>
-                        Add/install an agent via TUI flow
-  carrier add <agent_id> --webui
-                        Add/install an agent via WebUI flow
+  carrier add <agent_id> [--webui] [-q|--quiet]
+                        Add/install an agent (default: show install logs; use -q for quiet mode)
   carrier --help         Show this help message
 
 Notes:
@@ -339,7 +340,7 @@ func main() {
 				}
 				return
 			}
-			if err := runAddTUI(os.Stdin, os.Stdout, opts.AgentID); err != nil {
+			if err := runAddTUI(os.Stdin, os.Stdout, opts.AgentID, opts.Quiet); err != nil {
 				fmt.Fprintf(os.Stderr, "add failed: %v\n", err)
 				os.Exit(1)
 			}
@@ -362,24 +363,31 @@ func main() {
 
 func parseAddCommandArgs(args []string) (addCommandOptions, error) {
 	if len(args) == 0 {
-		return addCommandOptions{}, errors.New("usage: carrier add <agent_id> [--webui]")
+		return addCommandOptions{}, errors.New("usage: carrier add <agent_id> [--webui] [-q|--quiet]")
 	}
-	opts := addCommandOptions{
-		AgentID: strings.ToLower(strings.TrimSpace(args[0])),
-	}
-	if opts.AgentID == "" || strings.HasPrefix(opts.AgentID, "-") {
-		return addCommandOptions{}, errors.New("agent_id is required")
-	}
-	for _, raw := range args[1:] {
+
+	opts := addCommandOptions{}
+	for _, raw := range args {
 		arg := strings.ToLower(strings.TrimSpace(raw))
 		switch arg {
 		case "--webui", "--web", "webui":
 			opts.WebUI = true
+		case "-q", "--quiet", "--quite":
+			opts.Quiet = true
 		case "":
 			continue
 		default:
-			return addCommandOptions{}, fmt.Errorf("unknown add option: %s", raw)
+			if strings.HasPrefix(arg, "-") {
+				return addCommandOptions{}, fmt.Errorf("unknown add option: %s", raw)
+			}
+			if opts.AgentID != "" {
+				return addCommandOptions{}, fmt.Errorf("multiple agent ids provided: %s and %s", opts.AgentID, raw)
+			}
+			opts.AgentID = arg
 		}
+	}
+	if opts.AgentID == "" {
+		return addCommandOptions{}, errors.New("agent_id is required")
 	}
 	return opts, nil
 }
@@ -1349,7 +1357,7 @@ func ensureWebUIServices(out io.Writer) (string, error) {
 	return gatewayURL, nil
 }
 
-func runAddTUI(in io.Reader, out io.Writer, agentID string) error {
+func runAddTUI(in io.Reader, out io.Writer, agentID string, quiet bool) error {
 	agentID = strings.ToLower(strings.TrimSpace(agentID))
 	if agentID == "" {
 		return errors.New("agent_id is required")
@@ -1359,19 +1367,19 @@ func runAddTUI(in io.Reader, out io.Writer, agentID string) error {
 		if _, err := ensureDaemonRunning(out); err != nil {
 			return err
 		}
-		if err := daemonAgentAction(agentID, "install"); err != nil {
+		if err := daemonAgentActionWithProgress(out, agentID, "install", quiet); err != nil {
 			return err
 		}
-		if err := daemonAgentAction(agentID, "start"); err != nil {
+		if err := daemonAgentActionWithProgress(out, agentID, "start", quiet); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(out, "✅ %s installed and started.\n", agentID)
 		return nil
 	}
-	return runAddManagedAgentTUI(in, out, agentID)
+	return runAddManagedAgentTUI(in, out, agentID, quiet)
 }
 
-func runAddManagedAgentTUI(in io.Reader, out io.Writer, agentID string) error {
+func runAddManagedAgentTUI(in io.Reader, out io.Writer, agentID string, quiet bool) error {
 	cfg, ok := managedAgentByID(agentID)
 	if !ok {
 		return fmt.Errorf("managed agent %q is not supported", agentID)
@@ -1439,10 +1447,10 @@ func runAddManagedAgentTUI(in io.Reader, out io.Writer, agentID string) error {
 	if _, err := ensureDaemonRunning(out); err != nil {
 		return err
 	}
-	if err := daemonAgentAction(cfg.ID, "install"); err != nil {
+	if err := daemonAgentActionWithProgress(out, cfg.ID, "install", quiet); err != nil {
 		return err
 	}
-	if err := daemonAgentAction(cfg.ID, "start"); err != nil {
+	if err := daemonAgentActionWithProgress(out, cfg.ID, "start", quiet); err != nil {
 		return err
 	}
 	if strings.EqualFold(cfg.ID, "picoclaw") {
@@ -1746,6 +1754,90 @@ func ensureGatewayRunning(out io.Writer, startGateway func() error) (string, err
 	return gatewayURL, nil
 }
 
+func daemonAgentActionWithProgress(out io.Writer, agentID, action string, quiet bool) error {
+	if quiet {
+		return daemonAgentAction(agentID, action)
+	}
+
+	previousLogs, _ := daemonFetchAgentLogs(agentID, 1000)
+	startedAt := time.Now()
+	lastHeartbeat := startedAt
+
+	done := make(chan error, 1)
+	go func() {
+		done <- daemonAgentAction(agentID, action)
+	}()
+
+	ticker := time.NewTicker(daemonActionLogPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case err := <-done:
+			if currentLogs, logErr := daemonFetchAgentLogs(agentID, 1000); logErr == nil {
+				for _, line := range diffNewLogLines(previousLogs, currentLogs) {
+					_, _ = fmt.Fprintln(out, line)
+				}
+			}
+			return err
+		case <-ticker.C:
+			currentLogs, logErr := daemonFetchAgentLogs(agentID, 1000)
+			if logErr != nil {
+				if time.Since(lastHeartbeat) >= daemonActionHeartbeatInterval {
+					_, _ = fmt.Fprintf(out, "[%s] in progress (%s elapsed)\n", action, time.Since(startedAt).Round(time.Second))
+					lastHeartbeat = time.Now()
+				}
+				continue
+			}
+			newLines := diffNewLogLines(previousLogs, currentLogs)
+			for _, line := range newLines {
+				_, _ = fmt.Fprintln(out, line)
+			}
+			previousLogs = currentLogs
+			if len(newLines) == 0 && time.Since(lastHeartbeat) >= daemonActionHeartbeatInterval {
+				_, _ = fmt.Fprintf(out, "[%s] in progress (%s elapsed)\n", action, time.Since(startedAt).Round(time.Second))
+				lastHeartbeat = time.Now()
+			}
+			if len(newLines) > 0 {
+				lastHeartbeat = time.Now()
+			}
+		}
+	}
+}
+
+func diffNewLogLines(previous, current []string) []string {
+	if len(current) == 0 {
+		return nil
+	}
+	maxOverlap := 0
+	limit := len(previous)
+	if len(current) < limit {
+		limit = len(current)
+	}
+	for overlap := limit; overlap > 0; overlap-- {
+		if logSliceEqual(previous[len(previous)-overlap:], current[:overlap]) {
+			maxOverlap = overlap
+			break
+		}
+	}
+	if maxOverlap >= len(current) {
+		return nil
+	}
+	return append([]string(nil), current[maxOverlap:]...)
+}
+
+func logSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func daemonAgentAction(agentID, action string) error {
 	agentID = strings.TrimSpace(agentID)
 	action = strings.TrimSpace(action)
@@ -1909,21 +2001,40 @@ func isDaemonTransportErrorRecoverable(err error) bool {
 	return isDaemonEOFError(err) || isDaemonTimeoutError(err)
 }
 
-func daemonExtractPairCodeFromLogs(agentID string) (string, error) {
-	raw, status, err := daemonRequest(http.MethodGet, fmt.Sprintf("/api/v1/agents/%s/logs?tail=120", neturl.PathEscape(strings.TrimSpace(agentID))), nil)
+func daemonFetchAgentLogs(agentID string, tail int) ([]string, error) {
+	trimmedAgentID := strings.TrimSpace(agentID)
+	if trimmedAgentID == "" {
+		return nil, errors.New("agent id is required")
+	}
+	if tail <= 0 {
+		tail = 200
+	}
+	raw, status, err := daemonRequest(
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/agents/%s/logs?tail=%d", neturl.PathEscape(trimmedAgentID), tail),
+		nil,
+	)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if status < 200 || status >= 300 {
-		return "", fmt.Errorf("daemon logs request failed with status %d", status)
+		return nil, fmt.Errorf("daemon logs request failed with status %d", status)
 	}
 	var payload struct {
 		Lines []string `json:"lines"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", fmt.Errorf("decode logs response: %w", err)
+		return nil, fmt.Errorf("decode logs response: %w", err)
 	}
-	for _, line := range payload.Lines {
+	return payload.Lines, nil
+}
+
+func daemonExtractPairCodeFromLogs(agentID string) (string, error) {
+	lines, err := daemonFetchAgentLogs(agentID, 120)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range lines {
 		if code := strings.TrimSpace(picoclawPairCodePattern.FindString(line)); code != "" {
 			return code, nil
 		}

--- a/cmd/carrier/main_daemon_action_test.go
+++ b/cmd/carrier/main_daemon_action_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"net"
-	"os"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -239,4 +241,80 @@ func TestDaemonActionTimeoutUsesExtendedInstallWindow(t *testing.T) {
 			t.Fatalf("daemonActionTimeout( INSTALL , command_timeout=10m) = %s, want %s", got, 30*time.Minute)
 		}
 	})
+}
+
+func TestDaemonAgentActionWithProgressPrintsNewLogLines(t *testing.T) {
+	var installDone atomic.Bool
+	var logsCalls atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agents/openclaw/install":
+			time.Sleep(25 * time.Millisecond)
+			installDone.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/api/v1/agents/openclaw/logs":
+			logsCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			if installDone.Load() {
+				_, _ = w.Write([]byte(`{"lines":["old-line","install-progress-line"]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"lines":["old-line"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	configureDaemonProbeEnvForTest(t, server.URL)
+
+	prevPoll := daemonActionLogPollInterval
+	prevHeartbeat := daemonActionHeartbeatInterval
+	daemonActionLogPollInterval = 5 * time.Millisecond
+	daemonActionHeartbeatInterval = time.Hour
+	t.Cleanup(func() {
+		daemonActionLogPollInterval = prevPoll
+		daemonActionHeartbeatInterval = prevHeartbeat
+	})
+
+	var out bytes.Buffer
+	if err := daemonAgentActionWithProgress(&out, "openclaw", "install", false); err != nil {
+		t.Fatalf("daemonAgentActionWithProgress install error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "old-line") {
+		t.Fatalf("output should not replay baseline log lines, got %q", output)
+	}
+	if !strings.Contains(output, "install-progress-line") {
+		t.Fatalf("output should include new log lines, got %q", output)
+	}
+	if logsCalls.Load() == 0 {
+		t.Fatal("expected logs endpoint to be queried for progress output")
+	}
+}
+
+func TestDaemonAgentActionWithProgressQuietModeSuppressesLogs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agents/openclaw/install":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/api/v1/agents/openclaw/logs":
+			t.Fatalf("logs endpoint should not be called in quiet mode")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	configureDaemonProbeEnvForTest(t, server.URL)
+
+	var out bytes.Buffer
+	if err := daemonAgentActionWithProgress(&out, "openclaw", "install", true); err != nil {
+		t.Fatalf("daemonAgentActionWithProgress install error: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("quiet mode should not print progress logs, got %q", out.String())
+	}
 }

--- a/cmd/carrier/main_test.go
+++ b/cmd/carrier/main_test.go
@@ -217,6 +217,48 @@ func TestResolveManagedChannelTokenFallsBackToConfig(t *testing.T) {
 	}
 }
 
+func TestParseAddCommandArgsSupportsQuietOptions(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want addCommandOptions
+	}{
+		{
+			name: "quiet short flag after agent",
+			args: []string{"openclaw", "-q"},
+			want: addCommandOptions{AgentID: "openclaw", Quiet: true},
+		},
+		{
+			name: "quiet long flag before agent",
+			args: []string{"--quiet", "picoclaw"},
+			want: addCommandOptions{AgentID: "picoclaw", Quiet: true},
+		},
+		{
+			name: "quiet typo alias supported",
+			args: []string{"zeroclaw", "--quite"},
+			want: addCommandOptions{AgentID: "zeroclaw", Quiet: true},
+		},
+		{
+			name: "combined webui and quiet flags",
+			args: []string{"-q", "openclaw", "--webui"},
+			want: addCommandOptions{AgentID: "openclaw", Quiet: true, WebUI: true},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAddCommandArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseAddCommandArgs(%v) error: %v", tc.args, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseAddCommandArgs(%v) = %+v, want %+v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPickManagedAddProviderWithReasonUsesLatestManagedInstanceProvider(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("CARRIER_DEFAULT_PROVIDER_ID", "")

--- a/daemon/internal/commandexec/runner.go
+++ b/daemon/internal/commandexec/runner.go
@@ -1,12 +1,14 @@
 package commandexec
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 )
 
 type Result struct {
@@ -16,6 +18,10 @@ type Result struct {
 
 type Runner interface {
 	Run(ctx context.Context, command string) (Result, error)
+}
+
+type StreamingRunner interface {
+	RunStreaming(ctx context.Context, command string, onLine func(string)) (Result, error)
 }
 
 // ValidateCommand checks that a command string is safe to execute.
@@ -41,6 +47,14 @@ func NewShellRunner() ShellRunner {
 }
 
 func (r ShellRunner) Run(ctx context.Context, command string) (Result, error) {
+	return r.run(ctx, command, nil)
+}
+
+func (r ShellRunner) RunStreaming(ctx context.Context, command string, onLine func(string)) (Result, error) {
+	return r.run(ctx, command, onLine)
+}
+
+func (r ShellRunner) run(ctx context.Context, command string, onLine func(string)) (Result, error) {
 	if err := ValidateCommand(command); err != nil {
 		return Result{ExitCode: -1}, fmt.Errorf("validate command: %w", err)
 	}
@@ -52,15 +66,70 @@ func (r ShellRunner) Run(ctx context.Context, command string) (Result, error) {
 		cmd = exec.CommandContext(ctx, "/bin/sh", "-lc", command)
 	}
 
-	out, err := cmd.CombinedOutput()
+	stream := &lineCaptureWriter{onLine: onLine}
+	cmd.Stdout = stream
+	cmd.Stderr = stream
+	err := cmd.Run()
+	stream.Flush()
 	result := Result{
-		CombinedOutput: strings.TrimSpace(string(out)),
+		CombinedOutput: stream.CombinedOutput(),
 		ExitCode:       exitCode(err),
 	}
 	if err != nil {
 		return result, fmt.Errorf("run command %q: %w", command, err)
 	}
 	return result, nil
+}
+
+type lineCaptureWriter struct {
+	mu      sync.Mutex
+	output  bytes.Buffer
+	pending string
+	onLine  func(string)
+}
+
+func (w *lineCaptureWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	_, _ = w.output.Write(p)
+	chunk := w.pending + string(p)
+	start := 0
+	for start < len(chunk) {
+		idx := strings.IndexByte(chunk[start:], '\n')
+		if idx < 0 {
+			break
+		}
+		line := strings.TrimSuffix(chunk[start:start+idx], "\r")
+		if w.onLine != nil {
+			w.onLine(line)
+		}
+		start += idx + 1
+	}
+	w.pending = chunk[start:]
+	return len(p), nil
+}
+
+func (w *lineCaptureWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.pending == "" {
+		return
+	}
+	line := strings.TrimSuffix(w.pending, "\r")
+	if w.onLine != nil {
+		w.onLine(line)
+	}
+	w.pending = ""
+}
+
+func (w *lineCaptureWriter) CombinedOutput() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.TrimSpace(w.output.String())
 }
 
 func exitCode(err error) int {

--- a/daemon/internal/commandexec/runner_test.go
+++ b/daemon/internal/commandexec/runner_test.go
@@ -120,3 +120,27 @@ func TestShellRunnerExitCodeZeroOnSuccess(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
 	}
 }
+
+func TestShellRunnerRunStreamingEmitsOutputLines(t *testing.T) {
+	runner := ShellRunner{GOOS: "linux"}
+
+	var lines []string
+	result, err := runner.RunStreaming(context.Background(), "echo stdout-line; echo stderr-line >&2", func(line string) {
+		lines = append(lines, line)
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", result.ExitCode)
+	}
+	if len(lines) == 0 {
+		t.Fatal("expected streaming callback to receive at least one line")
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "stdout-line") {
+		t.Fatalf("expected stdout line in streamed output, got %v", lines)
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "stderr-line") {
+		t.Fatalf("expected stderr line in streamed output, got %v", lines)
+	}
+}

--- a/daemon/internal/lifecycle/helpers.go
+++ b/daemon/internal/lifecycle/helpers.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"archive/zip"
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,30 @@ func (s *Service) appendCommandLog(agentID, action, command string, result comma
 	if runErr != nil {
 		s.appendLog(agentID, fmt.Sprintf("[%s] error=%v", action, runErr))
 	}
+}
+
+func (s *Service) appendCommandLogSummary(agentID, action, command string, result commandexec.Result, runErr error) {
+	line := fmt.Sprintf("[%s] command=%q exit=%d", action, command, result.ExitCode)
+	s.appendLog(agentID, line)
+	if runErr != nil {
+		s.appendLog(agentID, fmt.Sprintf("[%s] error=%v", action, runErr))
+	}
+}
+
+func (s *Service) runCommandWithAgentLogs(ctx context.Context, agentID, action, command string) (commandexec.Result, bool, error) {
+	streamingRunner, ok := s.runner.(commandexec.StreamingRunner)
+	if !ok {
+		result, err := s.runner.Run(ctx, command)
+		return result, false, err
+	}
+	result, err := streamingRunner.RunStreaming(ctx, command, func(line string) {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			return
+		}
+		s.appendLog(agentID, fmt.Sprintf("[%s] %s", action, trimmed))
+	})
+	return result, true, err
 }
 
 func (s *Service) appendLog(agentID, line string) {

--- a/daemon/internal/lifecycle/install.go
+++ b/daemon/internal/lifecycle/install.go
@@ -32,13 +32,21 @@ func (s *Service) Install(ctx context.Context, agentID string) error {
 		}
 	}
 
-	result, runErr := s.runner.Run(opCtx, m.Runtime.Install.Command)
-	s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
+	result, streamed, runErr := s.runCommandWithAgentLogs(opCtx, agentID, "install", m.Runtime.Install.Command)
+	if streamed {
+		s.appendCommandLogSummary(agentID, "install", m.Runtime.Install.Command, result, runErr)
+	} else {
+		s.appendCommandLog(agentID, "install", m.Runtime.Install.Command, result, runErr)
+	}
 	if runErr != nil {
 		repaired := s.triageInstallFailure(ctx, opCtx, agentID, runErr)
 		if repaired {
-			retryResult, retryErr := s.runner.Run(opCtx, m.Runtime.Install.Command)
-			s.appendCommandLog(agentID, "install-retry", m.Runtime.Install.Command, retryResult, retryErr)
+			retryResult, retryStreamed, retryErr := s.runCommandWithAgentLogs(opCtx, agentID, "install-retry", m.Runtime.Install.Command)
+			if retryStreamed {
+				s.appendCommandLogSummary(agentID, "install-retry", m.Runtime.Install.Command, retryResult, retryErr)
+			} else {
+				s.appendCommandLog(agentID, "install-retry", m.Runtime.Install.Command, retryResult, retryErr)
+			}
 			if retryErr == nil {
 				s.markInstallSuccess(agentID)
 				s.recordAudit("", "system", "install", agentID, AuditResultSuccess, "", "install completed after auto-repair")
@@ -136,8 +144,12 @@ func (s *Service) tryAutoRepairInstallFailure(ctx context.Context, agentID strin
 		repairCommand = fmt.Sprintf("cd %s && %s", shellSingleQuote(targetPath), repairCommand)
 	}
 
-	result, repairErr := s.runner.Run(ctx, repairCommand)
-	s.appendCommandLog(agentID, "repair", repairCommand, result, repairErr)
+	result, streamed, repairErr := s.runCommandWithAgentLogs(ctx, agentID, "repair", repairCommand)
+	if streamed {
+		s.appendCommandLogSummary(agentID, "repair", repairCommand, result, repairErr)
+	} else {
+		s.appendCommandLog(agentID, "repair", repairCommand, result, repairErr)
+	}
 	if repairErr != nil {
 		s.recordAudit("", "base-agent", "repair", agentID, AuditResultFailure, "E_REPAIR_FAILED", repairErr.Error())
 		return false, repairErr

--- a/daemon/internal/lifecycle/service_test.go
+++ b/daemon/internal/lifecycle/service_test.go
@@ -36,6 +36,29 @@ type runResult struct {
 	err    error
 }
 
+type fakeStreamingRunner struct {
+	runCalls     []string
+	streamCalls  []string
+	streamLines  []string
+	streamResult commandexec.Result
+	streamErr    error
+}
+
+func (f *fakeStreamingRunner) Run(_ context.Context, command string) (commandexec.Result, error) {
+	f.runCalls = append(f.runCalls, command)
+	return commandexec.Result{}, nil
+}
+
+func (f *fakeStreamingRunner) RunStreaming(_ context.Context, command string, onLine func(string)) (commandexec.Result, error) {
+	f.streamCalls = append(f.streamCalls, command)
+	for _, line := range f.streamLines {
+		if onLine != nil {
+			onLine(line)
+		}
+	}
+	return f.streamResult, f.streamErr
+}
+
 func (f *fakeRunner) Run(_ context.Context, command string) (commandexec.Result, error) {
 	f.calls = append(f.calls, command)
 	if f.counts == nil {
@@ -251,6 +274,55 @@ func TestLifecycleInstallStartStop(t *testing.T) {
 		if runner.calls[i] != wantCalls[i] {
 			t.Fatalf("runner call %d mismatch: want %q got %q", i, wantCalls[i], runner.calls[i])
 		}
+	}
+}
+
+func TestInstallStreamsRunnerOutputIntoAgentLogs(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	runner := &fakeStreamingRunner{
+		streamLines: []string{
+			"npm installing package A",
+			"npm installing package B",
+		},
+		streamResult: commandexec.Result{
+			CombinedOutput: "npm installing package A\nnpm installing package B",
+			ExitCode:       0,
+		},
+	}
+	checker := &fakeChecker{}
+	clock := &fakeClock{current: time.Date(2026, 2, 14, 4, 20, 0, 0, time.UTC)}
+
+	svc := NewService(nil,
+		WithRunner(runner),
+		WithRuntimeChecker(checker),
+		WithDiagnoseDir(t.TempDir()),
+		WithNow(clock.Now),
+	)
+	if err := svc.RegisterManifest(sampleManifest()); err != nil {
+		t.Fatalf("register manifest: %v", err)
+	}
+
+	if err := svc.Install(context.Background(), "openclaw"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if len(runner.streamCalls) != 1 || runner.streamCalls[0] != "install-openclaw" {
+		t.Fatalf("expected streaming runner to execute install command once, got %+v", runner.streamCalls)
+	}
+	if len(runner.runCalls) != 0 {
+		t.Fatalf("expected non-streaming Run to be unused, got %+v", runner.runCalls)
+	}
+
+	logs, err := svc.Logs("openclaw", 20)
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	joined := strings.Join(logs, "\n")
+	if !strings.Contains(joined, "[install] npm installing package A") {
+		t.Fatalf("expected streamed install log line in logs, got %q", joined)
+	}
+	if !strings.Contains(joined, "[install] command=\"install-openclaw\" exit=0") {
+		t.Fatalf("expected install summary log line in logs, got %q", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `-q/--quiet` (and `--quite` alias) to `carrier add` to enable silent install/start mode
- default `carrier add` now streams install/start progress logs by polling daemon logs and printing only new lines
- add daemon command streaming support (`RunStreaming`) and wire install/repair lifecycle paths to append line-by-line logs during execution

## Test Plan
- go test ./...
- (cd daemon && go test ./...)