### PR TITLE
docs: document --quite alias as intentional typo tolerance

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -484,7 +484,7 @@ func parseAddCommandArgs(args []string) (addCommandOptions, error) {
 		switch arg {
 		case "--webui", "--web", "webui":
 			opts.WebUI = true
-		case "-q", "--quiet", "--quite":
+		case "-q", "--quiet", "--quite": // "--quite" is an intentional alias for the common typo
 			opts.Quiet = true
 		case "":
 			continue


### PR DESCRIPTION
Adds inline comment documenting that `--quite` is an intentional alias for the common typo of `--quiet`, so future maintainers don't remove it.

Closes #1378