### PR TITLE
feat(carrier): include Go runtime version in version output

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -97,9 +97,10 @@ type versionCommandOptions struct {
 }
 
 type versionInfo struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"buildDate"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit"`
+	BuildDate  string `json:"buildDate"`
+	GoVersion  string `json:"goVersion"`
 }
 
 type picoclawChannel struct {
@@ -633,6 +634,7 @@ func runVersionCommand(out io.Writer, opts versionCommandOptions) error {
 		Version:   carrierVersion,
 		Commit:    carrierCommit,
 		BuildDate: carrierBuildDate,
+		GoVersion: runtime.Version(),
 	}
 	if opts.JSON {
 		raw, err := json.MarshalIndent(info, "", "  ")
@@ -645,6 +647,7 @@ func runVersionCommand(out io.Writer, opts versionCommandOptions) error {
 	_, _ = fmt.Fprintf(out, "carrier %s\n", info.Version)
 	_, _ = fmt.Fprintf(out, "commit: %s\n", info.Commit)
 	_, _ = fmt.Fprintf(out, "build date: %s\n", info.BuildDate)
+	_, _ = fmt.Fprintf(out, "go version: %s\n", info.GoVersion)
 	return nil
 }
 

--- a/cmd/carrier/main_test.go
+++ b/cmd/carrier/main_test.go
@@ -446,6 +446,9 @@ func TestRunVersionCommandJSON(t *testing.T) {
 	if payload.Version == "" {
 		t.Fatalf("payload.version is empty")
 	}
+	if payload.GoVersion == "" {
+		t.Fatalf("payload.goVersion is empty")
+	}
 }
 
 func TestRunVersionCommandText(t *testing.T) {
@@ -456,6 +459,9 @@ func TestRunVersionCommandText(t *testing.T) {
 	text := out.String()
 	if !strings.Contains(text, "carrier") {
 		t.Fatalf("version text should contain command name, got: %q", text)
+	}
+	if !strings.Contains(text, "go version:") {
+		t.Fatalf("version text should contain go version, got: %q", text)
 	}
 }
 


### PR DESCRIPTION
Adds `runtime.Version()` to both human-readable and JSON version output for debugging.

Closes #1382