### PR TITLE
fix(manifest): validate supported command_by_os keys

### DIFF
--- a/daemon/internal/manifest/types.go
+++ b/daemon/internal/manifest/types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -26,6 +27,20 @@ const (
 const (
 	UpgradeStrategyInPlaceOrReinstall = "in_place_or_reinstall"
 )
+
+const (
+	CommandOSDarwin  = "darwin"
+	CommandOSLinux   = "linux"
+	CommandOSWindows = "windows"
+	CommandOSDefault = "default"
+)
+
+var supportedCommandOS = map[string]struct{}{
+	CommandOSDarwin:  {},
+	CommandOSLinux:   {},
+	CommandOSWindows: {},
+	CommandOSDefault: {},
+}
 
 // Manifest is the full agent manifest schema covering runtime, env, network,
 // health, upgrade, memory, and diagnostics as required by the PRD.
@@ -252,6 +267,14 @@ func validateCommandByOS(field string, byOS map[string]string) error {
 		}
 		if normalized != osName {
 			return fmt.Errorf("%s.command_by_os key %q must be lowercase and trimmed", field, osName)
+		}
+		if _, ok := supportedCommandOS[normalized]; !ok {
+			keys := make([]string, 0, len(supportedCommandOS))
+			for key := range supportedCommandOS {
+				keys = append(keys, fmt.Sprintf("%q", key))
+			}
+			sort.Strings(keys)
+			return fmt.Errorf("%s.command_by_os has unsupported key %q; supported: %s", field, osName, strings.Join(keys, ", "))
 		}
 		if strings.TrimSpace(raw) == "" {
 			return fmt.Errorf("%s.command_by_os.%s is required", field, osName)

--- a/daemon/internal/manifest/types_test.go
+++ b/daemon/internal/manifest/types_test.go
@@ -258,6 +258,25 @@ func TestValidateRejectsUppercaseCommandByOSKey(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsUnsupportedCommandByOSKey(t *testing.T) {
+	m := validManifestForTest()
+	m.Runtime.Install = CommandSpec{
+		CommandByOS: map[string]string{
+			"plan9": "curl -fsSL https://openclaw.ai/install.sh | bash",
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for unsupported command_by_os key")
+	}
+	if !strings.Contains(err.Error(), `unsupported key "plan9"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"darwin"`) || !strings.Contains(err.Error(), `"linux"`) || !strings.Contains(err.Error(), `"windows"`) || !strings.Contains(err.Error(), `"default"`) {
+		t.Fatalf("error should include supported keys, got: %v", err)
+	}
+}
+
 func TestCommandSpecResolveForGOOS(t *testing.T) {
 	spec := CommandSpec{
 		Command: "openclaw gateway",


### PR DESCRIPTION
## Summary
- follow up Gemini feedback from #1380 about `command_by_os` maintainability
- reject unsupported `command_by_os` keys in manifest validation
- generate supported key list dynamically from the source map (sorted)
- add unit test covering unsupported key rejection

## Validation
- `go test ./cmd/carrier`
- `cd daemon && go test ./internal/manifest ./internal/runtimecheck ./internal/lifecycle ./internal/catalog`
