### PR TITLE
docs(carrier): document --quite typo alias as intentional

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -530,7 +530,7 @@ func parseAddCommandArgs(args []string) (addCommandOptions, error) {
 		switch arg {
 		case "--webui", "--web", "webui":
 			opts.WebUI = true
-		case "-q", "--quiet", "--quite":
+		case "-q", "--quiet", "--quite": // "--quite" is an intentional typo alias for common misspelling
 			opts.Quiet = true
 		case "":
 			continue


### PR DESCRIPTION
Add inline comment clarifying the `--quite` flag alias is an intentional accommodation for a common misspelling of `--quiet`, preventing future maintainers from removing it.

Closes #1378