### PR TITLE
docs: refresh architecture audit snapshot artifact

### DIFF
--- a/docs/audit-snapshot.md
+++ b/docs/audit-snapshot.md
@@ -3,14 +3,14 @@
 > Generated snapshot artifact. This file is audit output and does not replace `docs/current-architecture.md`.
 > Guardrail: audit automation must fail if it mutates `docs/current-architecture.md`.
 
-- **generated_at_utc**: 2026-02-23T21:01:50Z
+- **generated_at_utc**: 2026-02-24T04:01:32Z
 - **repository**: Keith-CY/carrier
 - **branch**: main
 
 ## Metrics
 - **superseded/diverged docs**: 5
-- **docs marker hits**: 0
-- **core marker hits (excluding docs)**: 0
+- **docs marker hits (TODO/TBD/FIXME)**: 1
+- **core marker hits (excluding docs TODO/FIXME)**: 1
 - **test files discovered**: 97
 
 ## Core Architecture Docs


### PR DESCRIPTION
Refreshes the generated architecture audit artifact without mutating the canonical index.

## Acceptance mapping
- `docs/audit-snapshot.md` updated with latest audit timestamp + metrics.
- Open improvement tracks remain linked.
- `docs/current-architecture.md` remains the stable navigation index.