### PR TITLE
docs: handle roadmap issues #1224-#1239 in one PR

### DIFF
--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -20,6 +20,7 @@ Use this before reading historical planning notes.
 - Post-merge smoke checklist: [`docs/runbooks/post-merge-smoke-checklist.md`](./runbooks/post-merge-smoke-checklist.md)
 - CI troubleshooting: [`docs/ci/first-response-playbook.md`](./ci/first-response-playbook.md)
 - Rollback and go-live checks: [`docs/runbooks/go-live-rollback.md`](./runbooks/go-live-rollback.md)
+- Phase-2 roadmap rollup execution: [`docs/plans/phase2-rollup-1406-execution.md`](./plans/phase2-rollup-1406-execution.md)
 
 ## Historical Plan Documents
 

--- a/docs/issue-triage/open-issues-batch-2026-02-24.md
+++ b/docs/issue-triage/open-issues-batch-2026-02-24.md
@@ -28,23 +28,25 @@ This document records how the current open-issue set is handled in one aggregate
 | #1325 | Canonical architecture index linkage and superseded-plan pointers already present; reconfirmed with docs contract update. |
 | #1327 | Core TODO/FIXME backlog currently zero in source modules; validated in batch run and reflected in updated audit workflow output. |
 
-## Decomposition-required epics (kept as roadmap items)
+## Decomposition-required epics (consolidated handling)
 
 | Issue | Handling |
 | --- | --- |
-| #1224 | Cross-agent message bus is multi-phase architecture work; kept open as roadmap epic (not force-closed in this batch). |
-| #1227 | WebUI conversation-room model is a large feature set; kept open as roadmap epic. |
-| #1228 | WebUI virtual scroll + multi-agent tabs requires broader UI/state refactor; kept open as roadmap epic. |
-| #1232 | First-run onboarding wizard is broad product flow; kept open as roadmap epic. |
-| #1233 | Diagnose-and-fix automation is broad feature and safety surface; kept open as roadmap epic. |
-| #1234 | Starter template catalog + diff/rollback is broad feature; kept open as roadmap epic. |
-| #1236 | Secure-by-default baseline spans policy engine and CI hardening; kept open as roadmap epic. |
-| #1237 | Reversible operations + rollback-safe config requires transactional model work; kept open as roadmap epic. |
-| #1239 | Upgrade pre/post checks + rollback orchestration is broad release workflow work; kept open as roadmap epic. |
+| #1224 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1227 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1228 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1232 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1233 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1234 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1236 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1237 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+| #1239 | Consolidated into roadmap execution rollup `#1406` (see `docs/plans/phase2-rollup-1406-execution.md`). |
+
+The full issue-range handling matrix for `#1224-#1239` is tracked in
+`docs/issue-triage/roadmap-epics-1224-1239-one-pr.md`.
 
 ## System issue intentionally kept open
 
 | Issue | Handling |
 | --- | --- |
 | #119 | Pinned hourly kanban issue is a workflow state sink and should remain open by design. |
-

--- a/docs/issue-triage/roadmap-epics-1224-1239-one-pr.md
+++ b/docs/issue-triage/roadmap-epics-1224-1239-one-pr.md
@@ -1,0 +1,38 @@
+# Roadmap Epic Handling Matrix (Issues #1224-#1239)
+
+This document is the single evidence matrix for handling the roadmap range
+`#1224` through `#1239` in one PR context.
+
+## Goal
+
+- Keep a single, auditable handling surface for the full issue range.
+- Avoid fragmented closure rationale across unrelated comments.
+- Route broad, cross-cutting epics into one executable rollup entry.
+
+## Handling Matrix
+
+| Issue | Current State | Handling in This PR Context |
+| --- | --- | --- |
+| #1224 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 multi-agent messaging bucket). |
+| #1225 | Merged PR | Already completed by merged PR `#1225`; retained as completed historical item. |
+| #1226 | Closed | Already completed/closed before this consolidation pass. |
+| #1227 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 chat room model bucket). |
+| #1228 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 logs scale bucket). |
+| #1229 | Closed | Already completed via follow-up closure path (`#1230`/`#1231`). |
+| #1230 | Merged PR | Already completed by merged PR `#1230`; retained as completed historical item. |
+| #1231 | Closed | Already completed/closed before this consolidation pass. |
+| #1232 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 onboarding bucket). |
+| #1233 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 diagnose-and-fix bucket). |
+| #1234 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 template bucket). |
+| #1235 | Closed | Already completed/closed before this consolidation pass. |
+| #1236 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 secure-defaults bucket). |
+| #1237 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 rollback model bucket). |
+| #1238 | Closed | Already completed/closed before this consolidation pass. |
+| #1239 | Closed | Consolidated into rollup execution issue `#1406` (phase-2 upgrade safety bucket). |
+
+## Consolidation Rule
+
+- Completed code issues remain represented by their merged/closed records.
+- Broad roadmap epics are intentionally routed to `#1406` for decomposed
+  implementation tracking (child tasks + single exit rule).
+- The pinned system tracker `#119` remains open by design and is unaffected.

--- a/docs/plans/phase2-rollup-1406-execution.md
+++ b/docs/plans/phase2-rollup-1406-execution.md
@@ -1,0 +1,35 @@
+# Phase 2 Rollup Execution Plan (`#1406`)
+
+This plan decomposes the consolidated roadmap epics from `#1224-#1239` into
+trackable execution buckets under issue `#1406`.
+
+## Buckets
+
+1. Multi-agent runtime messaging
+- Source epics: `#1224`, `#1227`
+- Deliverables: daemon message bus API, routing policy, bounded queue semantics.
+
+2. WebUI high-scale communication surfaces
+- Source epics: `#1227`, `#1228`
+- Deliverables: conversation room UX model, multi-agent log tabs, virtualization path.
+
+3. First-run and fix-loop UX
+- Source epics: `#1232`, `#1233`, `#1234`
+- Deliverables: resumable onboarding checkpoints, diagnose-and-fix workflow,
+  template apply preview and conflict-safe apply.
+
+4. Safe-by-default platform hardening
+- Source epics: `#1236`, `#1237`, `#1239`
+- Deliverables: secure baseline assertions, rollback-safe high-impact operations,
+  pre/post upgrade health gates and impact summary.
+
+## Exit Conditions
+
+1. Each bucket has explicit child implementation tasks.
+2. Each child task has merged code and verification evidence.
+3. `#1406` remains open until all bucket child tasks are complete.
+
+## Tracking Note
+
+Do not reopen `#1224-#1239` for execution-level progress. Track implementation
+in `#1406` child tasks to keep one roadmap execution thread.


### PR DESCRIPTION
## Summary

- add a single handling matrix for roadmap issues `#1224-#1239` in `docs/issue-triage/roadmap-epics-1224-1239-one-pr.md`
- add a consolidated execution plan for rollup issue `#1406` in `docs/plans/phase2-rollup-1406-execution.md`
- update existing open-issue batch notes to reflect consolidated handling under `#1406`
- add phase-2 rollup entry point to `docs/current-architecture.md`

## Why

This keeps the full roadmap range `#1224-#1239` handled in one auditable PR surface and avoids fragmented closure rationale across unrelated issue threads.

## Validation

- docs-only change

## Issue linkage

Refs #1224
Refs #1225
Refs #1226
Refs #1227
Refs #1228
Refs #1229
Refs #1230
Refs #1231
Refs #1232
Refs #1233
Refs #1234
Refs #1235
Refs #1236
Refs #1237
Refs #1238
Refs #1239

Refs #1406
