### PR TITLE
fix(gateway): parse /install and return GUI-only error in chat

### DIFF
--- a/gateway/commands.go
+++ b/gateway/commands.go
@@ -21,6 +21,7 @@ const (
 	CmdChat            CommandName = "/chat"
 	CmdAgents          CommandName = "/agents"
 	CmdAdd             CommandName = "/add"
+	CmdInstall         CommandName = "/install"
 	CmdUninstall       CommandName = "/uninstall"
 	CmdStart           CommandName = "/start"
 	CmdStop            CommandName = "/stop"
@@ -37,6 +38,7 @@ var validCommands = map[CommandName]struct{}{
 	CmdChat:            {},
 	CmdAgents:          {},
 	CmdAdd:             {},
+	CmdInstall:         {},
 	CmdUninstall:       {},
 	CmdStart:           {},
 	CmdStop:            {},
@@ -164,6 +166,8 @@ func HandleCommand(ctx context.Context, cmd *GatewayCommand, daemon *DaemonClien
 	actor := fmt.Sprintf("%s:%s", cmd.Provider, cmd.ChatID)
 
 	switch cmd.Name {
+	case CmdInstall:
+		return installViaGUIOnlyResp(cmd.RequestID)
 	case CmdOnboard:
 		return onboardViaGUIOnlyResp(cmd.RequestID)
 	case CmdChat:
@@ -580,6 +584,10 @@ func addViaGUIOnlyResp(requestID string) GatewayResponse {
 
 func onboardViaGUIOnlyResp(requestID string) GatewayResponse {
 	return errResp(requestID, "E_ONBOARD_GUI_ONLY", "Onboarding is disabled in chat to protect credentials. Open Carrier GUI to complete onboarding and credential setup.")
+}
+
+func installViaGUIOnlyResp(requestID string) GatewayResponse {
+	return errResp(requestID, "E_INSTALL_GUI_ONLY", "Install is disabled in chat to protect credentials. Open Carrier GUI to install and onboard agents.")
 }
 
 func daemonErrResp(requestID string, err error) GatewayResponse {

--- a/gateway/commands_handlecommand_test.go
+++ b/gateway/commands_handlecommand_test.go
@@ -367,6 +367,24 @@ func TestHandleCommand_Onboard_GuiOnly(t *testing.T) {
 	}
 }
 
+func TestHandleCommand_Install_GuiOnly(t *testing.T) {
+	sessions := NewSessionStore("", 0, nil)
+	tok := pairAndGetSession(sessions, "telegram", "123")
+	defer sessions.Stop()
+	cmd := &GatewayCommand{
+		Provider: "telegram", ChatID: "123", RequestID: "r1",
+		Name: CmdInstall, Args: []string{"openclaw"}, SessionToken: tok,
+	}
+	// The session token is not validated for GUI-only install guard and daemon is not called.
+	resp := HandleCommand(context.Background(), cmd, nil, sessions, nil, nil, nil)
+	if resp.Result != "error" {
+		t.Fatalf("expected error, got %s: %s", resp.Result, resp.Message)
+	}
+	if resp.ErrorCode != "E_INSTALL_GUI_ONLY" {
+		t.Fatalf("expected E_INSTALL_GUI_ONLY, got %s", resp.ErrorCode)
+	}
+}
+
 func TestHandleCommand_Uninstall_Success(t *testing.T) {
 	srv, dc, sessions, downloads, onboard := setupTestEnv(t, map[string]http.HandlerFunc{
 		"POST /api/v1/agents/myagent/uninstall": func(w http.ResponseWriter, r *http.Request) {

--- a/gateway/commands_test.go
+++ b/gateway/commands_test.go
@@ -42,6 +42,12 @@ func TestParseInput_ValidCommands(t *testing.T) {
 			wantCmd: CmdAdd, wantArgs: []string{"myagent"}, wantSession: "session-xyz123",
 		},
 		{
+			name:         "install with argument",
+			input:        "telegram 123 req-install /install openclaw",
+			wantProvider: "telegram", wantChatID: "123", wantReqID: "req-install",
+			wantCmd: CmdInstall, wantArgs: []string{"openclaw"},
+		},
+		{
 			name:         "uninstall with session token",
 			input:        "feishu chat-abc req-3b session-xyz123 /uninstall myagent",
 			wantProvider: "feishu", wantChatID: "chat-abc", wantReqID: "req-3b",


### PR DESCRIPTION
## Summary
Fixes the Release workflow E2E failure in run 22355000628 (job 64692049575).

`/install <agent>` in chat was being rejected during parse as an unknown command (`E_PARSE`).
It should be recognized and then rejected with the explicit GUI-only guard (`E_INSTALL_GUI_ONLY`).

## Root cause
`/install` existed as behavior expectation in E2E, but was missing from the gateway command registry (`validCommands`) and command enum.

## Changes
- Add `CmdInstall` (`/install`) to `commands.go` command definitions and `validCommands`
- Handle `CmdInstall` in `HandleCommand` with `installViaGUIOnlyResp`
- Add regression tests:
  - parse test for `/install openclaw`
  - handler test for `E_INSTALL_GUI_ONLY`

## Validation
- `cd daemon && GOCACHE=/tmp/gocache go test ./internal/gateway -run 'TestParseInput_ValidCommands|TestParseInput_Errors|TestHandleCommand_Install_GuiOnly'`
- `./scripts/run-e2e-tests.sh` ✅ (now passes `/install openclaw blocked in chat`)

## CI context
- Failing run: https://github.com/Keith-CY/carrier/actions/runs/22355000628/job/64692049575