### PR TITLE
ci: pin upload-artifact and download-artifact to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: daemon-coverage
           path: |
@@ -236,7 +236,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Download daemon coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: daemon-coverage
           path: daemon
@@ -548,7 +548,7 @@ EOF
 
       - name: Upload visual snapshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: visual-snapshots
           path: webui/e2e/tests/visual.spec.ts-snapshots/
@@ -556,7 +556,7 @@ EOF
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: webui/e2e/test-results/


### PR DESCRIPTION
Pin `actions/upload-artifact@v4` and `actions/download-artifact@v4` to their current commit SHAs for consistency with the security posture established for other actions (checkout, setup-go, setup-node).

- `upload-artifact`: `ea165f8d65b6e75b540449e92b4886f43607fa02`
- `download-artifact`: `d3f86a106a0bac45b974a628896c90dbdf5c8093`

Closes #1410
Closes #1411
Closes #1412
Closes #1413