### PR TITLE
fix(remote): add identifier length bounds, validation tests, and SSH TOFU docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -218,3 +218,17 @@ For agent upgrades (managed via the lifecycle API), the daemon automatically cre
 - Rotate secrets in `/etc/carrier/carrier.env` regularly
 - The gateway uses crypto-secure tokens — do not downgrade to sequential generation
 - Review the [security audit](../docs/security-audit-command-execution.md) for command execution hardening
+
+### SSH Remote Control Plane — Host Key Verification
+
+The remote control plane uses `StrictHostKeyChecking=accept-new` for SSH connections,
+which implements Trust-On-First-Use (TOFU): new host keys are automatically accepted
+and saved on first connection, but changed keys are rejected on subsequent connections.
+
+For production deployments, consider pre-populating `~/.ssh/known_hosts` with the
+expected host keys of remote nodes to prevent potential MITM attacks on first connection:
+
+```bash
+# Pre-populate known_hosts for a remote node
+ssh-keyscan -H <remote-host> >> ~/.ssh/known_hosts
+```

--- a/gateway/remote_types.go
+++ b/gateway/remote_types.go
@@ -223,6 +223,9 @@ func validateAgentIdentifier(id string) error {
 	if trimmed == "" {
 		return fmt.Errorf("agent id is required")
 	}
+	if len(trimmed) > 128 {
+		return fmt.Errorf("agent id exceeds maximum length of 128 characters")
+	}
 	for _, ch := range trimmed {
 		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.' {
 			continue
@@ -236,6 +239,9 @@ func validateRemoteSessionIdentifier(id string) (string, error) {
 	trimmed := strings.TrimSpace(id)
 	if trimmed == "" {
 		return "", fmt.Errorf("sessionId is required")
+	}
+	if len(trimmed) > 128 {
+		return "", fmt.Errorf("sessionId exceeds maximum length of 128 characters")
 	}
 	for _, ch := range trimmed {
 		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.' {

--- a/gateway/remote_types_test.go
+++ b/gateway/remote_types_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAgentIdentifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"valid simple", "my-agent", false, ""},
+		{"valid with dots", "agent.v1.0", false, ""},
+		{"valid with underscore", "my_agent_01", false, ""},
+		{"empty", "", true, "agent id is required"},
+		{"whitespace only", "   ", true, "agent id is required"},
+		{"shell injection semicolon", "agent;rm -rf /", true, "unsupported character"},
+		{"shell injection backtick", "agent`id`", true, "unsupported character"},
+		{"shell injection dollar", "agent$(cmd)", true, "unsupported character"},
+		{"path traversal", "../../../etc/passwd", true, "unsupported character"},
+		{"null byte", "agent\x00id", true, "unsupported character"},
+		{"newline injection", "agent\nid", true, "unsupported character"},
+		{"pipe injection", "agent|cat /etc/shadow", true, "unsupported character"},
+		{"spaces", "agent id", true, "unsupported character"},
+		{"unicode", "agent-日本語", true, "unsupported character"},
+		{"too long", strings.Repeat("a", 129), true, "exceeds maximum length"},
+		{"exactly 128", strings.Repeat("a", 128), false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAgentIdentifier(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errMsg)
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Fatalf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRemoteSessionIdentifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"valid simple", "session-123", false, ""},
+		{"valid with dots", "sess.v2.main", false, ""},
+		{"empty", "", true, "sessionId is required"},
+		{"whitespace only", "  ", true, "sessionId is required"},
+		{"shell injection semicolon", "sess;rm -rf /", true, "unsupported character"},
+		{"shell injection backtick", "sess`id`", true, "unsupported character"},
+		{"shell injection dollar", "sess$(cmd)", true, "unsupported character"},
+		{"path traversal", "../../etc/passwd", true, "unsupported character"},
+		{"null byte", "sess\x00id", true, "unsupported character"},
+		{"newline injection", "sess\nid", true, "unsupported character"},
+		{"pipe injection", "sess|cat /etc/shadow", true, "unsupported character"},
+		{"too long", strings.Repeat("b", 129), true, "exceeds maximum length"},
+		{"exactly 128", strings.Repeat("b", 128), false, ""},
+		{"trims whitespace", "  valid-id  ", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := validateRemoteSessionIdentifier(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errMsg)
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Fatalf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if strings.TrimSpace(tt.input) != result {
+					t.Fatalf("expected trimmed %q, got %q", strings.TrimSpace(tt.input), result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- **#1425**: Upper-bound agent ID and session ID to 128 characters in `validateAgentIdentifier` and `validateRemoteSessionIdentifier`
- **#1420**: Add comprehensive test suite for invalid/malicious sessionId and agentId values (shell injection, path traversal, null bytes, newlines, pipes, unicode, length overflow)
- **#1424**: Document SSH `StrictHostKeyChecking=accept-new` TOFU behavior in deployment guide with `ssh-keyscan` mitigation

## Also closed (already resolved)
- **#1421**: Config snapshot path test already exists in `TestRemotePatchConfigSnapshotPath`
- **#1422**: Snapshot path already uses `$HOME/.openclaw/snapshots/`
- **#1423**: `chunkString` already uses `[]rune` for proper UTF-8 handling

Closes #1420, closes #1424, closes #1425