### PR TITLE
fix(gateway): accept optional config path override in listLocalSSHConfigHosts

### DIFF
--- a/gateway/ssh_config_hosts.go
+++ b/gateway/ssh_config_hosts.go
@@ -12,15 +12,23 @@ import (
 
 const maxSSHConfigIncludeDepth = 8
 
-func listLocalSSHConfigHosts() ([]string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("resolve home dir: %w", err)
+// listLocalSSHConfigHosts parses SSH config hosts. When configPath is empty it
+// defaults to ~/.ssh/config; pass an explicit path to override (useful when
+// the SSH config lives in a non-standard location).
+func listLocalSSHConfigHosts(configPath ...string) ([]string, error) {
+	var sshConfigPath string
+	if len(configPath) > 0 && configPath[0] != "" {
+		sshConfigPath = configPath[0]
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home dir: %w", err)
+		}
+		sshConfigPath = filepath.Join(home, ".ssh", "config")
 	}
-	configPath := filepath.Join(home, ".ssh", "config")
 	hosts := map[string]struct{}{}
 	seenFiles := map[string]struct{}{}
-	if err := collectSSHConfigHostsFromFile(configPath, 0, seenFiles, hosts); err != nil {
+	if err := collectSSHConfigHostsFromFile(sshConfigPath, 0, seenFiles, hosts); err != nil {
 		return nil, err
 	}
 	list := make([]string, 0, len(hosts))

--- a/gateway/ssh_config_hosts_test.go
+++ b/gateway/ssh_config_hosts_test.go
@@ -62,6 +62,23 @@ Host "quoted-host"
 	}
 }
 
+func TestListLocalSSHConfigHosts_CustomPathOverride(t *testing.T) {
+	dir := t.TempDir()
+	customConfig := filepath.Join(dir, "my_ssh_config")
+	if err := os.WriteFile(customConfig, []byte("Host custom-host-1\nHost custom-host-2\n"), 0o600); err != nil {
+		t.Fatalf("write custom config: %v", err)
+	}
+
+	hosts, err := listLocalSSHConfigHosts(customConfig)
+	if err != nil {
+		t.Fatalf("listLocalSSHConfigHosts with override error: %v", err)
+	}
+	want := []string{"custom-host-1", "custom-host-2"}
+	if !slices.Equal(hosts, want) {
+		t.Fatalf("unexpected hosts: got=%v want=%v", hosts, want)
+	}
+}
+
 func TestSplitSSHConfigDirective(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`listLocalSSHConfigHosts` now accepts an optional variadic `configPath` argument. When provided and non-empty, it is used instead of the default `~/.ssh/config`. This supports environments where the SSH config lives in a non-standard location (e.g. containerised setups, CI runners, custom HOME).

## Changes
- **`gateway/ssh_config_hosts.go`**: Changed signature from `listLocalSSHConfigHosts()` to `listLocalSSHConfigHosts(configPath ...string)` with backward-compatible variadic parameter
- **`gateway/ssh_config_hosts_test.go`**: Added `TestListLocalSSHConfigHosts_CustomPathOverride` test

All existing callers continue to work without changes (zero-arg call uses default `~/.ssh/config`).

Closes #1432