### PR TITLE
feat: add remote install live logs and server SSG chat in WebUI

### DIFF
--- a/gateway/remote_api.go
+++ b/gateway/remote_api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -226,6 +227,19 @@ func handleRemoteHostInstances(w http.ResponseWriter, r *http.Request, requestID
 		writeJSON(w, http.StatusOK, map[string]interface{}{"requestId": requestID, "result": "ok", "instance": status, "steps": steps})
 		return
 	case "install":
+		if len(parts) >= 5 {
+			subAction := strings.ToLower(strings.TrimSpace(parts[4]))
+			if subAction != "stream" {
+				writeJSON(w, http.StatusNotFound, gatewayErrBody("E_USAGE", "unsupported remote install action"))
+				return
+			}
+			if r.Method != http.MethodPost {
+				writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
+				return
+			}
+			streamRemoteInstallResponse(w, r, requestID, hostID, host, agentID)
+			return
+		}
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, gatewayErrBody("E_METHOD_NOT_ALLOWED", "method not allowed"))
 			return
@@ -278,6 +292,84 @@ func handleRemoteHostInstances(w http.ResponseWriter, r *http.Request, requestID
 		writeJSON(w, http.StatusNotFound, gatewayErrBody("E_USAGE", "unsupported remote instance action"))
 		return
 	}
+}
+
+func streamRemoteInstallResponse(w http.ResponseWriter, r *http.Request, requestID, hostID string, host RemoteHost, agentID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, gatewayErrBody("E_INTERNAL", "streaming not supported"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Request-Id", requestID)
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	var writeMu sync.Mutex
+	emit := func(payload map[string]interface{}) bool {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		if err := writeSSEEvent(w, payload); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !emit(map[string]interface{}{
+		"type":      "start",
+		"requestId": requestID,
+		"hostId":    hostID,
+		"agentId":   agentID,
+	}) {
+		return
+	}
+
+	startedAt := time.Now()
+	ctx, cancel := context.WithTimeout(r.Context(), 25*time.Minute)
+	defer cancel()
+
+	installResult, installErr := remoteInstallOpenClawStreaming(ctx, host, hostID, agentID, func(chunk remoteStreamChunk) {
+		line := strings.TrimSpace(RedactErrorMessage(chunk.Text))
+		if line == "" {
+			return
+		}
+		ok := emit(map[string]interface{}{
+			"type":   "log",
+			"stream": chunk.Stream,
+			"line":   line,
+		})
+		if !ok {
+			cancel()
+		}
+	})
+	recordRemoteOperationMetric(remoteOpInstancesInstall, startedAt, installErr)
+
+	if installResult != nil {
+		_ = emit(map[string]interface{}{
+			"type":    "result",
+			"install": installResult,
+		})
+	}
+	if installErr != nil {
+		_ = emit(map[string]interface{}{
+			"type":      "error",
+			"errorCode": "E_REMOTE_INSTALL_FAILED",
+			"message":   RedactErrorMessage(installErr.Error()),
+		})
+		_ = emit(map[string]interface{}{
+			"type":         "finish",
+			"finishReason": "error",
+		})
+		return
+	}
+	_ = emit(map[string]interface{}{
+		"type":         "finish",
+		"finishReason": "stop",
+	})
 }
 
 func handleRemoteHostConfig(w http.ResponseWriter, r *http.Request, requestID string, host RemoteHost) {

--- a/gateway/remote_api_test.go
+++ b/gateway/remote_api_test.go
@@ -90,6 +90,23 @@ func configureSSHRunner(t *testing.T, fn func(command string) remoteExecResult) 
 	})
 }
 
+func configureSSHStreamRunner(t *testing.T, fn func(command string, onChunk func(remoteStreamChunk)) remoteExecResult) {
+	t.Helper()
+	orig := sshExecStreamRunner
+	sshExecStreamRunner = func(_ context.Context, args []string, onChunk func(remoteStreamChunk)) (remoteExecResult, error) {
+		if len(args) == 0 {
+			return remoteExecResult{ExitCode: 1, Stderr: "missing ssh args"}, nil
+		}
+		cmd := args[len(args)-1]
+		result := fn(cmd, onChunk)
+		result.Command = cmd
+		return result, nil
+	}
+	t.Cleanup(func() {
+		sshExecStreamRunner = orig
+	})
+}
+
 func createRemoteHostForTests(t *testing.T, mux http.Handler) string {
 	t.Helper()
 	rec := runJSONRequest(t, mux, http.MethodPost, "/api/v1/remote/hosts", `{
@@ -300,6 +317,43 @@ func TestRemoteChatStreamSSE(t *testing.T) {
 	unifiedBody := unifiedRec.Body.String()
 	if !strings.Contains(unifiedBody, `"type":"text-delta"`) || !strings.Contains(unifiedBody, `"type":"finish"`) {
 		t.Fatalf("expected sse events in unified remote stream body: %s", unifiedBody)
+	}
+}
+
+func TestRemoteInstallStreamSSE(t *testing.T) {
+	configureSSHStreamRunner(t, func(command string, onChunk func(remoteStreamChunk)) remoteExecResult {
+		if strings.Contains(command, "install.sh") {
+			if onChunk != nil {
+				onChunk(remoteStreamChunk{Stream: "stdout", Text: "download complete"})
+				onChunk(remoteStreamChunk{Stream: "stdout", Text: "install complete"})
+			}
+			return remoteExecResult{ExitCode: 0, Stdout: "download complete\ninstall complete"}
+		}
+		return remoteExecResult{ExitCode: 0}
+	})
+
+	mux := buildRemoteFeatureMux(t)
+	hostID := createRemoteHostForTests(t, mux)
+
+	rec := runJSONRequest(t, mux, http.MethodPost, "/api/v1/remote/hosts/"+hostID+"/instances/main/install/stream", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install stream status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"type":"start"`) {
+		t.Fatalf("expected start event in stream body: %s", body)
+	}
+	if !strings.Contains(body, `"type":"log"`) {
+		t.Fatalf("expected log event in stream body: %s", body)
+	}
+	if !strings.Contains(body, `"line":"download complete"`) {
+		t.Fatalf("expected streamed install output in body: %s", body)
+	}
+	if !strings.Contains(body, `"type":"result"`) || !strings.Contains(body, `"installed":true`) {
+		t.Fatalf("expected result event with installed=true in body: %s", body)
+	}
+	if !strings.Contains(body, `"type":"finish"`) {
+		t.Fatalf("expected finish event in stream body: %s", body)
 	}
 }
 

--- a/gateway/remote_openclaw.go
+++ b/gateway/remote_openclaw.go
@@ -148,6 +148,46 @@ func remoteInstallOpenClaw(ctx context.Context, host RemoteHost, hostID, agentID
 	return result, nil
 }
 
+func remoteInstallOpenClawStreaming(
+	ctx context.Context,
+	host RemoteHost,
+	hostID, agentID string,
+	onChunk func(remoteStreamChunk),
+) (*remoteInstallResult, error) {
+	if err := validateAgentIdentifier(agentID); err != nil {
+		return nil, err
+	}
+	result := &remoteInstallResult{
+		HostID:      hostID,
+		AgentID:     agentID,
+		Installed:   false,
+		GatewayMode: host.RuntimeMode,
+		Steps:       []remoteExecResult{},
+	}
+
+	installCmd := "curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --no-prompt --no-onboard 2>&1"
+	installRes, err := runRemoteCommandStream(ctx, host, installCmd, onChunk)
+	if err != nil {
+		return result, err
+	}
+	result.Steps = append(result.Steps, installRes)
+	if installRes.ExitCode != 0 {
+		return result, remoteCommandError(installRes, "install openclaw")
+	}
+	if host.RuntimeMode == RemoteRuntimeModeManagedGateway {
+		restartRes, runErr := runRemoteCommandStream(ctx, host, "openclaw gateway restart 2>&1 || openclaw gateway start 2>&1", onChunk)
+		if runErr != nil {
+			return result, runErr
+		}
+		result.Steps = append(result.Steps, restartRes)
+		if restartRes.ExitCode != 0 {
+			return result, remoteCommandError(restartRes, "start managed gateway")
+		}
+	}
+	result.Installed = true
+	return result, nil
+}
+
 func remoteListInstancesForHost(ctx context.Context, host RemoteHost, hostID string) ([]RemoteInstance, []remoteExecResult, error) {
 	steps := []remoteExecResult{}
 	_, _, preflightSteps, err := ensureRemoteHealthyForOperation(ctx, host)

--- a/gateway/remote_ssh.go
+++ b/gateway/remote_ssh.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,7 +21,13 @@ type remoteExecResult struct {
 	DurationMs int64  `json:"durationMs"`
 }
 
+type remoteStreamChunk struct {
+	Stream string `json:"stream"`
+	Text   string `json:"text"`
+}
+
 var sshExecRunner = defaultSSHExecRunner
+var sshExecStreamRunner = defaultSSHExecStreamRunner
 
 func defaultSSHExecRunner(ctx context.Context, args []string) (remoteExecResult, error) {
 	cmd := exec.CommandContext(ctx, "ssh", args...)
@@ -47,12 +55,100 @@ func defaultSSHExecRunner(ctx context.Context, args []string) (remoteExecResult,
 	return result, fmt.Errorf("execute ssh: %w", runErr)
 }
 
+func defaultSSHExecStreamRunner(ctx context.Context, args []string, onChunk func(remoteStreamChunk)) (remoteExecResult, error) {
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return remoteExecResult{}, fmt.Errorf("prepare ssh stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return remoteExecResult{}, fmt.Errorf("prepare ssh stderr pipe: %w", err)
+	}
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return remoteExecResult{}, fmt.Errorf("start ssh: %w", err)
+	}
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	var cbMu sync.Mutex
+	emit := func(chunk remoteStreamChunk) {
+		if onChunk == nil {
+			return
+		}
+		cbMu.Lock()
+		onChunk(chunk)
+		cbMu.Unlock()
+	}
+	appendLine := func(buf *bytes.Buffer, line string) {
+		if buf.Len() > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(line)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdoutPipe)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			appendLine(&stdoutBuf, line)
+			emit(remoteStreamChunk{Stream: "stdout", Text: line})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderrPipe)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			appendLine(&stderrBuf, line)
+			emit(remoteStreamChunk{Stream: "stderr", Text: line})
+		}
+	}()
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	result := remoteExecResult{
+		Stdout:     stdoutBuf.String(),
+		Stderr:     stderrBuf.String(),
+		DurationMs: time.Since(start).Milliseconds(),
+	}
+	if waitErr == nil {
+		result.ExitCode = 0
+		return result, nil
+	}
+	if ee, ok := waitErr.(*exec.ExitError); ok {
+		result.ExitCode = ee.ExitCode()
+		return result, nil
+	}
+	return result, fmt.Errorf("execute ssh stream: %w", waitErr)
+}
+
 func runRemoteCommand(ctx context.Context, host RemoteHost, command string) (remoteExecResult, error) {
 	args, err := buildSSHArgs(host, command)
 	if err != nil {
 		return remoteExecResult{}, err
 	}
 	result, err := sshExecRunner(ctx, args)
+	result.Command = command
+	return result, err
+}
+
+func runRemoteCommandStream(ctx context.Context, host RemoteHost, command string, onChunk func(remoteStreamChunk)) (remoteExecResult, error) {
+	args, err := buildSSHArgs(host, command)
+	if err != nil {
+		return remoteExecResult{}, err
+	}
+	result, err := sshExecStreamRunner(ctx, args, onChunk)
 	result.Command = command
 	return result, err
 }

--- a/webui/src/app.ts
+++ b/webui/src/app.ts
@@ -42,6 +42,16 @@
   let serverHostLastOperationByID = {};
   let serverEditingHostID = '';
   let profileEditingProfileID = '';
+  let serverManageInstallStreamAbortController = null;
+  let serverManageLiveLogLines = [];
+  let serverManageDiagnosisPending = false;
+  let serverManageDiagnosisText = '';
+  let serverManageChatSessionID = '';
+  let serverManageChatAbortController = null;
+  let serverManageChatLastInput = '';
+  let serverManageChatActiveAssistantNode = null;
+  let serverManageChatMessages = [];
+  let serverManageChatMessageSeq = 0;
   let remoteChatSessionID = '';
   let remoteChatAbortController = null;
   let remoteChatLastInput = '';
@@ -2555,6 +2565,165 @@
     });
   }
 
+  function updateServerManageStreamStatus(text, type) {
+    const el = $('#server-manage-stream-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.classList.remove('msg-error', 'msg-success', 'msg-info');
+    if (type) el.classList.add('msg-' + type);
+  }
+
+  function renderServerManageDiagnosis(text, state) {
+    const out = $('#server-manage-diagnosis');
+    if (!out) return;
+    out.textContent = '';
+    const body = String(text || '').trim();
+    if (!body) return;
+
+    let pillState = 'manage-pill-warn';
+    let title = 'BaseAgent Diagnosis';
+    const normalized = String(state || '').trim().toLowerCase();
+    if (normalized === 'ok') {
+      pillState = 'manage-pill-ok';
+      title = 'BaseAgent Diagnosis';
+    } else if (normalized === 'error') {
+      pillState = 'manage-pill-bad';
+      title = 'BaseAgent Diagnosis Failed';
+    } else if (normalized === 'running') {
+      pillState = 'manage-pill-warn';
+      title = 'BaseAgent Analyzing';
+    }
+
+    const card = document.createElement('div');
+    card.className = 'manage-card';
+
+    const header = document.createElement('div');
+    header.className = 'manage-card-header';
+    const h = document.createElement('div');
+    h.className = 'manage-card-title';
+    h.textContent = title;
+    const pill = document.createElement('span');
+    pill.className = 'manage-pill ' + pillState;
+    pill.textContent = normalized || 'info';
+    header.appendChild(h);
+    header.appendChild(pill);
+    card.appendChild(header);
+
+    const pre = document.createElement('pre');
+    pre.className = 'code-block';
+    pre.textContent = body;
+    card.appendChild(pre);
+    out.appendChild(card);
+  }
+
+  function redactInstallLogLine(line) {
+    return String(line || '')
+      .replace(/\b[A-Za-z0-9._%+-]+:[A-Za-z0-9._%+-]+@/g, '***:***@')
+      .replace(/\b(sk|rk|pk)-[A-Za-z0-9_-]{10,}\b/g, '$1-***')
+      .replace(/\b(token|secret|password|apikey|api_key)\s*[:=]\s*[^\s]+/gi, '$1=***');
+  }
+
+  function appendServerManageLiveLogLine(line, stream) {
+    const clean = redactInstallLogLine(String(line || '').trim());
+    if (!clean) return;
+    const prefix = stream === 'stderr' ? '[stderr] ' : '';
+    serverManageLiveLogLines.push(prefix + clean);
+    if (serverManageLiveLogLines.length > 800) {
+      serverManageLiveLogLines = serverManageLiveLogLines.slice(serverManageLiveLogLines.length - 800);
+    }
+    renderServerManageLogs('--- install-stream.log ---\n' + serverManageLiveLogLines.join('\n'));
+  }
+
+  function isInstallAnomalyLine(line) {
+    const text = String(line || '').trim().toLowerCase();
+    if (!text) return false;
+    const patterns = [
+      'error',
+      'failed',
+      'panic',
+      'exception',
+      'permission denied',
+      'timed out',
+      'no such file',
+      'cannot',
+      'denied',
+    ];
+    return patterns.some(pattern => text.includes(pattern));
+  }
+
+  async function requestBaseAgentInstallDiagnosis(hostID, agentID, lines) {
+    const tail = (Array.isArray(lines) ? lines : []).slice(-20).join('\n');
+    const prompt = [
+      'Diagnose remote OpenClaw install progress and likely failure cause.',
+      'Host: ' + String(hostID || ''),
+      'Agent: ' + String(agentID || ''),
+      'Recent install logs:',
+      tail || '(empty)',
+      'Return concise diagnosis and next 3 actions.',
+    ].join('\n');
+
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+
+    const response = await fetch('/api/v1/chat/stream', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        target: 'local',
+        message: prompt,
+        provider: 'webui',
+        sessionId: '',
+        chatId: '',
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || 'diagnosis request failed (' + response.status + ')');
+    }
+    if (!response.body || !response.body.getReader) {
+      throw new Error('diagnosis stream is not supported in this browser');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let output = '';
+    for (;;) {
+      const step = await reader.read();
+      if (step.done) break;
+      buffer += decoder.decode(step.value, { stream: true });
+      buffer = parseSSEFrames(buffer, payload => {
+        if (String(payload && payload.type ? payload.type : '') === 'text-delta') {
+          output += String(payload.delta || '');
+        }
+      });
+    }
+    buffer = parseSSEFrames(buffer, payload => {
+      if (String(payload && payload.type ? payload.type : '') === 'text-delta') {
+        output += String(payload.delta || '');
+      }
+    });
+    return String(output || '').trim();
+  }
+
+  function maybeRunServerManageDiagnosis(hostID, agentID) {
+    if (serverManageDiagnosisPending || serverManageDiagnosisText) return;
+    serverManageDiagnosisPending = true;
+    renderServerManageDiagnosis('Analyzing install logs with local BaseAgent...', 'running');
+    requestBaseAgentInstallDiagnosis(hostID, agentID, serverManageLiveLogLines)
+      .then(text => {
+        serverManageDiagnosisText = text || 'No diagnosis returned.';
+        renderServerManageDiagnosis(serverManageDiagnosisText, 'ok');
+      })
+      .catch(err => {
+        serverManageDiagnosisText = 'BaseAgent diagnosis unavailable: ' + (err && err.message ? err.message : String(err));
+        renderServerManageDiagnosis(serverManageDiagnosisText, 'error');
+      })
+      .finally(() => {
+        serverManageDiagnosisPending = false;
+      });
+  }
+
   function renderServerManageSessions(entries) {
     const out = $('#server-manage-sessions');
     if (!out) return;
@@ -2589,10 +2758,163 @@
     }).join('\n');
   }
 
+  function renderServerManageChatMessages() {
+    const wrap = $('#server-manage-chat-messages');
+    if (!wrap) return;
+    const island = window.CarrierRemoteChatIsland;
+    if (island && typeof island.renderMessages === 'function' && island.renderMessages(wrap, serverManageChatMessages)) {
+      return;
+    }
+    wrap.textContent = '';
+    serverManageChatMessages.forEach(message => {
+      const msg = document.createElement('div');
+      msg.className = 'chat-msg';
+      const sender = document.createElement('span');
+      sender.className = 'sender';
+      sender.textContent = (message.role === 'user' ? 'You' : message.role === 'assistant' ? 'Agent' : 'Carrier') + ':';
+      const body = document.createElement('span');
+      body.className = 'body';
+      body.textContent = ' ' + String(message.text || '');
+      msg.appendChild(sender);
+      msg.appendChild(body);
+      wrap.appendChild(msg);
+    });
+    wrap.scrollTop = wrap.scrollHeight;
+  }
+
+  function appendServerManageChatMessage(role, text) {
+    serverManageChatMessageSeq += 1;
+    const messageID = 'server-manage-chat-msg-' + String(serverManageChatMessageSeq);
+    serverManageChatMessages.push({
+      id: messageID,
+      role: String(role || 'system'),
+      text: String(text || ''),
+    });
+    renderServerManageChatMessages();
+    return messageID;
+  }
+
+  function appendServerManageChatMessageDelta(messageID, delta) {
+    const id = String(messageID || '');
+    if (!id) return;
+    const index = serverManageChatMessages.findIndex(message => String(message.id || '') === id);
+    if (index < 0) return;
+    serverManageChatMessages[index].text = String(serverManageChatMessages[index].text || '') + String(delta || '');
+    renderServerManageChatMessages();
+  }
+
+  function updateServerManageChatStatus(text, type) {
+    const el = $('#server-manage-chat-status');
+    if (!el) return;
+    el.textContent = text || '';
+    el.classList.remove('msg-error', 'msg-success', 'msg-info');
+    if (type) el.classList.add('msg-' + type);
+  }
+
+  async function sendServerManageChat(inputText) {
+    const target = validateServerManageInstanceTarget();
+    if (!target.hostID || !target.agentID) return;
+    const message = (inputText || '').trim();
+    if (!message) {
+      updateServerManageChatStatus('message is required.', 'error');
+      return;
+    }
+    serverManageChatLastInput = message;
+    appendServerManageChatMessage('user', message);
+    serverManageChatActiveAssistantNode = appendServerManageChatMessage('assistant', '');
+
+    if (serverManageChatAbortController) {
+      serverManageChatAbortController.abort();
+      serverManageChatAbortController = null;
+    }
+    const controller = new AbortController();
+    serverManageChatAbortController = controller;
+    updateServerManageChatStatus('Streaming response...', 'info');
+
+    try {
+      const headers = { 'Content-Type': 'application/json' };
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+      const response = await fetch('/api/v1/chat/stream', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          target: 'remote',
+          hostId: target.hostID,
+          agentId: target.agentID,
+          message: message,
+          sessionId: serverManageChatSessionID || '',
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'remote chat failed (' + response.status + ')');
+      }
+      if (!response.body || !response.body.getReader) {
+        throw new Error('streaming body is not supported in this browser');
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      for (;;) {
+        const step = await reader.read();
+        if (step.done) break;
+        buffer += decoder.decode(step.value, { stream: true });
+        buffer = parseSSEFrames(buffer, payload => {
+          const eventType = String(payload && payload.type ? payload.type : '').trim();
+          if (eventType === 'text-delta') {
+            if (serverManageChatActiveAssistantNode) {
+              appendServerManageChatMessageDelta(serverManageChatActiveAssistantNode, String(payload.delta || ''));
+            }
+            return;
+          }
+          if (eventType === 'session') {
+            serverManageChatSessionID = String(payload.sessionId || '').trim();
+            updateServerManageChatStatus('Session: ' + serverManageChatSessionID, 'info');
+            return;
+          }
+          if (eventType === 'finish') {
+            updateServerManageChatStatus('Stream finished.', 'success');
+          }
+        });
+      }
+      buffer = parseSSEFrames(buffer, () => {});
+      updateServerManageChatStatus('Stream finished.', 'success');
+    } catch (e) {
+      if (e.name === 'AbortError') {
+        updateServerManageChatStatus('Stream cancelled.', 'info');
+      } else {
+        updateServerManageChatStatus('Stream failed: ' + e.message, 'error');
+      }
+    } finally {
+      if (serverManageChatAbortController === controller) {
+        serverManageChatAbortController = null;
+      }
+      serverManageChatActiveAssistantNode = null;
+    }
+  }
+
+  function resetServerManageChatState() {
+    if (serverManageChatAbortController) {
+      serverManageChatAbortController.abort();
+      serverManageChatAbortController = null;
+    }
+    serverManageChatSessionID = '';
+    serverManageChatLastInput = '';
+    serverManageChatActiveAssistantNode = null;
+    serverManageChatMessages = [];
+    renderServerManageChatMessages();
+    updateServerManageChatStatus('Ready to chat with selected SSG agent.', 'info');
+  }
+
   function showServerManagePanel(hostID) {
     const card = $('#server-manage-card');
     const hostLabel = $('#server-manage-host-label');
     if (!card || !hostLabel) return;
+    if (serverManageInstallStreamAbortController) {
+      serverManageInstallStreamAbortController.abort();
+      serverManageInstallStreamAbortController = null;
+    }
     const key = String(hostID || '').trim();
     if (!key) {
       card.classList.add('hidden');
@@ -2607,8 +2929,14 @@
     renderServerManageInstances([]);
     renderServerManageInstanceStatus({}, []);
     renderServerManageLogs('');
+    updateServerManageStreamStatus('', 'info');
+    serverManageLiveLogLines = [];
+    serverManageDiagnosisText = '';
+    serverManageDiagnosisPending = false;
+    renderServerManageDiagnosis('', '');
     renderServerManageSessions([]);
     renderServerManageMemory([]);
+    resetServerManageChatState();
     setServerManageOperationMeta(null);
     setMsg('#server-manage-msg', '', 'info');
   }
@@ -2635,6 +2963,11 @@
       'server-manage-archive-session',
       'server-manage-delete-session',
       'server-manage-load-memory',
+      'server-manage-chat-input',
+      'server-manage-chat-send',
+      'server-manage-chat-reset-session',
+      'server-manage-chat-cancel',
+      'server-manage-chat-retry',
       'server-manage-agent-id',
       'server-manage-session-id',
       'server-manage-log-tail',
@@ -2906,19 +3239,148 @@
     await runServerManageOperation('instance-status', task);
   }
 
+  async function streamServerManageInstall(target) {
+    const path = '/api/v1/remote/hosts/' + encodeURIComponent(target.hostID) + '/instances/' + encodeURIComponent(target.agentID) + '/install/stream';
+    const startedAt = performance.now();
+    let requestID = '';
+    let installPayload = null;
+    let streamError = '';
+    let finishReason = '';
+
+    if (serverManageInstallStreamAbortController) {
+      serverManageInstallStreamAbortController.abort();
+      serverManageInstallStreamAbortController = null;
+    }
+    serverManageLiveLogLines = [];
+    serverManageDiagnosisText = '';
+    serverManageDiagnosisPending = false;
+    renderServerManageLogs('');
+    renderServerManageDiagnosis('', '');
+    updateServerManageStreamStatus('Connecting stream...', 'info');
+
+    const controller = new AbortController();
+    serverManageInstallStreamAbortController = controller;
+
+    try {
+      const headers = { 'Content-Type': 'application/json' };
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+
+      const response = await fetch(path, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({}),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'install stream failed (' + response.status + ')');
+      }
+      if (!response.body || !response.body.getReader) {
+        throw new Error('streaming body is not supported in this browser');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      for (;;) {
+        const step = await reader.read();
+        if (step.done) break;
+        buffer += decoder.decode(step.value, { stream: true });
+        buffer = parseSSEFrames(buffer, payload => {
+          const eventType = String(payload && payload.type ? payload.type : '').trim();
+          if (eventType === 'start') {
+            requestID = String(payload.requestId || '').trim();
+            updateServerManageStreamStatus('Install stream started.', 'info');
+            return;
+          }
+          if (eventType === 'log') {
+            const line = String(payload.line || '');
+            const stream = String(payload.stream || 'stdout');
+            appendServerManageLiveLogLine(line, stream);
+            if (isInstallAnomalyLine(line)) {
+              updateServerManageStreamStatus('Potential issue detected in install output. Running BaseAgent diagnosis...', 'info');
+              maybeRunServerManageDiagnosis(target.hostID, target.agentID);
+            }
+            return;
+          }
+          if (eventType === 'result') {
+            installPayload = payload.install || null;
+            const steps = installPayload && Array.isArray(installPayload.steps) ? installPayload.steps : [];
+            renderServerManageInstanceStatus(installPayload || {}, steps);
+            updateServerManageStreamStatus('Install stream returned result.', 'info');
+            return;
+          }
+          if (eventType === 'error') {
+            streamError = String(payload.message || payload.error || 'remote install failed');
+            updateServerManageStreamStatus('Install stream error: ' + streamError, 'error');
+            return;
+          }
+          if (eventType === 'finish') {
+            finishReason = String(payload.finishReason || '').trim();
+            return;
+          }
+        });
+      }
+      buffer = parseSSEFrames(buffer, payload => {
+        const eventType = String(payload && payload.type ? payload.type : '').trim();
+        if (eventType === 'error') {
+          streamError = String(payload.message || payload.error || 'remote install failed');
+        }
+        if (eventType === 'finish') {
+          finishReason = String(payload.finishReason || '').trim();
+        }
+      });
+
+      const success = !streamError && (!finishReason || finishReason === 'stop');
+      setServerManageOperationMeta({
+        operation: 'instance_install_stream',
+        success: success,
+        requestId: requestID,
+        durationMs: performance.now() - startedAt,
+        path: path,
+        error: success ? '' : streamError || ('finishReason=' + finishReason),
+      });
+
+      return {
+        install: installPayload,
+        requestId: requestID,
+        error: streamError,
+        finishReason: finishReason,
+      };
+    } catch (e) {
+      const errMsg = e && e.message ? e.message : String(e);
+      setServerManageOperationMeta({
+        operation: 'instance_install_stream',
+        success: false,
+        durationMs: performance.now() - startedAt,
+        path: path,
+        error: errMsg,
+      });
+      throw e;
+    } finally {
+      if (serverManageInstallStreamAbortController === controller) {
+        serverManageInstallStreamAbortController = null;
+      }
+    }
+  }
+
   async function installServerManageInstance() {
     const target = validateServerManageInstanceTarget();
     if (!target.hostID || !target.agentID) return;
-    await runServerManageOperation('install', async () => {
-      renderServerManageProgress('Install', target.hostID + ':' + target.agentID);
-      setMsg('#server-manage-msg', 'Install in progress for ' + target.agentID + '...', 'info');
+    await runServerManageOperation('install-stream', async () => {
+      renderServerManageProgress('Install (Live)', target.hostID + ':' + target.agentID);
+      setMsg('#server-manage-msg', 'Live install in progress for ' + target.agentID + '...', 'info');
       try {
-        const path = '/api/v1/remote/hosts/' + encodeURIComponent(target.hostID) + '/instances/' + encodeURIComponent(target.agentID) + '/install';
-        const payload = await serverManageAPI('POST', path, {}, 'instance_install');
-        renderServerManageInstanceStatus(payload.install || {}, payload.steps || []);
+        const result = await streamServerManageInstall(target);
+        if (result && result.error) {
+          setMsg('#server-manage-msg', 'Install failed: ' + result.error, 'error');
+          return;
+        }
+        updateServerManageStreamStatus('Install stream finished.', 'success');
         setMsg('#server-manage-msg', 'Install completed for ' + target.agentID + '.', 'success');
         await loadServerManageInstances({ silent: true, skipLock: true });
       } catch (e) {
+        updateServerManageStreamStatus('Install stream failed.', 'error');
         setMsg('#server-manage-msg', 'Install failed: ' + e.message, 'error');
       }
     });
@@ -3127,9 +3589,16 @@
     const archiveSessionBtn = $('#server-manage-archive-session');
     const deleteSessionBtn = $('#server-manage-delete-session');
     const loadMemoryBtn = $('#server-manage-load-memory');
+    const chatInput = $('#server-manage-chat-input');
+    const chatSendBtn = $('#server-manage-chat-send');
+    const chatResetBtn = $('#server-manage-chat-reset-session');
+    const chatCancelBtn = $('#server-manage-chat-cancel');
+    const chatRetryBtn = $('#server-manage-chat-retry');
     const instancesOut = $('#server-manage-instances');
     const instanceStatusOut = $('#server-manage-instance-status-out');
     const logsOut = $('#server-manage-logs');
+    const streamStatusOut = $('#server-manage-stream-status');
+    const diagnosisOut = $('#server-manage-diagnosis');
     const sessionsOut = $('#server-manage-sessions');
     const memoryOut = $('#server-manage-memory');
 
@@ -3157,9 +3626,15 @@
         if (instancesOut) instancesOut.textContent = '';
         if (instanceStatusOut) instanceStatusOut.textContent = '';
         if (logsOut) logsOut.textContent = '';
+        if (streamStatusOut) streamStatusOut.textContent = '';
+        if (diagnosisOut) diagnosisOut.textContent = '';
+        serverManageLiveLogLines = [];
+        serverManageDiagnosisText = '';
+        serverManageDiagnosisPending = false;
         if (sessionsOut) sessionsOut.textContent = '';
         if (memoryOut) memoryOut.textContent = '';
         setServerManageOperationMeta(null);
+        resetServerManageChatState();
         setMsg('#server-manage-msg', '', 'info');
         return;
       }
@@ -3179,6 +3654,8 @@
     syncServerAuthModeInputs();
     updateServerEditorUI();
     setServerManageControlsDisabled(false);
+    renderServerManageChatMessages();
+    updateServerManageChatStatus('Ready to chat with selected SSG agent.', 'info');
 
     if (loadInstancesBtn) loadInstancesBtn.onclick = () => { loadServerManageInstances(); };
     if (instanceStatusBtn) instanceStatusBtn.onclick = () => { loadServerManageInstanceStatus(); };
@@ -3191,6 +3668,47 @@
     if (archiveSessionBtn) archiveSessionBtn.onclick = () => { applyServerManageSessionAction('archive'); };
     if (deleteSessionBtn) deleteSessionBtn.onclick = () => { applyServerManageSessionAction('delete'); };
     if (loadMemoryBtn) loadMemoryBtn.onclick = () => { loadServerManageMemory(); };
+    if (chatSendBtn) {
+      chatSendBtn.onclick = () => {
+        const text = chatInput && chatInput.value ? chatInput.value.trim() : '';
+        if (!text) return;
+        if (chatInput) chatInput.value = '';
+        sendServerManageChat(text);
+      };
+    }
+    if (chatInput) {
+      chatInput.onkeydown = e => {
+        if (e.key !== 'Enter') return;
+        const text = chatInput.value ? chatInput.value.trim() : '';
+        if (!text) return;
+        chatInput.value = '';
+        sendServerManageChat(text);
+      };
+    }
+    if (chatResetBtn) {
+      chatResetBtn.onclick = () => {
+        serverManageChatSessionID = '';
+        updateServerManageChatStatus('Session reset. Next message starts a new session.', 'info');
+      };
+    }
+    if (chatCancelBtn) {
+      chatCancelBtn.onclick = () => {
+        if (serverManageChatAbortController) {
+          serverManageChatAbortController.abort();
+        } else {
+          updateServerManageChatStatus('No active stream.', 'info');
+        }
+      };
+    }
+    if (chatRetryBtn) {
+      chatRetryBtn.onclick = () => {
+        if (!serverManageChatLastInput) {
+          updateServerManageChatStatus('No previous message to retry.', 'info');
+          return;
+        }
+        sendServerManageChat(serverManageChatLastInput);
+      };
+    }
 
     refreshBtn.onclick = async () => {
       try {

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -38,6 +38,16 @@
   let serverHostLastOperationByID = {};
   let serverEditingHostID = "";
   let profileEditingProfileID = "";
+  let serverManageInstallStreamAbortController = null;
+  let serverManageLiveLogLines = [];
+  let serverManageDiagnosisPending = false;
+  let serverManageDiagnosisText = "";
+  let serverManageChatSessionID = "";
+  let serverManageChatAbortController = null;
+  let serverManageChatLastInput = "";
+  let serverManageChatActiveAssistantNode = null;
+  let serverManageChatMessages = [];
+  let serverManageChatMessageSeq = 0;
   let remoteChatSessionID = "";
   let remoteChatAbortController = null;
   let remoteChatLastInput = "";
@@ -2493,6 +2503,154 @@
       out.appendChild(wrapper);
     });
   }
+  function updateServerManageStreamStatus(text, type) {
+    const el = $("#server-manage-stream-status");
+    if (!el)
+      return;
+    el.textContent = text || "";
+    el.classList.remove("msg-error", "msg-success", "msg-info");
+    if (type)
+      el.classList.add("msg-" + type);
+  }
+  function renderServerManageDiagnosis(text, state) {
+    const out = $("#server-manage-diagnosis");
+    if (!out)
+      return;
+    out.textContent = "";
+    const body = String(text || "").trim();
+    if (!body)
+      return;
+    let pillState = "manage-pill-warn";
+    let title = "BaseAgent Diagnosis";
+    const normalized = String(state || "").trim().toLowerCase();
+    if (normalized === "ok") {
+      pillState = "manage-pill-ok";
+      title = "BaseAgent Diagnosis";
+    } else if (normalized === "error") {
+      pillState = "manage-pill-bad";
+      title = "BaseAgent Diagnosis Failed";
+    } else if (normalized === "running") {
+      pillState = "manage-pill-warn";
+      title = "BaseAgent Analyzing";
+    }
+    const card = document.createElement("div");
+    card.className = "manage-card";
+    const header = document.createElement("div");
+    header.className = "manage-card-header";
+    const h = document.createElement("div");
+    h.className = "manage-card-title";
+    h.textContent = title;
+    const pill = document.createElement("span");
+    pill.className = "manage-pill " + pillState;
+    pill.textContent = normalized || "info";
+    header.appendChild(h);
+    header.appendChild(pill);
+    card.appendChild(header);
+    const pre = document.createElement("pre");
+    pre.className = "code-block";
+    pre.textContent = body;
+    card.appendChild(pre);
+    out.appendChild(card);
+  }
+  function redactInstallLogLine(line) {
+    return String(line || "").replace(/\b[A-Za-z0-9._%+-]+:[A-Za-z0-9._%+-]+@/g, "***:***@").replace(/\b(sk|rk|pk)-[A-Za-z0-9_-]{10,}\b/g, "$1-***").replace(/\b(token|secret|password|apikey|api_key)\s*[:=]\s*[^\s]+/gi, "$1=***");
+  }
+  function appendServerManageLiveLogLine(line, stream) {
+    const clean = redactInstallLogLine(String(line || "").trim());
+    if (!clean)
+      return;
+    const prefix = stream === "stderr" ? "[stderr] " : "";
+    serverManageLiveLogLines.push(prefix + clean);
+    if (serverManageLiveLogLines.length > 800) {
+      serverManageLiveLogLines = serverManageLiveLogLines.slice(serverManageLiveLogLines.length - 800);
+    }
+    renderServerManageLogs("--- install-stream.log ---\n" + serverManageLiveLogLines.join("\n"));
+  }
+  function isInstallAnomalyLine(line) {
+    const text = String(line || "").trim().toLowerCase();
+    if (!text)
+      return false;
+    const patterns = [
+      "error",
+      "failed",
+      "panic",
+      "exception",
+      "permission denied",
+      "timed out",
+      "no such file",
+      "cannot",
+      "denied"
+    ];
+    return patterns.some((pattern) => text.includes(pattern));
+  }
+  async function requestBaseAgentInstallDiagnosis(hostID, agentID, lines) {
+    const tail = (Array.isArray(lines) ? lines : []).slice(-20).join("\n");
+    const prompt = [
+      "Diagnose remote OpenClaw install progress and likely failure cause.",
+      "Host: " + String(hostID || ""),
+      "Agent: " + String(agentID || ""),
+      "Recent install logs:",
+      tail || "(empty)",
+      "Return concise diagnosis and next 3 actions."
+    ].join("\n");
+    const headers = { "Content-Type": "application/json" };
+    if (token)
+      headers["Authorization"] = "Bearer " + token;
+    const response = await fetch("/api/v1/chat/stream", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        target: "local",
+        message: prompt,
+        provider: "webui",
+        sessionId: "",
+        chatId: ""
+      })
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || "diagnosis request failed (" + response.status + ")");
+    }
+    if (!response.body || !response.body.getReader) {
+      throw new Error("diagnosis stream is not supported in this browser");
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder;
+    let buffer = "";
+    let output = "";
+    for (;; ) {
+      const step = await reader.read();
+      if (step.done)
+        break;
+      buffer += decoder.decode(step.value, { stream: true });
+      buffer = parseSSEFrames(buffer, (payload) => {
+        if (String(payload && payload.type ? payload.type : "") === "text-delta") {
+          output += String(payload.delta || "");
+        }
+      });
+    }
+    buffer = parseSSEFrames(buffer, (payload) => {
+      if (String(payload && payload.type ? payload.type : "") === "text-delta") {
+        output += String(payload.delta || "");
+      }
+    });
+    return String(output || "").trim();
+  }
+  function maybeRunServerManageDiagnosis(hostID, agentID) {
+    if (serverManageDiagnosisPending || serverManageDiagnosisText)
+      return;
+    serverManageDiagnosisPending = true;
+    renderServerManageDiagnosis("Analyzing install logs with local BaseAgent...", "running");
+    requestBaseAgentInstallDiagnosis(hostID, agentID, serverManageLiveLogLines).then((text) => {
+      serverManageDiagnosisText = text || "No diagnosis returned.";
+      renderServerManageDiagnosis(serverManageDiagnosisText, "ok");
+    }).catch((err) => {
+      serverManageDiagnosisText = "BaseAgent diagnosis unavailable: " + (err && err.message ? err.message : String(err));
+      renderServerManageDiagnosis(serverManageDiagnosisText, "error");
+    }).finally(() => {
+      serverManageDiagnosisPending = false;
+    });
+  }
   function renderServerManageSessions(entries) {
     const out = $("#server-manage-sessions");
     if (!out)
@@ -2527,11 +2685,165 @@
       return String(path) + " (size=" + String(size) + ", modified=" + String(modifiedAt) + ")";
     }).join("\n");
   }
+  function renderServerManageChatMessages() {
+    const wrap = $("#server-manage-chat-messages");
+    if (!wrap)
+      return;
+    const island = window.CarrierRemoteChatIsland;
+    if (island && typeof island.renderMessages === "function" && island.renderMessages(wrap, serverManageChatMessages)) {
+      return;
+    }
+    wrap.textContent = "";
+    serverManageChatMessages.forEach((message) => {
+      const msg = document.createElement("div");
+      msg.className = "chat-msg";
+      const sender = document.createElement("span");
+      sender.className = "sender";
+      sender.textContent = (message.role === "user" ? "You" : message.role === "assistant" ? "Agent" : "Carrier") + ":";
+      const body = document.createElement("span");
+      body.className = "body";
+      body.textContent = " " + String(message.text || "");
+      msg.appendChild(sender);
+      msg.appendChild(body);
+      wrap.appendChild(msg);
+    });
+    wrap.scrollTop = wrap.scrollHeight;
+  }
+  function appendServerManageChatMessage(role, text) {
+    serverManageChatMessageSeq += 1;
+    const messageID = "server-manage-chat-msg-" + String(serverManageChatMessageSeq);
+    serverManageChatMessages.push({
+      id: messageID,
+      role: String(role || "system"),
+      text: String(text || "")
+    });
+    renderServerManageChatMessages();
+    return messageID;
+  }
+  function appendServerManageChatMessageDelta(messageID, delta) {
+    const id = String(messageID || "");
+    if (!id)
+      return;
+    const index = serverManageChatMessages.findIndex((message) => String(message.id || "") === id);
+    if (index < 0)
+      return;
+    serverManageChatMessages[index].text = String(serverManageChatMessages[index].text || "") + String(delta || "");
+    renderServerManageChatMessages();
+  }
+  function updateServerManageChatStatus(text, type) {
+    const el = $("#server-manage-chat-status");
+    if (!el)
+      return;
+    el.textContent = text || "";
+    el.classList.remove("msg-error", "msg-success", "msg-info");
+    if (type)
+      el.classList.add("msg-" + type);
+  }
+  async function sendServerManageChat(inputText) {
+    const target = validateServerManageInstanceTarget();
+    if (!target.hostID || !target.agentID)
+      return;
+    const message = (inputText || "").trim();
+    if (!message) {
+      updateServerManageChatStatus("message is required.", "error");
+      return;
+    }
+    serverManageChatLastInput = message;
+    appendServerManageChatMessage("user", message);
+    serverManageChatActiveAssistantNode = appendServerManageChatMessage("assistant", "");
+    if (serverManageChatAbortController) {
+      serverManageChatAbortController.abort();
+      serverManageChatAbortController = null;
+    }
+    const controller = new AbortController;
+    serverManageChatAbortController = controller;
+    updateServerManageChatStatus("Streaming response...", "info");
+    try {
+      const headers = { "Content-Type": "application/json" };
+      if (token)
+        headers["Authorization"] = "Bearer " + token;
+      const response = await fetch("/api/v1/chat/stream", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          target: "remote",
+          hostId: target.hostID,
+          agentId: target.agentID,
+          message,
+          sessionId: serverManageChatSessionID || ""
+        }),
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || "remote chat failed (" + response.status + ")");
+      }
+      if (!response.body || !response.body.getReader) {
+        throw new Error("streaming body is not supported in this browser");
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder;
+      let buffer = "";
+      for (;; ) {
+        const step = await reader.read();
+        if (step.done)
+          break;
+        buffer += decoder.decode(step.value, { stream: true });
+        buffer = parseSSEFrames(buffer, (payload) => {
+          const eventType = String(payload && payload.type ? payload.type : "").trim();
+          if (eventType === "text-delta") {
+            if (serverManageChatActiveAssistantNode) {
+              appendServerManageChatMessageDelta(serverManageChatActiveAssistantNode, String(payload.delta || ""));
+            }
+            return;
+          }
+          if (eventType === "session") {
+            serverManageChatSessionID = String(payload.sessionId || "").trim();
+            updateServerManageChatStatus("Session: " + serverManageChatSessionID, "info");
+            return;
+          }
+          if (eventType === "finish") {
+            updateServerManageChatStatus("Stream finished.", "success");
+          }
+        });
+      }
+      buffer = parseSSEFrames(buffer, () => {
+      });
+      updateServerManageChatStatus("Stream finished.", "success");
+    } catch (e) {
+      if (e.name === "AbortError") {
+        updateServerManageChatStatus("Stream cancelled.", "info");
+      } else {
+        updateServerManageChatStatus("Stream failed: " + e.message, "error");
+      }
+    } finally {
+      if (serverManageChatAbortController === controller) {
+        serverManageChatAbortController = null;
+      }
+      serverManageChatActiveAssistantNode = null;
+    }
+  }
+  function resetServerManageChatState() {
+    if (serverManageChatAbortController) {
+      serverManageChatAbortController.abort();
+      serverManageChatAbortController = null;
+    }
+    serverManageChatSessionID = "";
+    serverManageChatLastInput = "";
+    serverManageChatActiveAssistantNode = null;
+    serverManageChatMessages = [];
+    renderServerManageChatMessages();
+    updateServerManageChatStatus("Ready to chat with selected SSG agent.", "info");
+  }
   function showServerManagePanel(hostID) {
     const card = $("#server-manage-card");
     const hostLabel = $("#server-manage-host-label");
     if (!card || !hostLabel)
       return;
+    if (serverManageInstallStreamAbortController) {
+      serverManageInstallStreamAbortController.abort();
+      serverManageInstallStreamAbortController = null;
+    }
     const key = String(hostID || "").trim();
     if (!key) {
       card.classList.add("hidden");
@@ -2546,8 +2858,14 @@
     renderServerManageInstances([]);
     renderServerManageInstanceStatus({}, []);
     renderServerManageLogs("");
+    updateServerManageStreamStatus("", "info");
+    serverManageLiveLogLines = [];
+    serverManageDiagnosisText = "";
+    serverManageDiagnosisPending = false;
+    renderServerManageDiagnosis("", "");
     renderServerManageSessions([]);
     renderServerManageMemory([]);
+    resetServerManageChatState();
     setServerManageOperationMeta(null);
     setMsg("#server-manage-msg", "", "info");
   }
@@ -2572,6 +2890,11 @@
       "server-manage-archive-session",
       "server-manage-delete-session",
       "server-manage-load-memory",
+      "server-manage-chat-input",
+      "server-manage-chat-send",
+      "server-manage-chat-reset-session",
+      "server-manage-chat-cancel",
+      "server-manage-chat-retry",
       "server-manage-agent-id",
       "server-manage-session-id",
       "server-manage-log-tail",
@@ -2846,20 +3169,143 @@
     }
     await runServerManageOperation("instance-status", task);
   }
+  async function streamServerManageInstall(target) {
+    const path = "/api/v1/remote/hosts/" + encodeURIComponent(target.hostID) + "/instances/" + encodeURIComponent(target.agentID) + "/install/stream";
+    const startedAt = performance.now();
+    let requestID = "";
+    let installPayload = null;
+    let streamError = "";
+    let finishReason = "";
+    if (serverManageInstallStreamAbortController) {
+      serverManageInstallStreamAbortController.abort();
+      serverManageInstallStreamAbortController = null;
+    }
+    serverManageLiveLogLines = [];
+    serverManageDiagnosisText = "";
+    serverManageDiagnosisPending = false;
+    renderServerManageLogs("");
+    renderServerManageDiagnosis("", "");
+    updateServerManageStreamStatus("Connecting stream...", "info");
+    const controller = new AbortController;
+    serverManageInstallStreamAbortController = controller;
+    try {
+      const headers = { "Content-Type": "application/json" };
+      if (token)
+        headers["Authorization"] = "Bearer " + token;
+      const response = await fetch(path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({}),
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || "install stream failed (" + response.status + ")");
+      }
+      if (!response.body || !response.body.getReader) {
+        throw new Error("streaming body is not supported in this browser");
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder;
+      let buffer = "";
+      for (;; ) {
+        const step = await reader.read();
+        if (step.done)
+          break;
+        buffer += decoder.decode(step.value, { stream: true });
+        buffer = parseSSEFrames(buffer, (payload) => {
+          const eventType = String(payload && payload.type ? payload.type : "").trim();
+          if (eventType === "start") {
+            requestID = String(payload.requestId || "").trim();
+            updateServerManageStreamStatus("Install stream started.", "info");
+            return;
+          }
+          if (eventType === "log") {
+            const line = String(payload.line || "");
+            const stream = String(payload.stream || "stdout");
+            appendServerManageLiveLogLine(line, stream);
+            if (isInstallAnomalyLine(line)) {
+              updateServerManageStreamStatus("Potential issue detected in install output. Running BaseAgent diagnosis...", "info");
+              maybeRunServerManageDiagnosis(target.hostID, target.agentID);
+            }
+            return;
+          }
+          if (eventType === "result") {
+            installPayload = payload.install || null;
+            const steps = installPayload && Array.isArray(installPayload.steps) ? installPayload.steps : [];
+            renderServerManageInstanceStatus(installPayload || {}, steps);
+            updateServerManageStreamStatus("Install stream returned result.", "info");
+            return;
+          }
+          if (eventType === "error") {
+            streamError = String(payload.message || payload.error || "remote install failed");
+            updateServerManageStreamStatus("Install stream error: " + streamError, "error");
+            return;
+          }
+          if (eventType === "finish") {
+            finishReason = String(payload.finishReason || "").trim();
+            return;
+          }
+        });
+      }
+      buffer = parseSSEFrames(buffer, (payload) => {
+        const eventType = String(payload && payload.type ? payload.type : "").trim();
+        if (eventType === "error") {
+          streamError = String(payload.message || payload.error || "remote install failed");
+        }
+        if (eventType === "finish") {
+          finishReason = String(payload.finishReason || "").trim();
+        }
+      });
+      const success = !streamError && (!finishReason || finishReason === "stop");
+      setServerManageOperationMeta({
+        operation: "instance_install_stream",
+        success,
+        requestId: requestID,
+        durationMs: performance.now() - startedAt,
+        path,
+        error: success ? "" : streamError || "finishReason=" + finishReason
+      });
+      return {
+        install: installPayload,
+        requestId: requestID,
+        error: streamError,
+        finishReason
+      };
+    } catch (e) {
+      const errMsg = e && e.message ? e.message : String(e);
+      setServerManageOperationMeta({
+        operation: "instance_install_stream",
+        success: false,
+        durationMs: performance.now() - startedAt,
+        path,
+        error: errMsg
+      });
+      throw e;
+    } finally {
+      if (serverManageInstallStreamAbortController === controller) {
+        serverManageInstallStreamAbortController = null;
+      }
+    }
+  }
   async function installServerManageInstance() {
     const target = validateServerManageInstanceTarget();
     if (!target.hostID || !target.agentID)
       return;
-    await runServerManageOperation("install", async () => {
-      renderServerManageProgress("Install", target.hostID + ":" + target.agentID);
-      setMsg("#server-manage-msg", "Install in progress for " + target.agentID + "...", "info");
+    await runServerManageOperation("install-stream", async () => {
+      renderServerManageProgress("Install (Live)", target.hostID + ":" + target.agentID);
+      setMsg("#server-manage-msg", "Live install in progress for " + target.agentID + "...", "info");
       try {
-        const path = "/api/v1/remote/hosts/" + encodeURIComponent(target.hostID) + "/instances/" + encodeURIComponent(target.agentID) + "/install";
-        const payload = await serverManageAPI("POST", path, {}, "instance_install");
-        renderServerManageInstanceStatus(payload.install || {}, payload.steps || []);
+        const result = await streamServerManageInstall(target);
+        if (result && result.error) {
+          setMsg("#server-manage-msg", "Install failed: " + result.error, "error");
+          return;
+        }
+        updateServerManageStreamStatus("Install stream finished.", "success");
         setMsg("#server-manage-msg", "Install completed for " + target.agentID + ".", "success");
         await loadServerManageInstances({ silent: true, skipLock: true });
       } catch (e) {
+        updateServerManageStreamStatus("Install stream failed.", "error");
         setMsg("#server-manage-msg", "Install failed: " + e.message, "error");
       }
     });
@@ -3052,9 +3498,16 @@
     const archiveSessionBtn = $("#server-manage-archive-session");
     const deleteSessionBtn = $("#server-manage-delete-session");
     const loadMemoryBtn = $("#server-manage-load-memory");
+    const chatInput = $("#server-manage-chat-input");
+    const chatSendBtn = $("#server-manage-chat-send");
+    const chatResetBtn = $("#server-manage-chat-reset-session");
+    const chatCancelBtn = $("#server-manage-chat-cancel");
+    const chatRetryBtn = $("#server-manage-chat-retry");
     const instancesOut = $("#server-manage-instances");
     const instanceStatusOut = $("#server-manage-instance-status-out");
     const logsOut = $("#server-manage-logs");
+    const streamStatusOut = $("#server-manage-stream-status");
+    const diagnosisOut = $("#server-manage-diagnosis");
     const sessionsOut = $("#server-manage-sessions");
     const memoryOut = $("#server-manage-memory");
     function syncServerEditSelection(hosts) {
@@ -3086,11 +3539,19 @@
           instanceStatusOut.textContent = "";
         if (logsOut)
           logsOut.textContent = "";
+        if (streamStatusOut)
+          streamStatusOut.textContent = "";
+        if (diagnosisOut)
+          diagnosisOut.textContent = "";
+        serverManageLiveLogLines = [];
+        serverManageDiagnosisText = "";
+        serverManageDiagnosisPending = false;
         if (sessionsOut)
           sessionsOut.textContent = "";
         if (memoryOut)
           memoryOut.textContent = "";
         setServerManageOperationMeta(null);
+        resetServerManageChatState();
         setMsg("#server-manage-msg", "", "info");
         return;
       }
@@ -3111,6 +3572,8 @@
     syncServerAuthModeInputs();
     updateServerEditorUI();
     setServerManageControlsDisabled(false);
+    renderServerManageChatMessages();
+    updateServerManageChatStatus("Ready to chat with selected SSG agent.", "info");
     if (loadInstancesBtn)
       loadInstancesBtn.onclick = () => {
         loadServerManageInstances();
@@ -3155,6 +3618,51 @@
       loadMemoryBtn.onclick = () => {
         loadServerManageMemory();
       };
+    if (chatSendBtn) {
+      chatSendBtn.onclick = () => {
+        const text = chatInput && chatInput.value ? chatInput.value.trim() : "";
+        if (!text)
+          return;
+        if (chatInput)
+          chatInput.value = "";
+        sendServerManageChat(text);
+      };
+    }
+    if (chatInput) {
+      chatInput.onkeydown = (e) => {
+        if (e.key !== "Enter")
+          return;
+        const text = chatInput.value ? chatInput.value.trim() : "";
+        if (!text)
+          return;
+        chatInput.value = "";
+        sendServerManageChat(text);
+      };
+    }
+    if (chatResetBtn) {
+      chatResetBtn.onclick = () => {
+        serverManageChatSessionID = "";
+        updateServerManageChatStatus("Session reset. Next message starts a new session.", "info");
+      };
+    }
+    if (chatCancelBtn) {
+      chatCancelBtn.onclick = () => {
+        if (serverManageChatAbortController) {
+          serverManageChatAbortController.abort();
+        } else {
+          updateServerManageChatStatus("No active stream.", "info");
+        }
+      };
+    }
+    if (chatRetryBtn) {
+      chatRetryBtn.onclick = () => {
+        if (!serverManageChatLastInput) {
+          updateServerManageChatStatus("No previous message to retry.", "info");
+          return;
+        }
+        sendServerManageChat(serverManageChatLastInput);
+      };
+    }
     refreshBtn.onclick = async () => {
       try {
         const aliases = await fetchSSHConfigHostAliases();

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -336,13 +336,29 @@
         <div class="btn-row">
           <button id="server-manage-load-instances" class="btn-sm btn-secondary">Load Instances</button>
           <button id="server-manage-instance-status" class="btn-sm btn-secondary">Instance Status</button>
-          <button id="server-manage-install-instance" class="btn-sm">Install</button>
+          <button id="server-manage-install-instance" class="btn-sm">Install (Live)</button>
           <button id="server-manage-repair-instance" class="btn-sm btn-secondary">Repair</button>
           <button id="server-manage-load-logs" class="btn-sm btn-secondary">Load Logs</button>
         </div>
         <pre id="server-manage-instances" class="code-block text-dim" style="margin-top:8px; min-height:72px"></pre>
         <div id="server-manage-instance-status-out" class="manage-output" style="margin-top:8px; min-height:72px"></div>
         <div id="server-manage-logs" class="manage-output" style="margin-top:8px; min-height:72px"></div>
+        <p id="server-manage-stream-status" class="text-dim"></p>
+        <div id="server-manage-diagnosis" class="manage-output" style="margin-top:8px"></div>
+        <div class="card" style="margin-top:10px">
+          <h4>SSG Agent Chat</h4>
+          <div id="server-manage-chat-messages" class="chat-messages manage-chat-messages"></div>
+          <div class="chat-input-row">
+            <input id="server-manage-chat-input" type="text" placeholder="Message selected remote agent…" autocomplete="off">
+            <button id="server-manage-chat-send" class="btn-sm">Send</button>
+          </div>
+          <div class="btn-row" style="margin-top:8px">
+            <button id="server-manage-chat-reset-session" class="btn-sm btn-secondary">New Session</button>
+            <button id="server-manage-chat-cancel" class="btn-sm btn-secondary">Cancel Stream</button>
+            <button id="server-manage-chat-retry" class="btn-sm btn-secondary">Retry Last</button>
+          </div>
+          <p id="server-manage-chat-status" class="text-dim"></p>
+        </div>
         <div class="btn-row">
           <button id="server-manage-load-config" class="btn-sm btn-secondary">Load Config</button>
           <button id="server-manage-apply-config" class="btn-sm">Apply Config Patch</button>

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -883,6 +883,13 @@ button:disabled,
   line-height: 1.4;
 }
 
+.manage-chat-messages {
+  min-height: 180px;
+  max-height: 300px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
 main {
   display: grid;
   gap: 16px;


### PR DESCRIPTION
## Summary
- add remote install streaming endpoint at `/api/v1/remote/hosts/{hostId}/instances/{agentId}/install/stream`
- stream SSH stdout/stderr from remote install and expose SSE `start/log/result/error/finish` events
- add Server Runtime Data live install UI with real-time logs, stream status, and BaseAgent anomaly diagnosis prompt
- add SSG agent chat panel in Server Runtime Data for remote instance conversations (session reset/cancel/retry)
- add gateway tests for remote install stream SSE and keep static WebUI assets rebuilt

## Testing
- `go test ./...` (workdir: `gateway`)
- `./scripts/build-webui.sh`
