### PR TITLE
docs: add clarifying comment to removeResetTarget two-step pattern

### DIFF
--- a/cmd/carrier/main.go
+++ b/cmd/carrier/main.go
@@ -1171,6 +1171,10 @@ func normalizeResetTarget(path string) (string, bool) {
 	return cleaned, true
 }
 
+// removeResetTarget removes the file or directory at path. It returns (false, nil) if the
+// target does not exist. The explicit os.Lstat check before os.RemoveAll is intentional:
+// os.RemoveAll silently succeeds on non-existent paths, so the two-step pattern lets us
+// distinguish "nothing to remove" (false) from "removed successfully" (true).
 func removeResetTarget(path string) (bool, error) {
 	if _, err := os.Lstat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
Adds a brief comment explaining why `removeResetTarget` uses an explicit `os.Lstat` check before `os.RemoveAll`: to distinguish "nothing to remove" (returns false) from "removed successfully" (returns true), since `os.RemoveAll` silently succeeds on non-existent paths.

Closes #1439