### PR TITLE
Fix PR coverage comment resilience and marker update behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,14 @@ jobs:
   coverage-comment:
     name: Coverage Comment
     # Reuse coverage artifacts from daemon-tests instead of re-running tests (#1170).
-    needs: daemon-tests
-    if: github.event_name == 'pull_request'
+    needs:
+      - classify-scope
+      - daemon-tests
+    if: github.event_name == 'pull_request' && needs.classify-scope.outputs.ci_only != 'true' && always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -237,9 +240,17 @@ jobs:
 
       - name: Download daemon coverage artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        continue-on-error: true
         with:
           name: daemon-coverage
           path: daemon
+
+      - name: Collect daemon coverage when artifact is unavailable
+        if: hashFiles('daemon/coverage.out') == ''
+        run: |
+          set -euo pipefail
+          cd daemon
+          go test ./... -coverprofile=coverage.out
 
       - name: Collect head branch coverage
         run: |


### PR DESCRIPTION
## What changed
- Hardened Coverage Comment workflow to remain executable for pull requests when daemon artifact is missing.
- Added fallback to regenerate daemon coverage in-place.
- Kept existing module/full-product coverage calculations and marker-based in-place comment updates.
- Added explicit issues write permission for issue-comment posting robustness.

## Why
Prevent PR coverage comments from disappearing due to upstream CI job skip/failure artifacts.

## Verification
- Workflow YAML diff is minimal and focused on coverage-comment job behavior.
- Existing coverage content/format remains the same with marker `<!-- carrier-pr-coverage-report -->`.
