### PR TITLE
feat(gateway): add upstream schema watch and version-aware managed renderers

### DIFF
--- a/.github/workflows/upstream-schema-watch.yml
+++ b/.github/workflows/upstream-schema-watch.yml
@@ -1,0 +1,24 @@
+name: Upstream Schema Watch
+
+on:
+  schedule:
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch-upstream-schema:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Run upstream schema watcher
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/ci/upstream-schema-watch.cjs --mode create-issues --lock compat/upstreams.lock.json

--- a/compat/upstreams.lock.json
+++ b/compat/upstreams.lock.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-02-27T00:00:00Z",
+  "agents": {
+    "openclaw": {
+      "repository": "openclaw/openclaw",
+      "recommended_version": "2026.2.26",
+      "supported_renderers": [
+        {
+          "id": "openclaw.json.v1",
+          "version_range": ">=0.0.0",
+          "config_format": "json",
+          "config_path": "~/.openclaw/config.json"
+        }
+      ],
+      "tracked_files": [
+        {
+          "path": "docs/gateway/configuration-reference.md",
+          "sha": "9bbf0328fc9c4470a2f2fb5d6ee02c94711dca86"
+        },
+        {
+          "path": "src/channels/plugins/config-schema.ts",
+          "sha": "75074ae569d9a895a7a2bf93d2c29058a7417caf"
+        },
+        {
+          "path": "src/config/config.ts",
+          "sha": "df667d498b12e045fc706893af1f7356f7de493d"
+        },
+        {
+          "path": "src/gateway/protocol/schema/config.ts",
+          "sha": "150cd6b4ad189d7cf74671e0ed2a420af976b0f6"
+        }
+      ],
+      "expected_fingerprint": "sha256:c6abd8d448495b1d5976a08bf3677a3f91c82f260d1f792c19e69b8865c23601"
+    },
+    "picoclaw": {
+      "repository": "sipeed/picoclaw",
+      "recommended_version": "0.1.2",
+      "supported_renderers": [
+        {
+          "id": "picoclaw.json.v1",
+          "version_range": ">=0.1.0 <1.0.0",
+          "config_format": "json",
+          "config_path": "~/.picoclaw/config.json"
+        }
+      ],
+      "tracked_files": [
+        {
+          "path": "config/config.example.json",
+          "sha": "9575039f8787754be78d39051ffafb85d904d295"
+        },
+        {
+          "path": "pkg/config/config.go",
+          "sha": "ca5803c35b4cc5cd38cc51158ab04cf1c138d2f4"
+        }
+      ],
+      "expected_fingerprint": "sha256:93c8d9ef27c45a44fbffeaedb26aa6032f0b2b4bc18c5a95f4020d624b4653da"
+    },
+    "zeroclaw": {
+      "repository": "zeroclaw-labs/zeroclaw",
+      "recommended_version": "0.1.7",
+      "supported_renderers": [
+        {
+          "id": "zeroclaw.toml.v1",
+          "version_range": ">=0.1.0 <1.0.0",
+          "config_format": "toml",
+          "config_path": "~/.zeroclaw/config.toml"
+        }
+      ],
+      "tracked_files": [
+        {
+          "path": "dev/config.template.toml",
+          "sha": "eae418c1a379fe83456b49963327d695e4774dfa"
+        },
+        {
+          "path": "docs/config-reference.md",
+          "sha": "4fa30452c6ab6fe0ed8dc7be62bc38e4161b32dc"
+        },
+        {
+          "path": "src/config/schema.rs",
+          "sha": "669396b6452dcb26f8dd52b3a0c96e786582cc22"
+        }
+      ],
+      "expected_fingerprint": "sha256:27f0c017721f28eeacceaaa8604b4d227e87e2d2c3755b1ae24c5e3105094a1f"
+    }
+  }
+}

--- a/gateway/managed_onboard.go
+++ b/gateway/managed_onboard.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -12,6 +13,7 @@ import (
 type managedAgentConfig struct {
 	ID             string
 	ConfigDir      string
+	ConfigFile     string
 	RequiredEnvKey string
 }
 
@@ -19,21 +21,28 @@ type managedOnboardResult struct {
 	WorkspacePath string
 	ConfigPath    string
 	RecordPath    string
+	RendererID    string
+	ConfigFormat  string
+	AgentVersion  string
+	VersionSource string
 }
 
 var managedAgents = map[string]managedAgentConfig{
 	"picoclaw": {
-		ID:        "picoclaw",
-		ConfigDir: ".picoclaw",
+		ID:         "picoclaw",
+		ConfigDir:  ".picoclaw",
+		ConfigFile: "config.json",
 	},
 	"openclaw": {
 		ID:             "openclaw",
 		ConfigDir:      ".openclaw",
+		ConfigFile:     "config.json",
 		RequiredEnvKey: "OPENAI_API_KEY",
 	},
 	"zeroclaw": {
-		ID:        "zeroclaw",
-		ConfigDir: ".zeroclaw",
+		ID:         "zeroclaw",
+		ConfigDir:  ".zeroclaw",
+		ConfigFile: "config.toml",
 	},
 }
 
@@ -183,6 +192,12 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 	if err != nil {
 		return nil, fmt.Errorf("resolve home dir: %w", err)
 	}
+
+	renderer, err := resolveManagedRenderer(cfg.ID)
+	if err != nil {
+		return nil, fmt.Errorf("select %s config renderer: %w", cfg.ID, err)
+	}
+
 	instanceID := strings.TrimSpace(sess.InstanceID)
 	if instanceID == "" {
 		instanceID = cfg.ID
@@ -191,7 +206,7 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 	if workspacePath == "" {
 		workspacePath = filepath.Join(home, cfg.ConfigDir, "instances", instanceID, "workspace")
 	}
-	configPath := filepath.Join(home, cfg.ConfigDir, "config.json")
+	configPath := resolveManagedConfigPath(home, cfg, renderer)
 	recordPath := filepath.Join(home, ".carrier", "agents", instanceID+".json")
 
 	if err := os.MkdirAll(workspacePath, 0o700); err != nil {
@@ -228,25 +243,12 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 		providerKey = strings.TrimSpace(vendor)
 	}
 	providerKey = mapCarrierProviderToManagedProvider(providerKey)
-	modelItem := map[string]interface{}{
-		"model_name": modelName,
-		"model":      modelID,
-	}
-	providerItem := map[string]interface{}{
-		"credential_ref": provider.ID,
-	}
-	token := pickProviderToken(provider, sess.EnvVars)
-	if strings.EqualFold(provider.ID, "openai-codex") {
-		modelItem["auth_method"] = "oauth"
-		providerItem["auth_method"] = "oauth"
-		if strings.EqualFold(cfg.ID, "picoclaw") {
-			accountID := extractOpenAIAccountID(token)
-			if err := savePicoclawAuthCredential(home, "openai", token, accountID); err != nil {
-				return nil, fmt.Errorf("write picoclaw auth store: %w", err)
-			}
+	providerToken := pickProviderToken(provider, sess.EnvVars)
+	if strings.EqualFold(provider.ID, "openai-codex") && strings.EqualFold(cfg.ID, "picoclaw") {
+		accountID := extractOpenAIAccountID(providerToken)
+		if err := savePicoclawAuthCredential(home, "openai", providerToken, accountID); err != nil {
+			return nil, fmt.Errorf("write picoclaw auth store: %w", err)
 		}
-	} else if token != "" {
-		providerItem["api_key"] = token
 	}
 
 	chatID := actorChatID(actor)
@@ -254,6 +256,126 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 	if chatID != "" {
 		allowFrom = append(allowFrom, chatID)
 	}
+
+	configRaw, err := renderManagedConfigBytes(
+		renderer,
+		cfg,
+		sess.SelectedChannel,
+		channelToken,
+		channelSetupPending,
+		allowFrom,
+		provider,
+		providerKey,
+		providerToken,
+		modelID,
+		modelName,
+		workspacePath,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("render %s config (%s): %w", cfg.ID, renderer.RendererID, err)
+	}
+	if err := os.WriteFile(configPath, configRaw, 0o600); err != nil {
+		return nil, fmt.Errorf("write %s config: %w", cfg.ID, err)
+	}
+
+	record := map[string]interface{}{
+		"instance_id":           instanceID,
+		"agent_id":              cfg.ID,
+		"workspace_path":        workspacePath,
+		"config_path":           configPath,
+		"channel":               sess.SelectedChannel,
+		"channel_setup_pending": channelSetupPending,
+		"provider":              provider.ID,
+		"renderer_id":           renderer.RendererID,
+		"config_format":         renderer.ConfigFormat,
+		"agent_version":         renderer.AgentVersion,
+		"version_source":        renderer.VersionSource,
+		"compat_repository":     renderer.Repository,
+		"compat_fingerprint":    renderer.ExpectedFingerprint,
+		"compat_version_range":  renderer.VersionRange,
+		"updated_at":            time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	recordRaw, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal carrier record: %w", err)
+	}
+	if err := os.WriteFile(recordPath, append(recordRaw, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("write carrier record: %w", err)
+	}
+
+	return &managedOnboardResult{
+		WorkspacePath: workspacePath,
+		ConfigPath:    configPath,
+		RecordPath:    recordPath,
+		RendererID:    renderer.RendererID,
+		ConfigFormat:  renderer.ConfigFormat,
+		AgentVersion:  renderer.AgentVersion,
+		VersionSource: renderer.VersionSource,
+	}, nil
+}
+
+func resolveManagedConfigPath(home string, cfg managedAgentConfig, renderer managedRendererSelection) string {
+	configPath := strings.TrimSpace(renderer.ConfigPath)
+	if configPath == "" {
+		configPath = filepath.Join(home, cfg.ConfigDir, cfg.ConfigFile)
+	}
+	if strings.HasPrefix(configPath, "~/") {
+		return filepath.Join(home, strings.TrimPrefix(configPath, "~/"))
+	}
+	if filepath.IsAbs(configPath) {
+		return filepath.Clean(configPath)
+	}
+	return filepath.Join(home, cfg.ConfigDir, configPath)
+}
+
+func renderManagedConfigBytes(
+	renderer managedRendererSelection,
+	cfg managedAgentConfig,
+	channelID, channelToken string,
+	channelSetupPending bool,
+	allowFrom []string,
+	provider *LLMProvider,
+	providerKey, providerToken, modelID, modelName, workspacePath string,
+) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(renderer.ConfigFormat)) {
+	case "toml":
+		if strings.EqualFold(cfg.ID, "zeroclaw") {
+			return renderZeroClawConfigTOML(channelID, channelToken, channelSetupPending, allowFrom, providerKey, providerToken, modelID), nil
+		}
+		return nil, fmt.Errorf("toml renderer is not supported for %s", cfg.ID)
+	case "json":
+		payload := buildManagedJSONConfigPayload(channelID, channelToken, channelSetupPending, allowFrom, provider, providerKey, providerToken, modelID, modelName, workspacePath)
+		raw, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return append(raw, '\n'), nil
+	default:
+		return nil, fmt.Errorf("unsupported config format %q", renderer.ConfigFormat)
+	}
+}
+
+func buildManagedJSONConfigPayload(
+	channelID, channelToken string,
+	channelSetupPending bool,
+	allowFrom []string,
+	provider *LLMProvider,
+	providerKey, providerToken, modelID, modelName, workspacePath string,
+) map[string]interface{} {
+	modelItem := map[string]interface{}{
+		"model_name": modelName,
+		"model":      modelID,
+	}
+	providerItem := map[string]interface{}{
+		"credential_ref": provider.ID,
+	}
+	if strings.EqualFold(provider.ID, "openai-codex") {
+		modelItem["auth_method"] = "oauth"
+		providerItem["auth_method"] = "oauth"
+	} else if providerToken != "" {
+		providerItem["api_key"] = providerToken
+	}
+
 	channelConfig := map[string]interface{}{
 		"enabled":    true,
 		"allow_from": allowFrom,
@@ -265,10 +387,10 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 		channelConfig["token"] = channelToken
 	}
 	channels := map[string]interface{}{
-		sess.SelectedChannel: channelConfig,
+		channelID: channelConfig,
 	}
 
-	payload := map[string]interface{}{
+	return map[string]interface{}{
 		"agents": map[string]interface{}{
 			"defaults": map[string]interface{}{
 				"workspace":             workspacePath,
@@ -286,38 +408,66 @@ func prepareManagedOnboard(agentID string, sess *OnboardSession, actor string) (
 		},
 		"channels": channels,
 	}
+}
 
-	raw, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal %s config: %w", cfg.ID, err)
+func renderZeroClawConfigTOML(
+	channelID, channelToken string,
+	channelSetupPending bool,
+	allowFrom []string,
+	providerKey, providerToken, modelID string,
+) []byte {
+	if strings.TrimSpace(channelID) == "" {
+		channelID = "telegram"
 	}
-	if err := os.WriteFile(configPath, append(raw, '\n'), 0o600); err != nil {
-		return nil, fmt.Errorf("write %s config: %w", cfg.ID, err)
+	if strings.TrimSpace(providerKey) == "" {
+		providerKey = "openrouter"
 	}
-
-	record := map[string]interface{}{
-		"instance_id":           instanceID,
-		"agent_id":              cfg.ID,
-		"workspace_path":        workspacePath,
-		"config_path":           configPath,
-		"channel":               sess.SelectedChannel,
-		"channel_setup_pending": channelSetupPending,
-		"provider":              provider.ID,
-		"updated_at":            time.Now().UTC().Format(time.RFC3339Nano),
+	if strings.TrimSpace(modelID) == "" {
+		modelID = "anthropic/claude-sonnet-4-6"
 	}
-	recordRaw, err := json.MarshalIndent(record, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal carrier record: %w", err)
-	}
-	if err := os.WriteFile(recordPath, append(recordRaw, '\n'), 0o600); err != nil {
-		return nil, fmt.Errorf("write carrier record: %w", err)
+	if strings.TrimSpace(providerToken) == "" {
+		providerToken = ""
 	}
 
-	return &managedOnboardResult{
-		WorkspacePath: workspacePath,
-		ConfigPath:    configPath,
-		RecordPath:    recordPath,
-	}, nil
+	allowedUsers := "[]"
+	if len(allowFrom) > 0 {
+		quoted := make([]string, 0, len(allowFrom))
+		for _, raw := range allowFrom {
+			id := strings.TrimSpace(raw)
+			if id == "" {
+				continue
+			}
+			quoted = append(quoted, strconv.Quote(id))
+		}
+		if len(quoted) > 0 {
+			allowedUsers = "[" + strings.Join(quoted, ", ") + "]"
+		}
+	}
+
+	lines := []string{
+		"# Generated by Carrier managed onboarding",
+		"# Edit manually if you need advanced ZeroClaw settings.",
+		"",
+		fmt.Sprintf("api_key = %s", strconv.Quote(providerToken)),
+		fmt.Sprintf("default_provider = %s", strconv.Quote(providerKey)),
+		fmt.Sprintf("default_model = %s", strconv.Quote(modelID)),
+		"default_temperature = 0.7",
+		"",
+		"[agent]",
+		"max_tool_iterations = 20",
+		"",
+		fmt.Sprintf("[channels_config.%s]", channelID),
+		fmt.Sprintf("bot_token = %s", strconv.Quote(channelToken)),
+		fmt.Sprintf("allowed_users = %s", allowedUsers),
+		"mention_only = false",
+	}
+	if channelSetupPending {
+		lines = append(lines,
+			"",
+			"# channel setup is pending; configure channel token in Web UI before enabling channel start",
+		)
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
 }
 
 func mapCarrierProviderToManagedProvider(providerID string) string {

--- a/gateway/managed_upstream_compat.go
+++ b/gateway/managed_upstream_compat.go
@@ -1,0 +1,395 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type upstreamCompatLock struct {
+	SchemaVersion int                            `json:"schema_version"`
+	UpdatedAt     string                         `json:"updated_at,omitempty"`
+	Agents        map[string]upstreamAgentCompat `json:"agents"`
+}
+
+type upstreamAgentCompat struct {
+	Repository          string                 `json:"repository"`
+	RecommendedVersion  string                 `json:"recommended_version"`
+	SupportedRenderers  []upstreamRendererSpec `json:"supported_renderers"`
+	TrackedFiles        []upstreamTrackedFile  `json:"tracked_files,omitempty"`
+	ExpectedFingerprint string                 `json:"expected_fingerprint,omitempty"`
+}
+
+type upstreamRendererSpec struct {
+	ID           string `json:"id"`
+	VersionRange string `json:"version_range"`
+	ConfigFormat string `json:"config_format"`
+	ConfigPath   string `json:"config_path"`
+}
+
+type upstreamTrackedFile struct {
+	Path string `json:"path"`
+	SHA  string `json:"sha"`
+}
+
+type managedRendererSelection struct {
+	AgentID             string
+	RendererID          string
+	ConfigFormat        string
+	ConfigPath          string
+	AgentVersion        string
+	VersionSource       string
+	Repository          string
+	ExpectedFingerprint string
+	VersionRange        string
+}
+
+type semVer struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+var (
+	semVerTextPattern  = regexp.MustCompile(`(?i)\bv?(\d+)\.(\d+)\.(\d+)\b`)
+	semVerExactPattern = regexp.MustCompile(`(?i)^v?(\d+)\.(\d+)\.(\d+)$`)
+	rangeTokenPattern  = regexp.MustCompile(`^(>=|<=|>|<|=)?v?(\d+\.\d+\.\d+)$`)
+
+	managedCompatLockOnce sync.Once
+	managedCompatLock     upstreamCompatLock
+)
+
+func defaultUpstreamCompatLock() upstreamCompatLock {
+	return upstreamCompatLock{
+		SchemaVersion: 1,
+		Agents: map[string]upstreamAgentCompat{
+			"openclaw": {
+				Repository:         "openclaw/openclaw",
+				RecommendedVersion: "1.0.0",
+				SupportedRenderers: []upstreamRendererSpec{
+					{ID: "openclaw.json.v1", VersionRange: ">=0.0.0", ConfigFormat: "json", ConfigPath: "~/.openclaw/config.json"},
+				},
+			},
+			"picoclaw": {
+				Repository:         "sipeed/picoclaw",
+				RecommendedVersion: "0.1.2",
+				SupportedRenderers: []upstreamRendererSpec{
+					{ID: "picoclaw.json.v1", VersionRange: ">=0.1.0 <1.0.0", ConfigFormat: "json", ConfigPath: "~/.picoclaw/config.json"},
+				},
+			},
+			"zeroclaw": {
+				Repository:         "zeroclaw-labs/zeroclaw",
+				RecommendedVersion: "0.1.7",
+				SupportedRenderers: []upstreamRendererSpec{
+					{ID: "zeroclaw.toml.v1", VersionRange: ">=0.1.0 <1.0.0", ConfigFormat: "toml", ConfigPath: "~/.zeroclaw/config.toml"},
+				},
+			},
+		},
+	}
+}
+
+func loadManagedCompatLock() upstreamCompatLock {
+	managedCompatLockOnce.Do(func() {
+		lock := defaultUpstreamCompatLock()
+		if fromDisk, err := readUpstreamCompatLockFromDisk(); err == nil && fromDisk != nil {
+			if normalized, ok := normalizeUpstreamCompatLock(*fromDisk); ok {
+				for agentID, cfg := range normalized.Agents {
+					lock.Agents[agentID] = cfg
+				}
+				lock.SchemaVersion = normalized.SchemaVersion
+				if strings.TrimSpace(normalized.UpdatedAt) != "" {
+					lock.UpdatedAt = strings.TrimSpace(normalized.UpdatedAt)
+				}
+				managedCompatLock = lock
+				return
+			}
+		}
+		managedCompatLock = lock
+	})
+	return managedCompatLock
+}
+
+func readUpstreamCompatLockFromDisk() (*upstreamCompatLock, error) {
+	for _, candidate := range upstreamCompatLockCandidates() {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		raw, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		var lock upstreamCompatLock
+		if err := json.Unmarshal(raw, &lock); err != nil {
+			continue
+		}
+		return &lock, nil
+	}
+	return nil, fmt.Errorf("compat lock not found")
+}
+
+func normalizeUpstreamCompatLock(lock upstreamCompatLock) (upstreamCompatLock, bool) {
+	if lock.SchemaVersion <= 0 {
+		lock.SchemaVersion = 1
+	}
+	if lock.Agents == nil {
+		return upstreamCompatLock{}, false
+	}
+	normalized := upstreamCompatLock{
+		SchemaVersion: lock.SchemaVersion,
+		UpdatedAt:     strings.TrimSpace(lock.UpdatedAt),
+		Agents:        map[string]upstreamAgentCompat{},
+	}
+	for rawAgentID, cfg := range lock.Agents {
+		agentID := strings.ToLower(strings.TrimSpace(rawAgentID))
+		if agentID == "" {
+			continue
+		}
+		if strings.TrimSpace(cfg.Repository) == "" || len(cfg.SupportedRenderers) == 0 {
+			continue
+		}
+		for i := range cfg.SupportedRenderers {
+			r := &cfg.SupportedRenderers[i]
+			r.ID = strings.TrimSpace(r.ID)
+			r.VersionRange = strings.TrimSpace(r.VersionRange)
+			r.ConfigFormat = strings.ToLower(strings.TrimSpace(r.ConfigFormat))
+			r.ConfigPath = strings.TrimSpace(r.ConfigPath)
+			if r.ID == "" || r.VersionRange == "" || r.ConfigFormat == "" {
+				return upstreamCompatLock{}, false
+			}
+		}
+		normalized.Agents[agentID] = cfg
+	}
+	if len(normalized.Agents) == 0 {
+		return upstreamCompatLock{}, false
+	}
+	return normalized, true
+}
+
+func upstreamCompatLockCandidates() []string {
+	candidates := []string{}
+	if custom := strings.TrimSpace(os.Getenv("CARRIER_UPSTREAM_LOCK_PATH")); custom != "" {
+		candidates = append(candidates, custom)
+	}
+	candidates = append(candidates,
+		filepath.Join("compat", "upstreams.lock.json"),
+		filepath.Join("..", "compat", "upstreams.lock.json"),
+	)
+	if exe, err := os.Executable(); err == nil {
+		exeDir := filepath.Dir(exe)
+		candidates = append(candidates,
+			filepath.Join(exeDir, "compat", "upstreams.lock.json"),
+			filepath.Join(exeDir, "..", "compat", "upstreams.lock.json"),
+		)
+	}
+	return candidates
+}
+
+func resolveManagedRenderer(agentID string) (managedRendererSelection, error) {
+	trimmedAgentID := strings.ToLower(strings.TrimSpace(agentID))
+	lock := loadManagedCompatLock()
+	compat, ok := lock.Agents[trimmedAgentID]
+	if !ok {
+		return managedRendererSelection{}, fmt.Errorf("no compatibility policy found for %s", trimmedAgentID)
+	}
+	version, source, err := resolveManagedAgentVersion(trimmedAgentID, compat.RecommendedVersion)
+	if err != nil {
+		return managedRendererSelection{}, err
+	}
+
+	for _, renderer := range compat.SupportedRenderers {
+		match, rangeErr := semverSatisfiesRange(version, renderer.VersionRange)
+		if rangeErr != nil {
+			continue
+		}
+		if !match {
+			continue
+		}
+		return managedRendererSelection{
+			AgentID:             trimmedAgentID,
+			RendererID:          renderer.ID,
+			ConfigFormat:        renderer.ConfigFormat,
+			ConfigPath:          renderer.ConfigPath,
+			AgentVersion:        version,
+			VersionSource:       source,
+			Repository:          compat.Repository,
+			ExpectedFingerprint: compat.ExpectedFingerprint,
+			VersionRange:        renderer.VersionRange,
+		}, nil
+	}
+
+	ranges := make([]string, 0, len(compat.SupportedRenderers))
+	for _, renderer := range compat.SupportedRenderers {
+		ranges = append(ranges, renderer.VersionRange)
+	}
+	return managedRendererSelection{}, fmt.Errorf(
+		"unsupported %s version %s (%s), supported ranges: %s",
+		trimmedAgentID,
+		version,
+		source,
+		strings.Join(ranges, ", "),
+	)
+}
+
+func resolveManagedAgentVersion(agentID, recommended string) (string, string, error) {
+	envKey := fmt.Sprintf("CARRIER_MANAGED_%s_VERSION", strings.ToUpper(strings.ReplaceAll(agentID, "-", "_")))
+	if override := strings.TrimSpace(os.Getenv(envKey)); override != "" {
+		if parsed, ok := parseSemVerFromText(override); ok {
+			return formatSemVer(parsed), "env:" + envKey, nil
+		}
+		return "", "", fmt.Errorf("invalid version override %s=%q", envKey, override)
+	}
+
+	if detected, ok := detectManagedAgentBinaryVersion(agentID); ok {
+		return detected, "binary:" + agentID, nil
+	}
+
+	if parsed, ok := parseSemVerFromText(recommended); ok {
+		return formatSemVer(parsed), "lock:recommended_version", nil
+	}
+	return "", "", fmt.Errorf("unable to resolve version for %s", agentID)
+}
+
+func detectManagedAgentBinaryVersion(agentID string) (string, bool) {
+	binaryPath, err := exec.LookPath(agentID)
+	if err != nil {
+		return "", false
+	}
+	if version, ok := detectVersionWithCommand(binaryPath, "--version"); ok {
+		return version, true
+	}
+	if version, ok := detectVersionWithCommand(binaryPath, "version"); ok {
+		return version, true
+	}
+	return "", false
+}
+
+func detectVersionWithCommand(binaryPath string, arg string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, arg)
+	out, err := cmd.CombinedOutput()
+	if len(out) == 0 && err != nil {
+		return "", false
+	}
+	if parsed, ok := parseSemVerFromText(string(out)); ok {
+		return formatSemVer(parsed), true
+	}
+	return "", false
+}
+
+func parseSemVerFromText(raw string) (semVer, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return semVer{}, false
+	}
+	if exact := semVerExactPattern.FindStringSubmatch(trimmed); len(exact) == 4 {
+		return parseSemVerParts(exact[1], exact[2], exact[3])
+	}
+	matches := semVerTextPattern.FindStringSubmatch(trimmed)
+	if len(matches) != 4 {
+		return semVer{}, false
+	}
+	return parseSemVerParts(matches[1], matches[2], matches[3])
+}
+
+func parseSemVerParts(major, minor, patch string) (semVer, bool) {
+	maj, err := strconv.Atoi(major)
+	if err != nil {
+		return semVer{}, false
+	}
+	min, err := strconv.Atoi(minor)
+	if err != nil {
+		return semVer{}, false
+	}
+	pat, err := strconv.Atoi(patch)
+	if err != nil {
+		return semVer{}, false
+	}
+	return semVer{Major: maj, Minor: min, Patch: pat}, true
+}
+
+func formatSemVer(v semVer) string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+func compareSemVer(a, b semVer) int {
+	if a.Major != b.Major {
+		if a.Major < b.Major {
+			return -1
+		}
+		return 1
+	}
+	if a.Minor != b.Minor {
+		if a.Minor < b.Minor {
+			return -1
+		}
+		return 1
+	}
+	if a.Patch != b.Patch {
+		if a.Patch < b.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func semverSatisfiesRange(version, rangeExpr string) (bool, error) {
+	v, ok := parseSemVerFromText(version)
+	if !ok {
+		return false, fmt.Errorf("invalid version %q", version)
+	}
+	raw := strings.TrimSpace(strings.ReplaceAll(rangeExpr, ",", " "))
+	if raw == "" {
+		return true, nil
+	}
+	for _, token := range strings.Fields(raw) {
+		matches := rangeTokenPattern.FindStringSubmatch(strings.TrimSpace(token))
+		if len(matches) != 3 {
+			return false, fmt.Errorf("invalid range token %q", token)
+		}
+		op := matches[1]
+		if op == "" {
+			op = "="
+		}
+		required, ok := parseSemVerFromText(matches[2])
+		if !ok {
+			return false, fmt.Errorf("invalid range version %q", matches[2])
+		}
+		cmp := compareSemVer(v, required)
+		if !evaluateSemVerConstraint(cmp, op) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func evaluateSemVerConstraint(cmp int, op string) bool {
+	switch op {
+	case "=":
+		return cmp == 0
+	case ">":
+		return cmp > 0
+	case ">=":
+		return cmp >= 0
+	case "<":
+		return cmp < 0
+	case "<=":
+		return cmp <= 0
+	default:
+		return false
+	}
+}
+
+func resetManagedCompatLockForTests() {
+	managedCompatLockOnce = sync.Once{}
+	managedCompatLock = upstreamCompatLock{}
+}

--- a/gateway/managed_upstream_compat_test.go
+++ b/gateway/managed_upstream_compat_test.go
@@ -1,0 +1,60 @@
+package gateway
+
+import "testing"
+
+func TestSemverSatisfiesRange(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		rangeEx string
+		want    bool
+	}{
+		{name: "within", version: "0.1.7", rangeEx: ">=0.1.0 <1.0.0", want: true},
+		{name: "lower-bound", version: "0.1.0", rangeEx: ">=0.1.0 <1.0.0", want: true},
+		{name: "too-low", version: "0.0.9", rangeEx: ">=0.1.0 <1.0.0", want: false},
+		{name: "too-high", version: "1.0.0", rangeEx: ">=0.1.0 <1.0.0", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := semverSatisfiesRange(tc.version, tc.rangeEx)
+			if err != nil {
+				t.Fatalf("semverSatisfiesRange(%q,%q) error: %v", tc.version, tc.rangeEx, err)
+			}
+			if got != tc.want {
+				t.Fatalf("semverSatisfiesRange(%q,%q)=%v, want %v", tc.version, tc.rangeEx, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveManagedRenderer_UsesEnvOverride(t *testing.T) {
+	resetManagedCompatLockForTests()
+	t.Cleanup(resetManagedCompatLockForTests)
+	t.Setenv("CARRIER_MANAGED_ZEROCLAW_VERSION", "0.1.7")
+
+	selection, err := resolveManagedRenderer("zeroclaw")
+	if err != nil {
+		t.Fatalf("resolveManagedRenderer: %v", err)
+	}
+	if selection.RendererID != "zeroclaw.toml.v1" {
+		t.Fatalf("renderer=%q, want zeroclaw.toml.v1", selection.RendererID)
+	}
+	if selection.ConfigFormat != "toml" {
+		t.Fatalf("format=%q, want toml", selection.ConfigFormat)
+	}
+	if selection.AgentVersion != "0.1.7" {
+		t.Fatalf("version=%q, want 0.1.7", selection.AgentVersion)
+	}
+}
+
+func TestResolveManagedRenderer_InvalidEnvOverride(t *testing.T) {
+	resetManagedCompatLockForTests()
+	t.Cleanup(resetManagedCompatLockForTests)
+	t.Setenv("CARRIER_MANAGED_ZEROCLAW_VERSION", "invalid-version")
+
+	if _, err := resolveManagedRenderer("zeroclaw"); err == nil {
+		t.Fatal("expected error for invalid env override")
+	}
+}

--- a/gateway/zeroclaw_onboard_test.go
+++ b/gateway/zeroclaw_onboard_test.go
@@ -16,9 +16,10 @@ func TestParseZeroclawChannel(t *testing.T) {
 	}
 }
 
-func TestPrepareZeroclawManagedOnboard_WritesConfigAndRecord(t *testing.T) {
+func TestPrepareZeroclawManagedOnboard_WritesTOMLConfigAndRecord(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_MANAGED_ZEROCLAW_VERSION", "0.1.7")
 
 	sess := &OnboardSession{
 		SelectedAgent:    "zeroclaw",
@@ -37,6 +38,9 @@ func TestPrepareZeroclawManagedOnboard_WritesConfigAndRecord(t *testing.T) {
 	if result.WorkspacePath == "" || result.ConfigPath == "" || result.RecordPath == "" {
 		t.Fatalf("expected non-empty output paths, got %+v", result)
 	}
+	if !strings.HasSuffix(result.ConfigPath, "config.toml") {
+		t.Fatalf("expected zeroclaw config.toml path, got %q", result.ConfigPath)
+	}
 	if got := strings.TrimSpace(sess.EnvVars["ZEROCLAW_API_KEY"]); got != "sk-zeroclaw-123" {
 		t.Fatalf("expected ZEROCLAW_API_KEY populated from provider token, got %q", got)
 	}
@@ -45,9 +49,18 @@ func TestPrepareZeroclawManagedOnboard_WritesConfigAndRecord(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
-	var cfg map[string]interface{}
-	if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
-		t.Fatalf("parse config json: %v", err)
+	cfgText := string(cfgRaw)
+	for _, snippet := range []string{
+		`api_key = "sk-zeroclaw-123"`,
+		`default_provider = "openai"`,
+		`default_model = "openai/`,
+		`[channels_config.telegram]`,
+		`bot_token = "telegram-token-zero"`,
+		`allowed_users = ["418258935"]`,
+	} {
+		if !strings.Contains(cfgText, snippet) {
+			t.Fatalf("expected config to contain %q, got:\n%s", snippet, cfgText)
+		}
 	}
 
 	recordRaw, err := os.ReadFile(result.RecordPath)
@@ -61,7 +74,33 @@ func TestPrepareZeroclawManagedOnboard_WritesConfigAndRecord(t *testing.T) {
 	if record["agent_id"] != "zeroclaw" {
 		t.Fatalf("unexpected agent_id: %v", record["agent_id"])
 	}
+	if record["renderer_id"] != "zeroclaw.toml.v1" {
+		t.Fatalf("unexpected renderer_id: %v", record["renderer_id"])
+	}
+	if record["config_format"] != "toml" {
+		t.Fatalf("unexpected config_format: %v", record["config_format"])
+	}
 	if strings.Contains(string(recordRaw), "sk-zeroclaw-123") || strings.Contains(string(recordRaw), "telegram-token-zero") {
 		t.Fatalf("managed record should not contain secret token values: %s", recordRaw)
+	}
+}
+
+func TestPrepareZeroclawManagedOnboard_RejectsUnsupportedVersion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CARRIER_MANAGED_ZEROCLAW_VERSION", "2.0.0")
+
+	sess := &OnboardSession{
+		SelectedAgent:    "zeroclaw",
+		SelectedChannel:  "telegram",
+		ChannelToken:     "telegram-token-zero",
+		SelectedProvider: "openai",
+		EnvVars: map[string]string{
+			"OPENAI_API_KEY": "sk-zeroclaw-123",
+		},
+	}
+
+	if _, err := prepareManagedOnboard("zeroclaw", sess, "telegram:418258935"); err == nil || !strings.Contains(err.Error(), "unsupported zeroclaw version") {
+		t.Fatalf("expected unsupported version error, got %v", err)
 	}
 }

--- a/scripts/ci/upstream-schema-watch.cjs
+++ b/scripts/ci/upstream-schema-watch.cjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+function parseArgs(argv) {
+  const out = {
+    lockPath: "compat/upstreams.lock.json",
+    mode: "check-only",
+    failOnDrift: true,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--lock" && argv[i + 1]) {
+      out.lockPath = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--mode" && argv[i + 1]) {
+      out.mode = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--no-fail-on-drift") {
+      out.failOnDrift = false;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!["check-only", "create-issues"].includes(out.mode)) {
+    throw new Error(`unsupported mode: ${out.mode}`);
+  }
+  if (out.mode === "create-issues") {
+    out.failOnDrift = false;
+  }
+  return out;
+}
+
+function loadLockFile(lockPath) {
+  const abs = path.resolve(lockPath);
+  const raw = fs.readFileSync(abs, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || !parsed.agents || typeof parsed.agents !== "object") {
+    throw new Error(`invalid lock file structure: ${abs}`);
+  }
+  return { absPath: abs, lock: parsed };
+}
+
+function repositoryOwnerAndName() {
+  const fallback = "Keith-CY/carrier";
+  const repo = String(process.env.GITHUB_REPOSITORY || fallback).trim() || fallback;
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    throw new Error(`invalid GITHUB_REPOSITORY: ${repo}`);
+  }
+  return { owner, repo: name, full: `${owner}/${name}` };
+}
+
+async function githubRequest(method, route, body) {
+  const token = String(process.env.GITHUB_TOKEN || "").trim();
+  const headers = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "carrier-upstream-schema-watch",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(`https://api.github.com${route}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`github api ${method} ${route} failed (${response.status}): ${text}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+  return await response.json();
+}
+
+function canonicalFingerprint(fileRows) {
+  const lines = fileRows
+    .map((row) => `${row.path}:${row.sha}`)
+    .sort((a, b) => a.localeCompare(b));
+  const payload = `${lines.join("\n")}\n`;
+  const digest = crypto.createHash("sha256").update(payload, "utf8").digest("hex");
+  return { digest: `sha256:${digest}`, lines };
+}
+
+async function loadRemoteFileSha(repository, filePath) {
+  const encodedPath = filePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const data = await githubRequest("GET", `/repos/${repository}/contents/${encodedPath}`);
+  if (!data || typeof data.sha !== "string") {
+    throw new Error(`missing sha for ${repository}:${filePath}`);
+  }
+  return data.sha.trim();
+}
+
+async function evaluateDrifts(lock) {
+  const drifts = [];
+  for (const [agentIDRaw, agent] of Object.entries(lock.agents || {})) {
+    const agentID = String(agentIDRaw || "").trim().toLowerCase();
+    if (!agentID) {
+      continue;
+    }
+    const repository = String(agent.repository || "").trim();
+    if (!repository) {
+      throw new Error(`agent ${agentID}: repository is required`);
+    }
+
+    const trackedFiles = Array.isArray(agent.tracked_files) ? agent.tracked_files : [];
+    if (!trackedFiles.length) {
+      throw new Error(`agent ${agentID}: tracked_files is required`);
+    }
+
+    const remoteRows = [];
+    for (const item of trackedFiles) {
+      const filePath = String(item.path || "").trim();
+      if (!filePath) {
+        throw new Error(`agent ${agentID}: tracked_files.path is required`);
+      }
+      const remoteSha = await loadRemoteFileSha(repository, filePath);
+      remoteRows.push({
+        path: filePath,
+        sha: remoteSha,
+        expectedSha: String(item.sha || "").trim(),
+      });
+    }
+
+    const actual = canonicalFingerprint(remoteRows);
+    const expectedFingerprint = String(agent.expected_fingerprint || "").trim();
+    const fingerprintChanged = expectedFingerprint !== "" && expectedFingerprint !== actual.digest;
+    const fileChanges = remoteRows.filter((row) => row.expectedSha && row.expectedSha !== row.sha);
+
+    if (fingerprintChanged || fileChanges.length > 0) {
+      drifts.push({
+        agentID,
+        repository,
+        expectedFingerprint,
+        actualFingerprint: actual.digest,
+        tracked: remoteRows,
+        changedFiles: fileChanges,
+        recommendedVersion: String(agent.recommended_version || "").trim(),
+        renderers: Array.isArray(agent.supported_renderers) ? agent.supported_renderers : [],
+      });
+    }
+  }
+  return drifts;
+}
+
+function markerFor(agentID, fingerprint) {
+  return `<!-- upstream-schema-watch:${agentID}:${fingerprint} -->`;
+}
+
+function buildIssueTitle(drift) {
+  const short = drift.actualFingerprint.replace(/^sha256:/, "").slice(0, 12);
+  return `[upstream-schema] ${drift.agentID}: schema drift detected (${short})`;
+}
+
+function buildIssueBody(drift) {
+  const marker = markerFor(drift.agentID, drift.actualFingerprint);
+  const rendererLines = drift.renderers.length
+    ? drift.renderers.map((r) => `- ${r.id}: \`${r.version_range}\` -> \`${r.config_format}\``)
+    : ["- (no renderer metadata in lock)"];
+
+  const changedLines = drift.changedFiles.length
+    ? drift.changedFiles.map((row) => `- \`${row.path}\`: \`${row.expectedSha || "(unset)"}\` -> \`${row.sha}\``)
+    : drift.tracked.map((row) => `- \`${row.path}\`: \`${row.sha}\``);
+
+  return [
+    marker,
+    `Upstream schema drift detected for **${drift.agentID}** from \`${drift.repository}\`.`,
+    "",
+    "## Snapshot",
+    `- Expected fingerprint: \`${drift.expectedFingerprint || "(unset)"}\``,
+    `- Current fingerprint: \`${drift.actualFingerprint}\``,
+    drift.recommendedVersion ? `- Recommended version (lock): \`${drift.recommendedVersion}\`` : "- Recommended version (lock): (unset)",
+    "",
+    "## Changed Files",
+    ...changedLines,
+    "",
+    "## Supported Renderers (Current Lock)",
+    ...rendererLines,
+    "",
+    "## Follow-up Checklist",
+    "- [ ] Verify upstream config/schema changes are intentional",
+    "- [ ] Update Carrier renderer or version-range routing if needed",
+    "- [ ] Update `compat/upstreams.lock.json` tracked SHAs/fingerprint",
+    "- [ ] Add or update tests for new schema fields",
+  ].join("\n");
+}
+
+async function listOpenIssues(owner, repo) {
+  const issues = await githubRequest("GET", `/repos/${owner}/${repo}/issues?state=open&per_page=100`);
+  return Array.isArray(issues) ? issues.filter((item) => !item.pull_request) : [];
+}
+
+async function ensureIssueForDrift(owner, repo, drift, openIssues) {
+  const issueBodyMarkerPrefix = `<!-- upstream-schema-watch:${drift.agentID}:`;
+  const exactMarker = markerFor(drift.agentID, drift.actualFingerprint);
+
+  const existingExact = openIssues.find((issue) => String(issue.body || "").includes(exactMarker));
+  if (existingExact) {
+    console.log(`drift for ${drift.agentID} already tracked in issue #${existingExact.number}`);
+    return;
+  }
+
+  const existingAgentIssue = openIssues.find((issue) => String(issue.body || "").includes(issueBodyMarkerPrefix));
+  if (existingAgentIssue) {
+    const comment = [
+      `New drift fingerprint detected for \`${drift.agentID}\`.`,
+      `- Previous lock fingerprint: \`${drift.expectedFingerprint || "(unset)"}\``,
+      `- Current upstream fingerprint: \`${drift.actualFingerprint}\``,
+      "",
+      "Please refresh the issue body/checklist after adapting.",
+      exactMarker,
+    ].join("\n");
+
+    await githubRequest("POST", `/repos/${owner}/${repo}/issues/${existingAgentIssue.number}/comments`, {
+      body: comment,
+    });
+    console.log(`updated existing issue #${existingAgentIssue.number} for ${drift.agentID}`);
+    return;
+  }
+
+  const title = buildIssueTitle(drift);
+  const body = buildIssueBody(drift);
+  const created = await githubRequest("POST", `/repos/${owner}/${repo}/issues`, { title, body });
+  console.log(`created issue #${created.number} for ${drift.agentID}`);
+}
+
+async function run() {
+  const args = parseArgs(process.argv);
+  const { lock } = loadLockFile(args.lockPath);
+  const drifts = await evaluateDrifts(lock);
+
+  if (!drifts.length) {
+    console.log("no upstream schema drift detected");
+    return;
+  }
+
+  console.log(`detected ${drifts.length} upstream schema drift item(s)`);
+  for (const drift of drifts) {
+    console.log(`- ${drift.agentID}: ${drift.expectedFingerprint || "(unset)"} -> ${drift.actualFingerprint}`);
+  }
+
+  if (args.mode === "create-issues") {
+    const { owner, repo } = repositoryOwnerAndName();
+    const openIssues = await listOpenIssues(owner, repo);
+    for (const drift of drifts) {
+      await ensureIssueForDrift(owner, repo, drift, openIssues);
+    }
+    return;
+  }
+
+  if (args.failOnDrift) {
+    process.exitCode = 1;
+  }
+}
+
+run().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `compat/upstreams.lock.json` to track upstream schema fingerprints and renderer compatibility for `openclaw` / `picoclaw` / `zeroclaw`
- add version-aware managed renderer selection in gateway onboarding (`prepareManagedOnboard`)
- switch ZeroClaw managed config output to TOML (`~/.zeroclaw/config.toml`) with fail-fast on unsupported version ranges
- add scheduled workflow + watcher script to detect upstream schema drift and auto-create/update issues

## Validation
- `go test ./...` (in `gateway`) passed
- `node --check scripts/ci/upstream-schema-watch.cjs` passed

## Notes
- this PR intentionally contains only schema-watch + renderer/compat changes
- existing unrelated local modifications were not included
