### PR TITLE
fix(remote): use shell double-quotes instead of %q so $HOME expands in remoteConfigFileExists

### DIFF
--- a/gateway/remote_openclaw.go
+++ b/gateway/remote_openclaw.go
@@ -409,7 +409,8 @@ func remoteConfigFileExists(ctx context.Context, host RemoteHost, path string) (
 	if trimmed == "" {
 		return false, nil, nil
 	}
-	cmd := fmt.Sprintf("if [ -f %q ]; then echo 1; else echo 0; fi", trimmed)
+	// Use double quotes (not %q) so shell variables like $HOME expand correctly.
+	cmd := fmt.Sprintf(`if [ -f "%s" ]; then echo 1; else echo 0; fi`, trimmed)
 	res, err := runRemoteCommand(ctx, host, cmd)
 	if err != nil {
 		return false, []remoteExecResult{res}, err


### PR DESCRIPTION
The `%q` verb produces Go-style quoted strings which prevents shell variable expansion on the remote host. Switch to shell double-quotes so `$HOME` resolves correctly when checking for picoclaw and zeroclaw config files.

Closes #1461