### PR TITLE
docs: refresh install, onboard, and remote VPS workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,672 +1,181 @@
 # Carrier
 
-Scaffold for the Agent Installation Platform.
+Carrier is a local control plane for onboarding agent credentials, installing managed agents, and operating remote VPS instances over SSH.
 
-## Source of truth
+## What Works Today
 
-- Current architecture index: `docs/current-architecture.md`
-- Runtime model ADR: `docs/phase1-runtime-adr.md`
-- Canonical product scope: `docs/Agent_Installation_Platform_PRD.md`
+- Local bootstrap/onboarding via CLI/TUI/WebUI.
+- Managed local install lifecycle for `openclaw`, `picoclaw`, `zeroclaw`.
+- Remote host control-plane APIs (host upsert/check/install/list/config/sync).
+- Deterministic remote OpenClaw install script (no LLM decision path).
+- Remote instance discovery with confirmation-gated config pull for newly discovered instances.
 
-## Current scope
-- Runtime: local host (macOS/Linux), WSL2 (Windows)
-- Runtime exclusions: Docker is out of scope for Phase 1
-- Full lifecycle target: OpenClaw
-- Candidate-only agents: Pi Mono, NanoClaw, Pico Claw
-- Memory model: Per-Agent, Shared, Public
-- Gateway providers: Telegram, Discord, Feishu
+## Core Docs
 
-## Read order (single source of truth)
-For product scope/priority decisions, use this order:
-1. `docs/current-architecture.md` (canonical index and task entry points)
-2. `docs/Agent_Installation_Platform_PRD.md` (source of truth for scope and requirements)
-3. `docs/phase1-runtime-adr.md` (canonical runtime-model ADR for Phase 1)
-4. `docs/Agent_Installation_Platform_Implementation_Plan.md` (historical execution plan context)
-5. `README.md` (quick orientation and current implementation status)
+- CLI reference: [`docs/carrier-cli.md`](./docs/carrier-cli.md)
+- Task-first guide: [`docs/task-first-quickstart.md`](./docs/task-first-quickstart.md)
+- Remote sync API: [`docs/api/remote-sync-api.md`](./docs/api/remote-sync-api.md)
+- Remote codeagent API: [`docs/api/remote-codeagent-api.md`](./docs/api/remote-codeagent-api.md)
+- Architecture: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
 
-## Task-first docs quick links
-- `docs/task-first-quickstart.md`
-- `docs/carrier-cli.md`
-- `docs/runbooks/pairing-lifecycle.md`
-- `docs/ci/first-response-playbook.md`
-- `docs/runbooks/go-live-rollback.md`
+## Quick Start
 
-## Contributor docs quick links
-- `CONTRIBUTING.md`
-- `docs/command-contract.md`
-- `docs/daemon-api-contract.md`
-- `docs/daemon-lifecycle-runtime.md`
-- `docs/e2e-parity-taxonomy.md`
+### 1) Install Carrier
 
-## Quick Navigation
-
-- [Architecture](#architecture)
-- [Repository Map](#repository-map)
-- [Installation and Testing](#installation-and-testing)
-- [Carrier CLI Flow](#carrier-cli-flow-recommended-bootstrap--onboard--add)
-- [EC2 Binary + TUI Validation](#ec2-binary--tui-validation)
-- [Install OpenClaw from Release](#install-openclaw-from-release-package-non-technical-quick-path)
-- [三平台 Bot 管理（中文）](#三平台-bot-管理超详细步骤可直接照做)
-- [Three-Platform Bot Management (English)](#three-platform-bot-management-detailed-step-by-step)
-
-## Architecture
-
-For a detailed overview of the system design and component interactions, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
-
-Key topics covered:
-- Top-level dependency boundaries (`webui -> gateway -> daemon -> shared`, `webui -> gateway -> baseagent -> shared`)
-- Daemon lifecycle state machine and service boundaries
-- Gateway routing and provider abstraction
-- Catalog manifest schema and validation flow
-- Memory model (Per-Agent, Shared, Public) and mount policy
-
-## Repository Map
-
-| Path | Purpose |
-|------|---------|
-| [`shared/`](./shared/) | Shared Go module — cross-module config and redaction primitives |
-| [`baseagent/`](./baseagent/) | Base Agent Go module — triage policy/runtime, independently testable |
-| [`daemon/`](./daemon/) | Go daemon — lifecycle scheduling, host runtime management, daemon API |
-| [`gateway/`](./gateway/) | Go gateway module — ingress, session/rate-limit, webhook/message routing |
-| [`webui/`](./webui/) | Local WebUI static app and handler package |
-| [`catalog/`](./catalog/) | OpenClaw manifest and candidate agent list |
-| [`docs/`](./docs/) | Product requirements, implementation plan, and architecture docs |
-| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | System design overview and component interaction diagrams |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Contributor workflow, branching policy, and review conventions |
-| [`skills/`](./skills/) | Automation and review helper skills (PR review, NBS follow-up) |
-| [`scripts/`](./scripts/) | Development and CI helper scripts |
-| [`tests/`](./tests/) | Cross-module integration and end-to-end tests |
-
-## M2 daemon scaffold status
-- Runtime prerequisite checks are implemented for local host and WSL2 requirement detection.
-- Lifecycle service now executes install/start/stop commands through a runner abstraction.
-- Start path validates required env vars and port conflicts before execution.
-- Logs tail retrieval and diagnose zip artifact generation are available in the lifecycle service.
-
-## M3 remote diagnosis scaffold status
-- Lifecycle service now stores audit logs for lifecycle, triage, diagnose, and consent actions.
-- Base Agent unresolved flow can create a remote diagnosis handoff placeholder with user consent.
-- Handoff records include consent flag, status, and diagnose artifact reference.
-
-## M4 gateway routing scaffold status
-- Gateway now supports `pair/agents/install/start/stop/status/logs/upgrade/diagnose/diagnose-consent` routing scaffold.
-- `/pair <code>` binds provider chat sessions and enforces session checks before non-pair commands.
-- Gateway forwards `provider`, `chat_id`, and `request_id` into daemon request context for command handling.
-- Logs/diagnose responses can issue short-lived read-only download tokens and URLs.
-- Telegram/Discord/Feishu payload parsers now normalize provider events/interactions into one gateway command DTO shape.
-
-## Development flow
-- Start work from `origin/main` using a new `codex/*` branch and worktree.
-- Submit all feature updates via Pull Request.
-- Use GitHub Actions as test source of truth.
-- For non-blocking review suggestions, use `NBS:` lines (one suggestion per line). Post-merge automation creates follow-up issues from those lines.
-
-See `CONTRIBUTING.md` for command examples and required process. For security vulnerability reporting, see [`SECURITY.md`](./SECURITY.md). For install/upgrade integrity verification, see [`docs/security-install-integrity.md`](./docs/security-install-integrity.md).
-
-## Terminology Mapping
-
-| Term | Mapping |
-|---|---|
-| Runtime | Local host (macOS/Linux) or WSL2 (Windows), no Docker path in Phase 1 |
-| Diagnose | Sanitized diagnostic artifact generation with optional remote diagnosis consent flow |
-| Per-Agent Memory | Memory private to one agent instance |
-| Shared Memory | Reusable memory across local agents (default read-only mount) |
-| Public Memory | Template memory packages (read-only) |
-| P0 | Must-have for Phase 1 acceptance |
-| P1 | Important priority after P0 |
-
-## Installation and testing
-
-### Carrier CLI flow (recommended: bootstrap → onboard → install)
-
-Carrier CLI is now the recommended first path:
-
-1. `carrier` (bootstrap)
-   - If no onboarding config exists, it starts onboarding automatically.
-   - If already onboarded, it starts/reuses daemon + gateway and exits.
-2. `carrier onboard` (interactive TUI/CLI)
-   - This flow is Telegram-first today.
-   - Explicit terminal aliases are also supported: `carrier onboard --tui` and `carrier onboard --cli`.
-   - For Discord/Feishu onboarding, use `carrier onboard --webui` (or provider/manual setup) and run install flow through WebUI where needed.
-3. `carrier install <agent_id>` (managed or direct)
-   - `openclaw`, `picoclaw`, and `zeroclaw`: managed-agent flow with provider/channel setup, then install/start plus instance tracking.
-   - Other agent IDs: direct install + start for the daemon.
-   - `carrier add <agent_id>` remains supported as an alias.
-4. `carrier install <agent_id> --webui` (browser-assisted for all managed flows)
-
-For full command coverage, see [`docs/carrier-cli.md`](./docs/carrier-cli.md).
-
-Notes:
-
-- Chat `/install` and `/onboard` command names still exist, but onboarding/install in chat mode are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) to protect credentials; use Carrier CLI/TUI (`carrier install`, `carrier onboard`) or WebUI instead.
-- Release/package flows below are still valid and useful for non-CLI deployment scenarios.
-
-### Onboarding Runbook (Directly Executable)
-
-1. Run bootstrap first (one-time setup)
-   - Command: `carrier`
-   - Expected result:
-     - If not initialized, onboarding guidance starts automatically.
-     - If already initialized, daemon and gateway are started/reused and the command exits.
-2. Enter onboarding explicitly (recommended)
-   - Command: `carrier onboard`
-   - Complete the prompts:
-     - Select communication channel (Telegram/Discord/Feishu).
-     - Enter channel credentials.
-     - Select and configure model provider credentials.
-3. Use WebUI onboarding if a browser-assisted flow is preferred
-   - Command: `carrier onboard --webui`
-   - Expected result:
-     - Local browser opens the WebUI onboarding flow.
-     - Gateway health endpoint is reachable at `http://127.0.0.1:8787/healthz`.
-4. Install an agent after onboarding for validation
-   - Command: `carrier add openclaw`
-   - Expected result:
-     - Install/start logs are printed.
-     - `carrier list` includes the new instance.
-5. Quick troubleshooting
-   - `carrier gateway` startup fails: check whether `CARRIER_GATEWAY_PORT` is already in use.
-   - Command timeout: verify `CARRIER_DAEMON_BASE_URL` is reachable.
-   - Channel pairing fails: re-run `carrier onboard` and verify channel token/secret values.
-
-### Prerequisites
-- Go toolchain (see `daemon/go.mod` for the required version)
-- Bun (required for WebUI TypeScript build and utility scripts)
-
-#### Toolchain quick check
-
-Run the following to verify required tools are installed and print their versions:
+#### Option A: Install from release script (recommended)
 
 ```bash
-echo "gh:  $(gh --version | head -1)"
-echo "go:  $(go version)"
-echo "bun: $(bun --version)"
+curl -fsSL https://raw.githubusercontent.com/Keith-CY/carrier/main/scripts/install.sh | bash
+carrier --version
 ```
 
-If any command fails, install the missing tool before running automation scripts. See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed CI troubleshooting.
+Notes:
+- Installer resolves `main` HEAD SHA, downloads `carrier-main-<full_sha>-<platform>.zip`, verifies `.sha256`, then installs `carrier`.
+- Default install path is `/usr/local/bin/carrier` (falls back to `~/.local/bin/carrier` when needed).
 
-### Install
-- Carrier/Daemon/Gateway/BaseAgent/Shared (Go): Go modules are loaded automatically when building or testing; no additional install command needed.
-- WebUI assets: source files are TypeScript in `webui/src/*.ts`; build output is generated to `webui/static/*.js` via `bash scripts/build-webui.sh`.
+#### Option B: Build from source
 
-### Run tests / checks
-- Daemon tests:
-  - `cd daemon`
-  - `go test ./...`
-  - `go test ./internal/manifest -run TestLoadFileAcceptsCatalogManifest -count=1`
-- Gateway tests:
-  - `cd gateway`
-  - `go test ./...`
-- Base Agent tests:
-  - `cd baseagent`
-  - `go test ./...`
-- Shared module tests:
-  - `cd shared`
-  - `go test ./...`
-- Coverage gate from repo root:
-  - `make coverage-gate`
-  - Strict all-module 100% mode: `COVERAGE_STRICT_100=1 make coverage-gate`
-- Full local flow from repo root (mandatory before pushing):
-  - `./scripts/run-all-tests.sh`
-
-Optional local flow from repo root:
-  - `cd daemon && go test ./...`
-
-### Gateway runtime server (Go)
-
-- Start gateway runtime HTTP server:
-  - `go run ./cmd/carrier gateway`
-- Health route:
-  - `GET /healthz`
-- Command ingress route:
-  - `POST /command` with JSON body `{ "input": "<provider> <chat_id> <request_id> <command> [...args]" }`
-  - If `CARRIER_GATEWAY_API_TOKEN` is set, send `Authorization: Bearer <gateway_api_token>`
-  - For authenticated commands (non-`/pair`), provide session token via `x-session-token` header or `sessionToken` field in JSON body
-- Artifact download route:
-  - `GET /downloads/<token>/<filename>`
-
-Runtime environment variables:
-- `CARRIER_DAEMON_BASE_URL` (default: `http://127.0.0.1:9090`)
-- `CARRIER_DAEMON_TIMEOUT_MS` (default: `30000`)
-- `CARRIER_COMMAND_TIMEOUT` (default: `5m`, daemon lifecycle install/upgrade command timeout)
-- `CARRIER_GATEWAY_HOST` (default: `127.0.0.1`)
-- `CARRIER_GATEWAY_PORT` (default: `8787`)
-- `CARRIER_GATEWAY_API_TOKEN` (optional on loopback; required for non-loopback bind)
-- `CARRIER_MAX_COMMAND_BODY_BYTES` (default: `65536`)
-- `CARRIER_REMOTE_CONTROL_PLANE_ENABLED` (default: `true`)
-- `CARRIER_REMOTE_CHAT_ENABLED` (default: `true`, effective only when `CARRIER_REMOTE_CONTROL_PLANE_ENABLED=true`)
-- `CARRIER_PROVIDER_BINDING_ENABLED` (default: `true`, effective only when `CARRIER_REMOTE_CONTROL_PLANE_ENABLED=true`)
-
-Remote rollout metrics:
-- `GET /api/v1/remote/metrics` returns aggregate remote-operation metrics plus `rollout` status:
-  - `rollout.state`: `healthy | canary | hold`
-  - `rollout.canPromote`: rollout gate signal for full promotion
-  - `rollout.reasons`: threshold-based reasons when state is not fully healthy
-
-SSH trust behavior note:
-- Remote SSH uses `StrictHostKeyChecking=accept-new` (TOFU) by default for first connection convenience.
-- For production environments, pre-populate `known_hosts` and/or use controlled SSH config to avoid implicit first-seen trust.
-
-### Managed PicoClaw Secret Persistence
-
-- Managed instance record files (`~/.carrier/agents/*.json`) do not store channel/provider secret values.
-- Shared provider credentials are loaded from the credential store (`CARRIER_CREDENTIAL_STORE`, with keychain/file fallback logic in code).
-- For OAuth provider flows (for example `openai-codex`), tokens are persisted in `~/.picoclaw/auth.json`; generated `config.json` keeps auth metadata/reference fields and avoids duplicating OAuth token values in model entries.
-- API-key providers keep a single provider-level credential entry in generated PicoClaw config instead of duplicating the same key across multiple config nodes.
-
-#### Merge Queue
-- This repository supports GitHub Merge Queue for `main`.
-- For merge operations, prefer queue-based merge from the GitHub UI.
-
-#### CI coverage note (E2E execution policy)
-- `Provider Parity (core/failure)` matrix in `.github/workflows/ci.yml` runs on PR and push, and uploads per-scenario log artifacts (`provider-parity-core`, `provider-parity-failure`) for drift diagnosis.
-- `End-to-End Tests` in `.github/workflows/ci.yml` run only on `push` to `main` (`github.event_name == 'push' && github.ref == 'refs/heads/main'`).
-- Pull requests do not run E2E in `ci.yml`.
-- Docs-only changes run `.github/workflows/docs-consistency.yml`, which executes `scripts/check-doc-command-sync.sh`.
-- Release flow also enforces mandatory end-to-end validation in `.github/workflows/release.yml` (`End-to-End Tests (Deployment)`).
-
-## Local workflow notes
-
-- Before making changes, read the skill instructions under `skills/` (especially `skills/pr-review/SKILL.md` and `skills/review-followup/SKILL.md`) to follow repository-specific conventions.
-
-## Runbooks
-
-- Pairing lifecycle and troubleshooting matrix: `docs/runbooks/pairing-lifecycle.md`
-- Go-live checklist and rollback: `docs/runbooks/go-live-rollback.md`
-- Post-merge smoke checklist (includes remote control plane flows): `docs/runbooks/post-merge-smoke-checklist.md`
-- CI first-response playbook: `docs/ci/first-response-playbook.md`
-
-## Kanban workflow env vars
-
-For `.github/workflows/carrier-kanban-operations.yml` (see [`.github/workflows/carrier-kanban-operations.yml`](./.github/workflows/carrier-kanban-operations.yml)):
-
-- `CARRIER_PROJECTS_TOKEN` (required): token with project read/write permissions for field/view operations.
-- `CARRIER_PROJECT_ID` (optional override): target project node ID override.
-- `CARRIER_DISCUSSION_CATEGORY_ID` (optional): discussion category override for workflow-generated discussion posts.
-
-Target project resolution order:
-1. workflow dispatch input `project_id`
-2. `CARRIER_PROJECT_ID`
-3. repository workflow/config default
-
-Implementation notes:
-- `carrier-kanban-operations.yml` can fall back to the pre-authenticated `github` client from `@actions/github` for repository-scoped calls when an explicit token is not provided.
-- Kanban workflows skip with a warning when `CARRIER_PROJECTS_TOKEN` is missing or project access is unavailable, so unrelated CI checks are not blocked by Kanban configuration gaps.
-
-## EC2 Binary + TUI Validation
-
-- For each push to `main`, release workflow publishes a **pre-release** with tag `main-<full_commit_sha>`.
-- Binary package naming on that tag:
-  - `carrier-main-<full_commit_sha>-linux-x64.zip`
-  - `carrier-main-<full_commit_sha>-windows-x64.zip`
-- Release assets can be downloaded directly from:
-  - `https://github.com/Keith-CY/carrier/releases/download/main-<full_commit_sha>/carrier-main-<full_commit_sha>-<label>.zip`
-- Quick install (`curl ... | bash`) is available via:
-  - `curl -fsSL https://raw.githubusercontent.com/Keith-CY/carrier/main/scripts/install.sh | bash`
-  - Installer behavior: resolves `main` HEAD SHA, downloads `carrier-main-<full_commit_sha>-<label>.zip`, verifies `.sha256`, installs `carrier`.
-- Do not infer latest by taking the first `/releases` entry; resolve `main` HEAD SHA and use `main-<full_commit_sha>`.
-- Use TUI/CLI flow for onboarding/install on EC2:
-  - `carrier onboard`
-  - `carrier install openclaw` (or `carrier add openclaw`)
-- Chat `/install` and `/onboard` are intentionally blocked in gateway chat mode (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) for credential safety.
-- End-to-end no-rebuild scripts:
-  - Linux: `scripts/ec2-binary-tui-linux.sh` (no args defaults to latest `main` push release)
-  - Windows: `scripts/ec2-binary-tui-windows.ps1` (no args defaults to latest `main` push release)
-- Detailed runbook: `docs/runbooks/ec2-binary-tui-validation.md`
-
-## Install OpenClaw from release package (non-technical quick path)
-
-> Status note: this project is still in Phase 1 scaffold, but release packages can already be used as the starting point for local installation flow.
-
-### English
-
-1. Open [**Releases**](https://github.com/Keith-CY/carrier/releases) for this repository. Artifacts follow the naming pattern `carrier-<commit-sha>-<os>-<arch>.zip` (e.g., `carrier-1feeeb7-linux-x64.zip`, `carrier-1feeeb7-darwin-arm64.zip`).
-2. Download the ZIP package for your OS/CPU (for example: `linux-x64`, `darwin-arm64`, `windows-x64`).
-3. (Optional but recommended) Download the matching `.sha256` file and verify checksum:
-   - Linux (GNU): `sha256sum -c carrier-*.sha256`
-   - macOS: `shasum -a 256 carrier-*.zip`
-   - Windows PowerShell: `Get-FileHash .\carrier-*.zip -Algorithm SHA256`
-4. Extract the ZIP to a local folder.
-5. Start the daemon from the extracted folder:
-   - macOS/Linux: `./carrier daemon`
-   - Windows PowerShell: `.\carrier.exe daemon`
-6. Get your pairing code from the daemon terminal output (format: `pair-<hex>`). If needed, you can also issue one via API: `curl -s -X POST http://127.0.0.1:9090/api/v1/pairing/codes`.
-   - Note: `PAIR_CODE` has a short TTL (currently 5 minutes). If pairing fails due to expiration, request a fresh code and retry `/pair <code>`.
-7. Use your chat provider flow (Telegram/Discord/Feishu) to pair and run commands:
-   - `/pair <code>`
-   - `/agents`
-   - If `/agents` returns an empty list, verify the daemon is running and successfully paired, then retry after a few seconds. If still empty, re-run `/pair <code>` with a fresh code.
-8. Install OpenClaw through Carrier CLI/TUI or WebUI (chat `/install` is intentionally blocked):
-   - `carrier install openclaw` (or `carrier add openclaw`)
-9. Configure required OpenClaw environment (for example `OPENAI_API_KEY`) before start.
-10. Start and verify:
-   - `/start openclaw`
-   - `/status openclaw`
-
-If install/start fails, run `/diagnose openclaw` and use the generated artifact for support.
-
-### 中文（简版）
-
-1. 打开本仓库 [**Releases**](https://github.com/Keith-CY/carrier/releases) 页面。
-2. 下载与你系统匹配的 ZIP（如 `linux-x64`、`darwin-arm64`、`windows-x64`）。
-3. （可选）下载同名 `.sha256` 文件做校验：
-   - Linux（GNU）：`sha256sum -c carrier-*.sha256`
-   - macOS：`shasum -a 256 carrier-*.zip`
-   - Windows PowerShell：`Get-FileHash .\carrier-*.zip -Algorithm SHA256`
-4. 解压 ZIP 到本地目录。
-5. 运行解压目录里的 daemon：
-   - macOS/Linux：`./carrier daemon`
-   - Windows PowerShell：`.\carrier.exe daemon`
-6. 从 daemon 终端输出里获取配对码（格式：`pair-<hex>`）。如需手动申请，也可调用 API：`curl -s -X POST http://127.0.0.1:9090/api/v1/pairing/codes`。
-   - 说明：`PAIR_CODE` 有较短有效期（当前为 5 分钟）。若因过期导致配对失败，请重新获取新配对码后再执行 `/pair <code>`。
-7. 通过 Telegram/Discord/Feishu 配对后执行：
-   - `/pair <code>`
-   - `/agents`
-   - 若 `/agents` 返回空列表，请先确认 daemon 正在运行且已成功配对，等待数秒后重试；若仍为空，请用新的配对码重新执行 `/pair <code>`。
-8. 通过 Carrier CLI/WebUI 安装 OpenClaw（chat `/install` 已被有意禁用）：
-   - `carrier add openclaw`
-9. 启动前先配置 OpenClaw 必需环境变量（如 `OPENAI_API_KEY`）。
-10. 启动并检查：
-   - `/start openclaw`
-   - `/status openclaw`
-
-如果安装或启动失败，请执行 `/diagnose openclaw` 并提交诊断产物。
-
-### Flow verification checklist (download → pair → add/start)
-
-Use this as a quick pass/fail checklist when validating the README flow:
-
-1. **Download**
-   - Can locate matching ZIP + `.sha256` in [Releases](https://github.com/Keith-CY/carrier/releases).
-   - Artifact naming is expected as `carrier-<commit-sha>-<os>-<arch>.zip` with matching checksum file `carrier-<commit-sha>-<os>-<arch>.zip.sha256`.
-2. **Checksum**
-   - Verification command is available for your OS and returns success.
-3. **Daemon start**
-   - `carrier daemon` starts and prints a usable `PAIR_CODE`.
-4. **Pair**
-   - `/pair <code>` returns success before TTL expires.
-5. **Add path**
-   - `carrier add openclaw` completes successfully.
-6. **Start/Status**
-   - `/start openclaw` succeeds; `/status openclaw` returns healthy/running.
-7. **Fallback path**
-   - On failure, `/diagnose openclaw` generates a support artifact.
-
-### 流程验收清单（下载 → 配对 → add/启动）
-
-可用下面清单快速确认 README 流程是否可执行：
-
-1. **下载**：能在 [Releases](https://github.com/Keith-CY/carrier/releases) 找到匹配 ZIP 与 `.sha256`。
-   - 产物命名建议为 `carrier-<commit-sha>-<os>-<arch>.zip`，对应校验文件为 `carrier-<commit-sha>-<os>-<arch>.zip.sha256`。
-2. **校验**：对应系统校验命令可用且结果成功。
-3. **启动 daemon**：`carrier daemon` 启动后可看到可用 `PAIR_CODE`。
-4. **配对**：`/pair <code>` 在有效期内返回成功。
-5. **安装链路**：`carrier add openclaw` 能成功完成。
-6. **启动与状态**：`/start openclaw` 成功，`/status openclaw` 显示 healthy/running。
-7. **兜底诊断**：失败场景可通过 `/diagnose openclaw` 产出诊断文件。
-
-## 三平台 Bot 管理（超详细步骤，可直接照做）
-
-本节用于“聊天侧运维命令（start/stop/status 等）”的场景。  
-安装必须通过 Carrier TUI/WebUI 完成，聊天里的 `/install` 已禁用。
-
-### 先准备（缺一不可）
-
-在开始前，请向项目管理员索取以下信息：
-
-1. Telegram 机器人入口（用户名或邀请链接）
-2. Discord 机器人入口（服务器+频道，或私聊入口）
-3. 飞书机器人入口（会话入口）
-4. 一次性配对码 `PAIR_CODE`（示例：`pair-4e72e19a9f2a`）
-
-如果缺少以上任意一项，本流程无法完成。
-
-### 固定规则（所有平台都一样）
-
-1. 命令必须发给机器人账号（Bot），不能发给真人账号
-2. 每个平台第一次都要先执行：`/pair <PAIR_CODE>`
-3. 配对成功后，才能执行 `/agents`、`/start openclaw` 等管理命令
-4. 如果提示配对码无效或过期，向管理员申请新的 `PAIR_CODE`
-
-### Telegram（逐步执行）
-
-1. 打开 Telegram
-2. 搜索管理员给你的机器人账号
-3. 进入机器人聊天窗口
-4. 发送：`/pair <PAIR_CODE>`
-5. 等待回复，确认包含 `paired` 或“已配对”
-6. 发送：`/agents`
-7. 确认回复中包含 `openclaw`
-8. 依次发送：
-   - `/start openclaw`
-   - `/status openclaw`
-9. 确认状态回复包含 `healthy`（或“健康”）
-
-### Discord（逐步执行）
-
-1. 打开 Discord
-2. 进入管理员提供的服务器和频道（或机器人私聊窗口）
-3. 确认消息对象是机器人账号
-4. 发送：`/pair <PAIR_CODE>`
-5. 等待回复，确认包含 `paired` 或“已配对”
-6. 发送：`/agents`
-7. 确认回复中包含 `openclaw`
-8. 依次发送：
-   - `/start openclaw`
-   - `/status openclaw`
-9. 确认状态回复包含 `healthy`（或“健康”）
-
-### 飞书（逐步执行）
-
-1. 打开飞书
-2. 进入管理员提供的机器人会话
-3. 确认不是同事聊天窗口，而是机器人会话
-4. 发送：`/pair <PAIR_CODE>`
-5. 等待回复，确认包含 `paired` 或“已配对”
-6. 发送：`/agents`
-7. 确认回复中包含 `openclaw`
-8. 依次发送：
-   - `/start openclaw`
-   - `/status openclaw`
-9. 确认状态回复包含 `healthy`（或“健康”）
-
-### 常用命令（可复制）
-
-```text
-/pair <PAIR_CODE>
-/agents
-# 安装请在终端执行：carrier add openclaw
-/start openclaw
-/status openclaw
-/logs openclaw 200
-/diagnose openclaw
-/stop openclaw
+```bash
+git clone https://github.com/Keith-CY/carrier.git
+cd carrier
+go build -o ./carrier ./cmd/carrier
+./carrier --version
 ```
 
+### 2) Onboard Carrier
 
-### 预期响应示例
+```bash
+# bootstrap: runs onboarding automatically if config is missing
+carrier
 
-以下是通用响应示例（不含真实 ID 或令牌）：
-
-**配对成功 (`/pair`)：**
-```
-✅ 配对成功。你现在可以使用 /agents、/start、/status 等管理命令。
-```
-
-**代理列表 (`/agents`)：**
-```
-可用代理:
-- openclaw (v0.1.0) — 已停止
+# explicit onboarding entry
+carrier onboard
 ```
 
-**健康状态 (`/status openclaw`)：**
-```
-代理: openclaw
-版本: 0.1.0
-状态: running
-健康: healthy
+WebUI onboarding:
+
+```bash
+carrier onboard --webui
 ```
 
-### 验收标准（三平台都要通过）
+Notes:
+- Onboarding stores config at `${CARRIER_CONFIG:-~/.carrier/config.v2.json}`.
+- Chat `/onboard` is intentionally blocked for credential safety.
+- Chat `/install` is policy-gated; default policy supports remote OpenClaw install with explicit host binding (`/install openclaw <host_id>`).
 
-以下 3 条都满足，表示配置成功：
+### 3) Install OpenClaw Locally
 
-1. Telegram 里 `/status openclaw` 返回 `healthy`
-2. Discord 里 `/status openclaw` 返回 `healthy`
-3. 飞书里 `/status openclaw` 返回 `healthy`
-
-### 报错处理（按文字处理）
-
-1. `pairing code is invalid or expired`
-   - 处理：配对码错误或过期，向管理员申请新码，再执行 `/pair <PAIR_CODE>`
-2. `chat is not paired; run /pair <code> first`
-   - 处理：当前聊天窗口还未配对，先执行 `/pair <PAIR_CODE>`
-3. `E_NOT_INSTALLED`
-   - 处理：先在终端执行 `carrier add openclaw`，再执行 `/start openclaw`
-4. `E_ALREADY_RUNNING`
-   - 处理：说明已经在运行，直接执行 `/status openclaw` 即可
-5. 没有任何回复
-   - 处理：通常是入口错误（发给了非机器人账号）或机器人未接通后端，请联系管理员
-
-### 管理员信息模板（建议放在团队文档）
-
-```text
-Telegram Bot: <填写用户名或链接>
-Discord 入口: <填写服务器/频道或私聊入口>
-飞书入口: <填写机器人会话入口>
-PAIR_CODE 获取方式: <填写由谁提供、有效期多久>
-支持联系人: <填写姓名与联系方式>
+```bash
+carrier add openclaw
+carrier status openclaw
+carrier list
 ```
 
-## Three-Platform Bot Management (Detailed Step-by-Step)
+`carrier install openclaw` is an alias of `carrier add openclaw`.
 
-This section covers chat-side management commands (`/start`, `/stop`, `/status`, etc.).  
-Installation must be done in Carrier TUI/WebUI because chat `/install` is intentionally blocked.
+### 4) Install OpenClaw To VPS (Deterministic)
 
-### Prerequisites (all required)
+Use `scripts/remote-openclaw-install.sh` to run a fixed, repeatable sequence:
 
-Before starting, ask your project administrator for:
+1. upsert remote host
+2. pre-check host
+3. install OpenClaw via remote install stream
+4. post-check host
+5. list instances
+6. reconnect simulation check (optional)
 
-1. Telegram bot entry (username or invite link)
-2. Discord bot entry (server + channel, or DM entry)
-3. Feishu bot entry (chat entry)
-4. One-time pairing code `PAIR_CODE` (example: `pair-4e72e19a9f2a`)
+#### Prerequisites
 
-If any of the items above is missing, this flow cannot be completed.
+- Local gateway reachable at `http://127.0.0.1:8787` (`carrier` bootstrap can start it).
+- SSH access to VPS (`host`, `port`, `user`, private key path).
+- Local tools: `curl`, `jq`.
 
-### Fixed rules (same for all platforms)
+#### Minimal example
 
-1. Send commands to a bot account, not to a human account
-2. On each platform, run pairing first: `/pair <PAIR_CODE>`
-3. Only after pairing succeeds, run `/agents`, `/start openclaw`, and other management commands
-4. If pairing code is invalid or expired, request a new `PAIR_CODE` from admin
-
-### Telegram (step by step)
-
-1. Open Telegram
-2. Search for the bot account provided by admin
-3. Open the bot chat window
-4. Send: `/pair <PAIR_CODE>`
-5. Wait for reply and confirm it includes `paired`
-6. Send: `/agents`
-7. Confirm response includes `openclaw`
-8. Send in order:
-   - `/start openclaw`
-   - `/status openclaw`
-9. Confirm status response includes `healthy`
-
-### Discord (step by step)
-
-1. Open Discord
-2. Enter the server/channel provided by admin (or bot DM)
-3. Confirm your message target is the bot account
-4. Send: `/pair <PAIR_CODE>`
-5. Wait for reply and confirm it includes `paired`
-6. Send: `/agents`
-7. Confirm response includes `openclaw`
-8. Send in order:
-   - `/start openclaw`
-   - `/status openclaw`
-9. Confirm status response includes `healthy`
-
-### Feishu (step by step)
-
-1. Open Feishu
-2. Enter the bot chat provided by admin
-3. Confirm this is a bot chat, not a human chat
-4. Send: `/pair <PAIR_CODE>`
-5. Wait for reply and confirm it includes `paired`
-6. Send: `/agents`
-7. Confirm response includes `openclaw`
-8. Send in order:
-   - `/start openclaw`
-   - `/status openclaw`
-9. Confirm status response includes `healthy`
-
-### Common commands (copy-paste)
-
-```text
-/pair <PAIR_CODE>
-/agents
-# Install via terminal: carrier add openclaw
-/start openclaw
-/status openclaw
-/logs openclaw 200
-/diagnose openclaw
-/stop openclaw
+```bash
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519
 ```
 
+#### Install with selected local config sync
 
-### Expected response examples
+If you already onboarded locally and want to push selected local channel/provider settings to remote `openclaw.json`:
 
-Below are generic response examples (no real IDs or tokens):
-
-**Pairing success (`/pair`):**
-```
-✅ Paired successfully. You can now use /agents, /start, /status, and other management commands.
-```
-
-**Agent listing (`/agents`):**
-```
-Available agents:
-- openclaw (v0.1.0) — stopped
-```
-
-**Healthy status (`/status openclaw`):**
-```
-Agent: openclaw
-Version: 0.1.0
-Status: running
-Health: healthy
+```bash
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519 \
+  --sync-channel telegram \
+  --sync-provider openai-codex
 ```
 
-### Acceptance criteria (all 3 platforms)
+Optional allow-list flags:
+- `--telegram-allow-from <id>`
+- `--discord-allow-from <id>`
 
-Configuration is successful only when all conditions are met:
+### 5) Full Remote Matrix Validation (Optional)
 
-1. In Telegram, `/status openclaw` returns `healthy`
-2. In Discord, `/status openclaw` returns `healthy`
-3. In Feishu, `/status openclaw` returns `healthy`
+For Docker-VPS style end-to-end validation across OpenClaw + PicoClaw + ZeroClaw + codeagent backends:
 
-### Error handling (match exact message)
-
-1. `pairing code is invalid or expired`
-   - Action: pairing code is wrong or expired; request a new code and run `/pair <PAIR_CODE>` again
-2. `chat is not paired; run /pair <code> first`
-   - Action: current chat is not paired; run `/pair <PAIR_CODE>` first
-3. `E_NOT_INSTALLED`
-   - Action: run `carrier add openclaw` in terminal first, then run `/start openclaw`
-4. `E_ALREADY_RUNNING`
-   - Action: bot is already running; run `/status openclaw` directly
-5. No reply at all
-   - Action: usually wrong entry (not a bot account) or bot backend not connected; contact admin
-
-### Admin info template (recommended)
-
-```text
-Telegram Bot: <username or invite link>
-Discord Entry: <server/channel or DM entry>
-Feishu Entry: <bot chat entry>
-PAIR_CODE Process: <who provides it and expiration policy>
-Support Contact: <name and contact method>
+```bash
+scripts/remote-vps-agent-suite.sh \
+  --host-id vps-1 \
+  --host 127.0.0.1 \
+  --port 2224 \
+  --user carrier \
+  --key-path /tmp/carrier-e2e-keys/id_ed25519
 ```
+
+## Daily Commands
+
+```bash
+# services
+carrier
+carrier stop
+carrier daemon
+carrier gateway
+
+# managed instances
+carrier list
+carrier start <id|name>
+carrier stop <id|name>
+carrier status <id|name>
+carrier upgrade <id|name>
+carrier uninstall <id|name>
+
+# install aliases
+carrier add <agent_id>
+carrier install <agent_id>
+```
+
+## Remote Control Notes
+
+- `carrier remote ...` currently covers sync/diagnose/reconcile/rollback/codeagent actions.
+- OpenClaw remote installation is currently provided by `scripts/remote-openclaw-install.sh` (gateway API wrapper).
+- On first host check, newly discovered remote instances may require explicit confirmation before pulling config to local repo.
+- Chat `/install` can perform remote install when boundary policy allows it (default: requires host binding).
+
+## Troubleshooting
+
+- Gateway not reachable:
+  - `carrier` (bootstrap) or `carrier gateway`
+  - verify `http://127.0.0.1:8787/healthz`
+- Remote host check failures:
+  - verify SSH key path and remote login
+  - retry host check from script (`--check-retries`, `--check-retry-delay`)
+- OpenClaw runtime issues:
+  - `carrier status openclaw`
+  - `carrier remote diagnose <host_id> <agent_id>` (for remote instance)
+
+## Development
+
+- Contributor guide: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- Test entrypoint: `./scripts/run-all-tests.sh`
+- Docs consistency check: `./scripts/check-doc-command-sync.sh`

--- a/docs/Agent_Installation_Platform_PRD.md
+++ b/docs/Agent_Installation_Platform_PRD.md
@@ -100,8 +100,8 @@ Input:
 - `agent_id` in catalog allowlist
 
 Notes:
-- Chat `/install` is intentionally blocked (`E_INSTALL_GUI_ONLY`) for credential safety.
-- Installation entrypoint is Carrier TUI/WebUI (`carrier add <agent>`).
+- Chat `/install` is policy-gated; default policy supports remote OpenClaw install with explicit host binding (`/install openclaw <host_id>`).
+- Local installation entrypoint remains Carrier CLI/TUI/WebUI (`carrier add <agent>` / `carrier install <agent>`).
 
 Steps:
 1. validate runtime preconditions (OS-specific + toolchain)
@@ -388,5 +388,5 @@ Memory criteria:
 2. WSL2 distro and shell assumptions for Windows support baseline
 3. Remote diagnosis handoff schema and privacy policy contract
 Notes:
-- Chat `/install` is intentionally blocked (`E_INSTALL_GUI_ONLY`) for credential safety.
-- Installation entrypoint is Carrier TUI/WebUI (`carrier add <agent>`).
+- Chat `/install` is policy-gated; default policy supports remote OpenClaw install with explicit host binding (`/install openclaw <host_id>`).
+- Local installation entrypoint remains Carrier CLI/TUI/WebUI (`carrier add <agent>` / `carrier install <agent>`).

--- a/docs/api/remote-sync-api.md
+++ b/docs/api/remote-sync-api.md
@@ -1,28 +1,114 @@
-# Remote Sync API (Gateway)
+# Remote Host and Sync API (Gateway)
 
-These endpoints extend the remote control plane for managed instance profile synchronization.
+This document covers remote host discovery/sync semantics and instance sync actions.
 
-## Endpoints
+## Base Path
 
-- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/sync`
-  - Body: `{ "mode": "always_push|pull_validate_push|manual" }` (optional, default `always_push`)
-  - Response: sync result envelope (`status`, `driftState`, `lastRemoteHash`)
+- `/api/v1/remote/hosts`
 
-- `GET /api/v1/remote/hosts/:hostId/instances/:agentId/sync/status`
-  - Response: persisted sync status for that instance
+## Host Endpoints
 
-- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/diagnose`
-  - Response: drift diagnosis result
+### `POST /api/v1/remote/hosts`
 
-- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/reconcile`
-  - Response: reconcile outcome (`reconciled`, `driftState`)
+Upsert remote host metadata.
 
-- `POST /api/v1/remote/hosts/:hostId/instances/:agentId/rollback`
-  - Body: `{ "commit": "<target-commit>" }` (optional if service can infer latest common commit)
-  - Response: rollback outcome (`rolledBack`, `fromCommit`, `newCommit`)
+Request body (example):
+
+```json
+{
+  "id": "vps-1",
+  "name": "vps-1",
+  "host": "203.0.113.10",
+  "port": 22,
+  "user": "ubuntu",
+  "authMode": "private_key",
+  "keyPath": "~/.ssh/id_ed25519",
+  "runtimeMode": "on_demand"
+}
+```
+
+### `POST /api/v1/remote/hosts/:hostId/check`
+
+Runs host check and remote instance discovery.  
+Supports confirmation-gated pulling for newly discovered instances.
+
+Request body:
+
+```json
+{
+  "pullNewInstances": false,
+  "pullAgentIds": ["picoclaw", "zeroclaw"]
+}
+```
+
+Fields:
+- `pullNewInstances`: when `true`, allows pulling all newly discovered instances.
+- `pullAgentIds`: optional allow-list for selective pull of newly discovered instances.
+
+Response fields:
+- `check`: host health/preflight result
+- `instances`: discovered instances
+- `pendingPullInstances`: newly discovered instances that were not pulled yet
+- `pullConfirmationRequired`: `true` when pending pull confirmation is required
+
+Behavior:
+- First discovery can return pending instances with `pullConfirmationRequired=true`.
+- Caller confirms by re-calling check with `pullNewInstances=true` (or targeted `pullAgentIds`).
+- Already tracked instances continue to sync without new-instance confirmation.
+
+### `GET /api/v1/remote/hosts/:hostId/instances`
+
+List managed instances for the host.
+
+## Instance Sync Endpoints
+
+### `POST /api/v1/remote/hosts/:hostId/instances/:agentId/sync`
+
+Run profile sync for one instance.
+
+Request body:
+
+```json
+{
+  "mode": "always_push"
+}
+```
+
+`mode`:
+- `always_push`
+- `pull_validate_push`
+- `manual`
+
+Response includes sync result envelope (`status`, `driftState`, `lastRemoteHash`).
+
+### `GET /api/v1/remote/hosts/:hostId/instances/:agentId/sync/status`
+
+Returns persisted sync status for the instance.
+
+### `POST /api/v1/remote/hosts/:hostId/instances/:agentId/diagnose`
+
+Returns drift diagnosis result.
+
+### `POST /api/v1/remote/hosts/:hostId/instances/:agentId/reconcile`
+
+Returns reconcile outcome (`reconciled`, `driftState`).
+
+### `POST /api/v1/remote/hosts/:hostId/instances/:agentId/rollback`
+
+Request body:
+
+```json
+{
+  "commit": "<target-commit>"
+}
+```
+
+`commit` is optional when service can infer target rollback point.
+
+Response includes rollback outcome (`rolledBack`, `fromCommit`, `newCommit`).
 
 ## Notes
 
-- Sync status is persisted in remote control store (`instanceSyncs`).
-- `syncMode` now supports `always_push`, `pull_validate_push`, and `manual`.
-- Existing remote host and provider profile APIs remain backward-compatible.
+- Remote sync status is persisted in remote control store (`instanceSyncs`).
+- Existing provider profile APIs remain backward-compatible.
+- Remote OpenClaw installation itself is usually orchestrated through `scripts/remote-openclaw-install.sh`, which wraps these APIs in a deterministic sequence.

--- a/docs/carrier-cli.md
+++ b/docs/carrier-cli.md
@@ -1,107 +1,116 @@
-# Carrier CLI reference
+# Carrier CLI Reference
 
-This page summarizes the implemented CLI command surface and the recommended usage flow.
+This document reflects the current `carrier --help` command surface.
 
-## Command surface
+## Command Surface
+
+### Bootstrap and runtime
 
 - `carrier`
-  - Bootstrap command.
-  - If no onboard config exists, it runs `carrier onboard`.
-  - If already onboarded, it ensures daemon and gateway are running and then exits.
-- `carrier onboard`
-  - Interactive onboarding flow (TUI).
-- `carrier onboard --tui` / `carrier onboard --cli`
-  - Explicit terminal onboarding mode aliases (same terminal flow).
-- `carrier onboard --webui`
-  - Browser/WebUI onboarding flow.
-- `carrier add <agent_id>`
-  - Add/install agent via TUI flow.
-  - Managed agents (`openclaw`, `picoclaw`, `zeroclaw`) use managed-agent setup and instance tracking.
-  - Non-managed agent IDs run direct daemon install + start.
-- `carrier add <agent_id> --tui` / `carrier add <agent_id> --cli`
-  - Explicit terminal add/install mode aliases (same terminal flow).
-- `carrier add <agent_id> --webui`
-  - Browser/WebUI add flow.
-- `carrier install <agent_id>`
-  - Alias for `carrier add <agent_id>`.
-- `carrier install <agent_id> --tui|--cli|--webui`
-  - Alias mode flags for terminal or WebUI install flows.
-- `carrier list`
-  - Lists managed agent instances with state.
-- `carrier stop`
-  - Stops background services started by Carrier: daemon and gateway.
-- `carrier start <id|name>`
-  - Starts one managed agent instance.
-- `carrier stop <id|name>`
-  - Stops one managed agent instance.
-- `carrier status <id|name>`
-  - Shows install/runtime status for one managed agent instance.
-- `carrier upgrade <id|name>`
-  - Upgrades one managed agent instance.
-- `carrier uninstall <id|name>`
-  - Uninstalls and removes a managed agent instance.
+  - Bootstrap entrypoint.
+  - If not onboarded, enters onboarding flow.
+  - If onboarded, ensures daemon + gateway are running and exits.
 - `carrier daemon`
-  - Starts Carrier daemon in the foreground.
+  - Start daemon API server in foreground.
 - `carrier gateway`
-  - Starts Carrier gateway in the foreground.
+  - Start gateway API server in foreground.
+- `carrier stop`
+  - Stop background daemon and gateway services.
+- `carrier version` / `carrier --version` / `carrier -v` / `carrier -V`
+  - Print version metadata.
+- `carrier update [options]`
+  - Update local Carrier to target ref/channel.
 
-## Recommended flow (bootstrap-first)
+### Onboarding
 
-1. `carrier`
-2. `carrier onboard` (Telegram-first TUI flow)
-3. `carrier add <agent_id>`
+- `carrier onboard`
+- `carrier onboard --tui`
+- `carrier onboard --cli`
+- `carrier onboard --webui`
 
-Use `--webui` when interactive terminal access is unavailable or when onboarding needs a browser-assisted path.
+Onboarding writes config to `${CARRIER_CONFIG:-~/.carrier/config.v2.json}`.
 
-## TUI vs WebUI vs chat commands
+### Managed local instance lifecycle
 
-- Use TUI when:
-  - You are running from terminal and can complete setup interactively.
-  - Provider setup is comfortable in terminal.
-- Use WebUI when:
-  - You are doing Telegram-less onboarding (Discord/Feishu) or using managed agents from a browser flow.
-  - Manual setup of provider credentials is needed outside the TUI path.
-- Use chat commands when:
-  - You are already paired in chat and need quick operational commands.
-  - You are not relying on primary CLI onboarding/install flow.
+- `carrier add <agent_id> [--tui|--cli|--webui] [-q|--quiet]`
+- `carrier install <agent_id> [--tui|--cli|--webui] [-q|--quiet]`
+  - Alias of `carrier add`.
+- `carrier list`
+- `carrier start <id|name>`
+- `carrier stop <id|name>`
+- `carrier status <id|name>`
+- `carrier upgrade <id|name>`
+- `carrier uninstall <id|name>`
 
-`/install` and `/onboard` chat commands still parse at gateway level, but onboarding/install actions in chat mode are intentionally blocked (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`) to avoid credential handling in chat. Use `carrier install` / `carrier onboard` (CLI/TUI) or WebUI.
+Managed agent IDs currently include `openclaw`, `picoclaw`, `zeroclaw`.
 
-## Concise example flows
+### Remote instance operations
 
-- Local CLI bootstrap + managed TUI add
+`carrier remote <action> <host_id> <agent_id> [options]`
+
+Supported actions:
+
+- `sync [--mode <always_push|pull_validate_push|manual>]`
+- `sync-status`
+- `diagnose`
+- `reconcile`
+- `rollback [--commit <hash>]`
+- `codeagent-install [--backend <codex|opencode>] [--workspace-root <path>]`
+- `codeagent-configure [--backend <codex|opencode>] [--workspace-root <path>] [--profile-json <json>]`
+- `codeagent-health [--backend <codex|opencode>] [--workspace-root <path>]`
+- `codeagent-version [--backend <codex|opencode>]`
+- `codeagent-run --capability <...> [backend/workspace/options]`
+
+Important:
+- Remote OpenClaw installation itself is currently done by script: `scripts/remote-openclaw-install.sh`.
+- `carrier remote` is currently focused on sync/diagnose/codeagent operations after host/instance is available.
+
+## Recommended Workflows
+
+### Local first-time setup
 
 ```bash
 carrier
 carrier onboard
 carrier add openclaw
 carrier status openclaw
-carrier list
 ```
 
-- Browser/WebUI onboarding + managed add (Discord/Feishu recommended)
+WebUI variant:
 
 ```bash
 carrier onboard --webui
 carrier add openclaw --webui
-carrier list
 ```
 
-- Direct add flow for non-managed agents
+### Install OpenClaw on VPS
 
 ```bash
-carrier add <agent_id>
-carrier stop
-# For managed-instance flows:
-carrier start <id|name>
-carrier stop <id|name>
-carrier status <id|name>
-carrier upgrade <id|name>
-carrier uninstall <id|name>
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519
 ```
 
-## Daemon and gateway helpers
+With selected local config sync:
 
-- `carrier stop` only manages background carrier services and does not remove instance metadata.
-- `carrier start|stop|status|upgrade|uninstall <id|name>` accept either the instance ID or the instance name (for example, `openclaw`).
-- `carrier daemon` and `carrier gateway` are foreground commands and keep process running until interrupted.
+```bash
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519 \
+  --sync-channel telegram \
+  --sync-provider openai-codex
+```
+
+## Behavior Notes
+
+- Gateway default: `http://127.0.0.1:8787`
+- Daemon default: `http://127.0.0.1:9090`
+- Chat `/onboard` is intentionally blocked for credential safety.
+- Chat `/install` is policy-gated; default policy requires explicit host binding and supports remote OpenClaw install (`/install openclaw <host_id>`).
+- For newly discovered remote instances, config pull can require explicit confirmation.

--- a/docs/command-contract.md
+++ b/docs/command-contract.md
@@ -68,7 +68,8 @@ type GatewayResponse = {
 | `E_AUTH_INVALID`                 | Provided session token is invalid                     |
 | `E_PAIR_CODE_INVALID`            | Pairing code is invalid or expired                    |
 | `E_SESSION_REQUIRED`             | Chat is not paired; must run `/pair` first            |
-| `E_INSTALL_GUI_ONLY`            | Chat install is disabled; use Carrier TUI/WebUI       |
+| `E_ADD_GUI_ONLY`                | Chat add/install shortcut is disabled; use Carrier CLI/TUI/WebUI |
+| `E_INSTALL_GUI_ONLY`            | Chat install command is disabled by policy; use Carrier CLI/TUI/WebUI |
 | `E_ONBOARD_GUI_ONLY`            | Chat onboarding is disabled; use Carrier TUI/WebUI    |
 | `E_HOST_BINDING_REQUIRED`        | Install requires a bound/selected remote host         |
 | `E_REMOTE_INSTALL_FAILED`        | Remote host install flow failed                       |
@@ -107,6 +108,16 @@ Lists all known agents and their install status.
 - **Requires session:** yes
 - **Success:** `{ result: "ok", message: "listed <n> agents (<m> installed)" }`
 
+### `/add <agent_id>`
+
+Add/install shortcut in chat context.
+
+- **Args:** `agent_id` (required)
+- **Requires session:** yes
+- **Current behavior:** intentionally blocked for credential safety.
+- **Result:** `{ result: "error", errorCode: "E_ADD_GUI_ONLY", message: "...Use Carrier CLI/TUI..." }`
+- **Alternative flows:** `carrier add <agent_id>` / `carrier install <agent_id>` / WebUI.
+
 ### `/install <agent_id> <host_id>`
 
 Installs an agent.
@@ -115,9 +126,12 @@ Installs an agent.
 - **Requires session:** yes
 - **Policy gate:** behavior is controlled by boundary policy `command_policies.chat_install`.
 - **Current policy value:** `requires_host_binding`.
+- **Default behavior with current policy:**
+  - requires explicit host binding (`/install <agent_id> <host_id>`)
+  - remote install path currently supports `openclaw` only
 - **Success:** `{ result: "ok", message: "remote install completed for <agent_id> on host <host_id>" }`
-- **Errors:** `E_USAGE`, `E_HOST_BINDING_REQUIRED`, `E_REMOTE_HOST_NOT_FOUND`, `E_REMOTE_INSTALL_FAILED`
-- **Notes:** current remote chat install path supports `openclaw` only.
+- **Errors:** `E_USAGE`, `E_INSTALL_GUI_ONLY`, `E_HOST_BINDING_REQUIRED`, `E_REMOTE_HOST_NOT_FOUND`, `E_REMOTE_INSTALL_FAILED`
+- **Notes:** when `chat_install` policy is `disabled`, `/install` returns `E_INSTALL_GUI_ONLY`.
 
 ### `/onboard`
 

--- a/docs/daemon-lifecycle-runtime.md
+++ b/docs/daemon-lifecycle-runtime.md
@@ -79,7 +79,7 @@ Safe local reset procedure:
 sudo systemctl stop carrier-daemon
 sudo rm -f /var/lib/carrier/state.json   # NOTE: this discards pending diagnose-consent records
 sudo systemctl start carrier-daemon
-curl -s http://127.0.0.1:8081/healthz
+curl -s http://127.0.0.1:9090/healthz
 ```
 
 Use the reset flow only for local troubleshooting or planned maintenance windows.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,92 +1,102 @@
-# Production Deployment Guide
+# Carrier Deployment Guide
 
-This guide covers deploying the Carrier daemon (`carrier`) and gateway in a production environment.
+This guide reflects the current runtime model:
+- one `carrier` binary
+- daemon service (`carrier daemon`)
+- gateway service (`carrier gateway`)
 
 Related runbooks:
+- [`docs/runbooks/go-live-rollback.md`](./runbooks/go-live-rollback.md)
+- [`docs/runbooks/pairing-lifecycle.md`](./runbooks/pairing-lifecycle.md)
+- [`docs/ci/first-response-playbook.md`](./ci/first-response-playbook.md)
 
-- Go-live + rollback: `docs/runbooks/go-live-rollback.md`
-- Pairing lifecycle troubleshooting: `docs/runbooks/pairing-lifecycle.md`
-- CI first response: `docs/ci/first-response-playbook.md`
+## 1) Prerequisites
 
-For lifecycle state transitions, crash-loop behavior, and operator troubleshooting, see `docs/daemon-lifecycle-runtime.md`.
+- Linux host (amd64/arm64 recommended for production)
+- systemd
+- dedicated non-root user (example: `carrier`)
+- TLS/ingress policy if exposing gateway outside loopback
 
-## Prerequisites
+## 2) Install Binary
 
-- **Go 1.22+** (build from source) or a pre-built binary
-- **Linux** (amd64 or arm64) — the daemon uses `/proc` for port-occupant detection
-- **systemd** (recommended for service management)
-- A dedicated non-root user (e.g., `carrier`)
+Recommended (release script):
 
-## Build
+```bash
+curl -fsSL https://raw.githubusercontent.com/Keith-CY/carrier/main/scripts/install.sh | bash
+carrier --version
+```
+
+Source build option:
 
 ```bash
 go build -o carrier ./cmd/carrier
-```
-
-## Gateway
-
-The gateway has been rewritten in Go and is now part of the daemon binary.
-No separate build step is required — the daemon serves the gateway API directly.
-
-## Configuration
-
-The daemon reads configuration from a JSON file. Create `/etc/carrier/carrier.json`:
-
-```json
-{
-  "server": {
-    "host": "127.0.0.1",
-    "port": 9090,
-    "api_token": ""
-  },
-  "log": {
-    "level": "info",
-    "format": "json"
-  },
-  "lifecycle": {
-    "crash_threshold": 3,
-    "crash_window": "5m",
-    "crash_cooldown": "5m"
-  }
-}
-```
-
-> **Note:** If `api_token` is set, the config file must have restrictive permissions (`chmod 0600`).
-> See `shared/config/config.go` for all fields and environment variable overrides (`CARRIER_` prefix).
-
-Ensure the data and diagnose directories exist:
-
-```bash
-sudo mkdir -p /var/lib/carrier/{data,diagnose}
-sudo chown carrier:carrier /var/lib/carrier/{data,diagnose}
-```
-
-### Environment Variables
-
-Agent manifests may declare required environment variables. Set them in the systemd unit or a dedicated env file:
-
-```bash
-# /etc/carrier/carrier.env
-# Example — adjust per your agent manifests
-MY_AGENT_API_KEY=changeme
-```
-
-## Installation
-
-```bash
 sudo install -o root -g root -m 0755 carrier /usr/local/bin/carrier
-sudo install -o root -g root -m 0755 carrier-gateway /usr/local/bin/carrier-gateway
 ```
 
-## systemd Service
+## 3) Runtime Configuration
 
-### Daemon (`carrier`)
+Daemon config source:
+- loads `config.json` in current working directory if present
+- then applies `CARRIER_*` env overrides
 
-Create `/etc/systemd/system/carrier-daemon.service`:
+Important daemon env vars:
+- `CARRIER_SERVER_HOST` (default `127.0.0.1`)
+- `CARRIER_SERVER_PORT` (default `9090`)
+- `CARRIER_SERVER_API_TOKEN` (required when binding daemon to non-loopback host)
+
+Important gateway env vars:
+- `CARRIER_GATEWAY_HOST` (default `127.0.0.1`)
+- `CARRIER_GATEWAY_PORT` (default `8787`)
+- `CARRIER_GATEWAY_API_TOKEN` (required when binding gateway to non-loopback host)
+- `CARRIER_DAEMON_BASE_URL` (default `http://127.0.0.1:9090`)
+- `CARRIER_SERVER_API_TOKEN` (gateway->daemon bearer token when daemon token is enabled)
+
+Remote feature flags:
+- `CARRIER_REMOTE_CONTROL_PLANE_ENABLED` (default `true`)
+- `CARRIER_REMOTE_CHAT_ENABLED` (default `true`)
+- `CARRIER_PROVIDER_BINDING_ENABLED` (default `true`)
+
+## 4) systemd Units
+
+Create runtime directories:
+
+```bash
+sudo mkdir -p /var/lib/carrier
+sudo chown carrier:carrier /var/lib/carrier
+```
+
+Optional env file:
+
+```bash
+sudo mkdir -p /etc/carrier
+sudo touch /etc/carrier/carrier.env
+sudo chmod 600 /etc/carrier/carrier.env
+```
+
+Example `/etc/carrier/carrier.env`:
+
+```bash
+# daemon
+CARRIER_SERVER_HOST=127.0.0.1
+CARRIER_SERVER_PORT=9090
+
+# gateway
+CARRIER_GATEWAY_HOST=127.0.0.1
+CARRIER_GATEWAY_PORT=8787
+CARRIER_DAEMON_BASE_URL=http://127.0.0.1:9090
+
+# optional hardening for non-loopback binds
+# CARRIER_SERVER_API_TOKEN=<daemon_token>
+# CARRIER_GATEWAY_API_TOKEN=<gateway_token>
+```
+
+### Daemon unit
+
+`/etc/systemd/system/carrier-daemon.service`
 
 ```ini
 [Unit]
-Description=Carrier Agent Daemon
+Description=Carrier Daemon
 After=network-online.target
 Wants=network-online.target
 
@@ -94,13 +104,11 @@ Wants=network-online.target
 Type=simple
 User=carrier
 Group=carrier
-ExecStart=/usr/local/bin/carrier --config /etc/carrier/carrier.json
+WorkingDirectory=/var/lib/carrier
 EnvironmentFile=-/etc/carrier/carrier.env
+ExecStart=/usr/local/bin/carrier daemon
 Restart=on-failure
 RestartSec=5s
-LimitNOFILE=65536
-
-# Hardening
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -110,9 +118,9 @@ ReadWritePaths=/var/lib/carrier
 WantedBy=multi-user.target
 ```
 
-### Gateway
+### Gateway unit
 
-Create `/etc/systemd/system/carrier-gateway.service`:
+`/etc/systemd/system/carrier-gateway.service`
 
 ```ini
 [Unit]
@@ -124,11 +132,11 @@ Wants=network-online.target
 Type=simple
 User=carrier
 Group=carrier
-ExecStart=/usr/local/bin/carrier-gateway
+WorkingDirectory=/var/lib/carrier
+EnvironmentFile=-/etc/carrier/carrier.env
+ExecStart=/usr/local/bin/carrier gateway
 Restart=on-failure
 RestartSec=5s
-LimitNOFILE=65536
-
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -138,97 +146,82 @@ ReadWritePaths=/var/lib/carrier
 WantedBy=multi-user.target
 ```
 
-### Enable and Start
+Enable/start:
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now carrier-daemon carrier-gateway
 ```
 
-## Health Monitoring
+## 5) Health Checks
 
-The daemon exposes a health endpoint (default port 8081):
+- Daemon: `GET http://127.0.0.1:9090/healthz`
+- Gateway: `GET http://127.0.0.1:8787/healthz`
+
+Readiness:
+- Daemon also exposes `GET /readyz`
+
+Quick verify:
 
 ```bash
-curl -s http://localhost:8081/healthz
+curl -fsS http://127.0.0.1:9090/healthz
+curl -fsS http://127.0.0.1:8787/healthz
 ```
 
-Integrate with your monitoring stack (Prometheus, Datadog, etc.):
+## 6) Upgrade
 
-- **Liveness**: `GET /healthz` — returns 200 when the daemon process is alive
-- **Readiness**: check that agents report `healthy` via the status API
-
-### Alerting Recommendations
-
-| Condition | Alert |
-|-----------|-------|
-| `/healthz` returns non-200 for >30s | Critical |
-| Agent in `crashing` state for >5m | Warning |
-| Audit buffer >80% full | Warning |
-| Disk usage on data dir >90% | Critical |
-
-## Logging
-
-With structured logging enabled (`log_format: "json"`), logs are written to stdout and captured by journald:
+1. install new `carrier` binary
+2. restart services:
 
 ```bash
-journalctl -u carrier-daemon -f --output=json
+sudo systemctl restart carrier-daemon carrier-gateway
 ```
 
-Ship logs to your aggregation platform (ELK, Loki, etc.) via journald or a sidecar.
+3. re-check health endpoints and smoke commands
 
-## Backup
+## 7) Backup and Recovery
 
-### What to Back Up
+Back up at least:
+- `/etc/carrier/`
+- `/var/lib/carrier/`
+- user config under `~/.carrier/` for operator accounts that run local onboarding/control
 
-- `/etc/carrier/` — configuration files and env
-- `/var/lib/carrier/data/` — agent state, manifests, memory store
-- `/var/lib/carrier/diagnose/` — diagnostic bundles and upgrade backups
+Restore:
+1. stop services
+2. restore files
+3. start services
+4. verify `/healthz` and basic command path
 
-### Backup Strategy
+## 8) Remote VPS OpenClaw Deployment
+
+Operationally, remote OpenClaw rollout should use deterministic script flow:
 
 ```bash
-# Daily backup example (add to cron)
-tar czf /backup/carrier-$(date +%Y%m%d).tar.gz \
-  /etc/carrier/ \
-  /var/lib/carrier/data/
+scripts/remote-openclaw-install.sh \
+  --host-id <id> \
+  --host <ip-or-domain> \
+  --port <port> \
+  --user <ssh-user> \
+  --key-path <private-key-path>
 ```
 
-### Restore
+This wraps gateway remote APIs with fixed sequencing and retry behavior.
 
-1. Stop services: `sudo systemctl stop carrier-daemon carrier-gateway`
-2. Restore files from backup
-3. Start services: `sudo systemctl start carrier-daemon carrier-gateway`
-4. Verify health: `curl http://localhost:8081/healthz`
+## 9) Security Considerations
 
-## Upgrade Procedure
+- Run as a non-root user with minimal privileges.
+- Keep `ProtectSystem=strict` and `NoNewPrivileges=true` in systemd units.
+- Rotate secrets in `/etc/carrier/carrier.env` regularly.
+- If daemon/gateway bind to non-loopback, enforce API tokens.
 
-1. Build or download the new binary
-2. Stop the service: `sudo systemctl stop carrier-daemon`
-3. Replace the binary: `sudo install -o root -g root -m 0755 carrier /usr/local/bin/carrier`
-4. Start the service: `sudo systemctl start carrier-daemon`
-5. Verify: `curl http://localhost:8081/healthz`
+### SSH Host Key Verification
 
-For agent upgrades (managed via the lifecycle API), the daemon automatically creates pre-upgrade backups in the diagnose directory.
+Remote control plane SSH uses `StrictHostKeyChecking=accept-new` (TOFU):
+- first-seen host keys are accepted and stored
+- changed host keys are rejected on later connections
 
-## Security Considerations
-
-- Run as a non-root user with minimal privileges
-- Use `ProtectSystem=strict` and `NoNewPrivileges=true` in systemd
-- Rotate secrets in `/etc/carrier/carrier.env` regularly
-- The gateway uses crypto-secure tokens — do not downgrade to sequential generation
-- Review the [security audit](../docs/security-audit-command-execution.md) for command execution hardening
-
-### SSH Remote Control Plane — Host Key Verification
-
-The remote control plane uses `StrictHostKeyChecking=accept-new` for SSH connections,
-which implements Trust-On-First-Use (TOFU): new host keys are automatically accepted
-and saved on first connection, but changed keys are rejected on subsequent connections.
-
-For production deployments, consider pre-populating `~/.ssh/known_hosts` with the
-expected host keys of remote nodes to prevent potential MITM attacks on first connection:
+For production, pre-populate `known_hosts` where possible:
 
 ```bash
-# Pre-populate known_hosts for a remote node
 ssh-keyscan -H <remote-host> >> ~/.ssh/known_hosts
 ```

--- a/docs/runbooks/ec2-binary-tui-validation.md
+++ b/docs/runbooks/ec2-binary-tui-validation.md
@@ -92,8 +92,9 @@ Successful flow should include:
 
 ## 5) Important Behavioral Note
 
-Chat commands `/install` and `/onboard` are intentionally blocked in gateway chat mode (`E_INSTALL_GUI_ONLY` / `E_ONBOARD_GUI_ONLY`).
-
-Use either:
-- TUI (`carrier onboard`, `carrier add picoclaw`, `carrier add openclaw`), or
-- WebUI (`carrier onboard --webui`, `carrier add picoclaw --webui`, `carrier add openclaw --webui`).
+- Chat `/onboard` is intentionally blocked (`E_ONBOARD_GUI_ONLY`).
+- Chat `/install` is policy-gated. With current default policy (`requires_host_binding`), it supports remote OpenClaw install with explicit host binding:
+  - `/install openclaw <host_id>`
+- Local install should still be done with CLI/TUI/WebUI:
+  - TUI: `carrier onboard`, `carrier add picoclaw`, `carrier add openclaw`
+  - WebUI: `carrier onboard --webui`, `carrier add picoclaw --webui`, `carrier add openclaw --webui`

--- a/docs/runbooks/go-live-rollback.md
+++ b/docs/runbooks/go-live-rollback.md
@@ -1,49 +1,60 @@
-# Go-live Checklist and Rollback Steps
+# Go-Live Checklist and Rollback
 
 Source issue: #426
 
 ## Cross-links
 
-- Deployment guide: `docs/deployment.md`
-- Pairing runbook: `docs/runbooks/pairing-lifecycle.md`
-- CI first response: `docs/ci/first-response-playbook.md`
+- Deployment guide: [`docs/deployment.md`](../deployment.md)
+- Pairing runbook: [`docs/runbooks/pairing-lifecycle.md`](./pairing-lifecycle.md)
+- CI first response: [`docs/ci/first-response-playbook.md`](../ci/first-response-playbook.md)
 
 ## Go-live Checklist
 
-1. Confirm CI is green for merge candidate.
-2. Validate daemon and gateway binaries for target platform.
-3. Run smoke path: `carrier add openclaw` -> pair -> start -> status -> logs.
-4. Run remote control plane WebUI smoke:
-   - `#/servers`: create -> edit/update -> check -> delete.
-   - `#/profiles`: create/edit profile -> bind -> delete binding -> profile test with explicit host selection.
-   - `#/remote-chat`: verify stream starts for `target=remote` and `target=local`.
-   - `#/remote-observability`: verify `rollout.state=healthy` before full enablement (`canary` only for limited cohort, `hold` blocks rollout).
-5. Verify WebUI TypeScript build artifact step passes (`bash scripts/build-webui.sh`) and generated `webui/static/*.js` assets are present for packaging.
-6. Verify diagnose path and artifact download URL.
-7. Confirm audit logs are generated for add/install/start/stop/diagnose.
-8. Confirm required secrets/env are present (without printing values).
-9. Confirm monitoring and health endpoint checks are active.
-10. Publish release notes and known limitations.
+1. Confirm required CI checks are green for merge candidate.
+2. Validate target platform binaries (`carrier --version`).
+3. Start services and verify health:
+   - daemon: `http://127.0.0.1:9090/healthz`
+   - gateway: `http://127.0.0.1:8787/healthz`
+4. Run local smoke:
+   - `carrier onboard` (or `carrier onboard --webui`)
+   - `carrier add openclaw`
+   - `carrier status openclaw`
+5. Run remote control-plane smoke:
+   - host create/update/check/delete
+   - provider profile create/edit/test
+   - remote observability rollout card status
+6. Run deterministic remote install smoke:
+   - `scripts/remote-openclaw-install.sh ...`
+   - verify host check returns `openclawFound=true`
+7. Validate first-discovery confirmation path:
+   - newly discovered instances appear in `pendingPullInstances`
+   - confirmation re-check clears pending list
+8. Verify audit logs and diagnose path.
+9. Confirm required secrets/env are present (without printing secret values).
+10. Publish release notes and known limits.
 
 ## Rollback Triggers
 
 - repeated start failures on healthy hosts
 - critical security regression
-- diagnose artifacts missing or corrupted
-- unsupported command failures on core P0 path
+- diagnose artifacts missing/corrupted
+- deterministic remote install path regresses
+- remote discovery/confirmation flow regresses
 
 ## Rollback Procedure
 
 1. Stop rollout and freeze new changes.
 2. Revert to last known good release tag.
-3. Restart daemon/gateway with previous binaries.
-4. Validate health endpoint and P0 command path.
-5. Re-run pairing and one OpenClaw lifecycle smoke test.
-6. Capture incident summary and root-cause tracking issue.
+3. Restart daemon and gateway with previous binary.
+4. Re-verify `/healthz` endpoints.
+5. Re-run one local OpenClaw lifecycle smoke.
+6. Re-run one remote install smoke (`scripts/remote-openclaw-install.sh`).
+7. Capture incident summary and open root-cause tracking issue.
 
 ## Post-Rollback Validation
 
-- `/health` returns healthy.
-- `carrier add openclaw` works in TUI/WebUI.
-- `/pair`, `/start`, `/status`, `/stop` execute normally in chat mode.
-- audit log and diagnose commands remain available.
+- daemon and gateway `/healthz` return `{"status":"ok"}`
+- `carrier add openclaw` works in CLI/TUI/WebUI
+- chat management commands (`/pair`, `/agents`, `/start`, `/status`, `/stop`) work
+- if chat `/install` policy is enabled, `/install openclaw <host_id>` works as expected
+- diagnose and audit paths remain available

--- a/docs/task-first-quickstart.md
+++ b/docs/task-first-quickstart.md
@@ -1,88 +1,117 @@
-# Task-First Quickstart and Troubleshooting
+# Task-First Quickstart
 
-This guide is task-oriented.
-It is the fastest path from clean machine to a working first session.
+This guide is optimized for execution, not architecture reading.
 
-## Task 1: 5-Minute First Setup
+## Task 1: Install Carrier On Local Machine
 
-Prerequisites:
-- Go 1.23+ (matches `daemon/go.mod` / `toolchain go1.23.0`)
-- Bun 1.0+ (required by gateway validation scripts)
-- Repository cloned
+Recommended:
 
-Commands:
 ```bash
-./scripts/run-all-tests.sh
+curl -fsSL https://raw.githubusercontent.com/Keith-CY/carrier/main/scripts/install.sh | bash
+carrier --version
 ```
 
-Expected output:
-- daemon tests pass
-- gateway checks pass
+Source build alternative:
 
-Rollback notes:
-- If any check fails, do not continue with release/install workflows.
-- Move to Task 3 (common failure triage) before retrying.
+```bash
+git clone https://github.com/Keith-CY/carrier.git
+cd carrier
+go build -o ./carrier ./cmd/carrier
+./carrier --version
+```
 
-## Task 2: Connect Provider and Verify Health
+## Task 2: Onboard Carrier
+
+```bash
+# bootstrap
+carrier
+
+# explicit onboarding
+carrier onboard
+```
+
+WebUI flow:
+
+```bash
+carrier onboard --webui
+```
+
+Expected result:
+- onboarding completes without error
+- config exists at `${CARRIER_CONFIG:-~/.carrier/config.v2.json}`
+- gateway health is reachable at `http://127.0.0.1:8787/healthz`
+
+## Task 3: Install OpenClaw Locally
+
+```bash
+carrier add openclaw
+carrier status openclaw
+carrier list
+```
+
+Expected result:
+- `openclaw` exists in managed instance list
+- status is reachable and not in install-pending failure
+
+## Task 4: Install OpenClaw To VPS
 
 Prerequisites:
-- daemon running
-- pairing code available
+- SSH host/user/key ready
+- local gateway running (`carrier` bootstrap can start it)
+- local tools available: `curl`, `jq`
 
-Commands:
-```text
-carrier add openclaw
-/pair <code>
-/agents
-/start openclaw
-/status openclaw
+Minimal flow:
+
+```bash
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519
 ```
 
-Expected output:
-- `carrier add openclaw` completes install/start for OpenClaw
-- `/pair` returns success
-- `/status openclaw` reports running/healthy
+Selected local config sync flow:
 
-Rollback notes:
-- If startup fails, run `/stop openclaw` and then `/diagnose openclaw`.
-- If chat reports `E_INSTALL_GUI_ONLY`, use `carrier add <agent_id>` in TUI/WebUI; chat install is intentionally blocked.
-- Keep diagnose artifacts with request IDs before retrying.
+```bash
+scripts/remote-openclaw-install.sh \
+  --host-id vps-1 \
+  --host 203.0.113.10 \
+  --port 22 \
+  --user ubuntu \
+  --key-path ~/.ssh/id_ed25519 \
+  --sync-channel telegram \
+  --sync-provider openai-codex
+```
 
-## Task 3: Fix Common Failures Quickly
+Expected result:
+- script finishes with `done: remote openclaw install flow succeeded ...`
+- remote host check returns `openclawFound=true`
+- instance list includes `<host-id>:main`
 
-Use this decision table first:
+## Task 5: Validate Full Remote Agent Matrix (Optional)
+
+```bash
+scripts/remote-vps-agent-suite.sh \
+  --host-id vps-1 \
+  --host 127.0.0.1 \
+  --port 2224 \
+  --user carrier \
+  --key-path /tmp/carrier-e2e-keys/id_ed25519
+```
+
+This runs deterministic validation for OpenClaw + PicoClaw + ZeroClaw + codeagent backends.
+
+## Task 6: Common Failures
 
 | Signal | Action |
 |---|---|
-| `E_PAIR_CODE_INVALID` | Request a new pair code and retry `/pair` immediately |
-| `E_SESSION_REQUIRED` | Re-run `/pair <code>` before non-pair commands |
-| start fails with missing env | Set required env vars and retry `/start` |
-| port conflict | stop conflicting process, then retry `/start` |
+| `gateway not healthy` | run `carrier` or `carrier gateway`, then check `http://127.0.0.1:8787/healthz` |
+| SSH check failed | verify host/port/user/key and remote network access |
+| missing local channel/provider during `--sync-*` | complete `carrier onboard` first or pass correct IDs |
+| chat returns `E_ONBOARD_GUI_ONLY` | run onboarding via CLI/TUI/WebUI (`carrier onboard`, `carrier onboard --webui`) |
+| chat `/install` returns `E_HOST_BINDING_REQUIRED` | provide host binding: `/install openclaw <host_id>` |
 
-Detailed references:
-- Pairing failures: [`docs/runbooks/pairing-lifecycle.md`](./runbooks/pairing-lifecycle.md)
-- CI/test failures: [`docs/ci/first-response-playbook.md`](./ci/first-response-playbook.md)
-
-Rollback notes:
-- After one corrected retry, if failure repeats, escalate with request ID and logs.
-
-## Task 4: Safe Upgrade and Rollback
-
-Prerequisites:
-- agent currently installed
-- maintenance window confirmed
-
-Commands:
-```text
-/status openclaw
-/upgrade openclaw
-/status openclaw
-```
-
-Expected output:
-- upgrade succeeds and returns a version bump
-- post-upgrade status is healthy
-
-Rollback notes:
-- If upgrade fails, use captured pre-upgrade backup guidance in error output.
-- Follow runbook: [`docs/runbooks/go-live-rollback.md`](./runbooks/go-live-rollback.md).
+References:
+- CLI command surface: [`docs/carrier-cli.md`](./carrier-cli.md)
+- Pairing lifecycle runbook: [`docs/runbooks/pairing-lifecycle.md`](./runbooks/pairing-lifecycle.md)


### PR DESCRIPTION
## Summary
- rewrite README to remove outdated sections and center executable flows
- explicitly document:
  - install Carrier
  - onboard Carrier
  - install OpenClaw to remote VPS (deterministic script path)
- align docs with current command/runtime behavior:
  - chat `/onboard` blocked
  - chat `/install` policy-gated (default: requires host binding)
  - remote host check confirmation pull fields and semantics
- refresh deployment and runbooks to match current daemon/gateway model

## Updated Docs
- `README.md`
- `docs/carrier-cli.md`
- `docs/task-first-quickstart.md`
- `docs/command-contract.md`
- `docs/api/remote-sync-api.md`
- `docs/deployment.md`
- `docs/runbooks/go-live-rollback.md`
- `docs/runbooks/ec2-binary-tui-validation.md`
- `docs/Agent_Installation_Platform_PRD.md`
- `docs/daemon-lifecycle-runtime.md`

## Validation
- `bash scripts/check-doc-command-sync.sh`
