### PR TITLE
ci: add progress logging to SSH readiness loop in e2e workflow

### DIFF
--- a/.github/workflows/e2e-packaged-binary.yml
+++ b/.github/workflows/e2e-packaged-binary.yml
@@ -420,14 +420,17 @@ jobs:
           }
           trap cleanup EXIT
 
+          echo "Waiting for SSH readiness (up to 60s)..."
           for attempt in $(seq 1 60); do
             if ssh -i "${RUNNER_TEMP}/id_ed25519" -p 2224 -o StrictHostKeyChecking=accept-new -o ConnectTimeout=3 carrier@127.0.0.1 "echo ssh-ready" >/dev/null 2>&1; then
+              echo "SSH ready after ${attempt}s"
               break
             fi
             if [[ "$attempt" -eq 60 ]]; then
               echo "remote VPS SSH endpoint did not become ready in time" >&2
               exit 1
             fi
+            printf "."
             sleep 1
           done
 


### PR DESCRIPTION
Print dots during the SSH wait loop and a final 'SSH ready after Ns' message so CI output clearly shows the wait isn't hung.

Closes #1471