### PR TITLE
fix(ci): repair coverage gate review comment heredoc in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,15 +566,11 @@ jobs:
             exit 0
           fi
 
-          body=$(cat <<EOF
-$marker
-Coverage gate triggered.
-
-Full product (Go modules) coverage: ${current}% (${delta}% vs base).
-
-Policy: request changes when full product coverage drops by 3.00% or more.
-EOF
-)
+          body="$(printf '%s\n%s\n\n%s\n\n%s' \
+            "$marker" \
+            'Coverage gate triggered.' \
+            "Full product (Go modules) coverage: ${current}% (${delta}% vs base)." \
+            'Policy: request changes when full product coverage drops by 3.00% or more.')"
 
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews" \
             -f event=REQUEST_CHANGES \


### PR DESCRIPTION
修复 `.github/workflows/ci.yml` 中 `Coverage Comment` 的 `Request changes` 步骤 heredoc 语法问题，导致该 workflow 解析失败（workflow file issue）。

修复后：
- `body` 字符串改为 `printf` 组装，避免 YAML 对 heredoc 缩进导致的解析误判。
- 覆盖率回退时的 PR Review 留言可正常触发。
- 本地已验证 workflow YAML 可成功解析。
