### PR TITLE
fix: preserve HOME expansion in remote memory contract path

### DIFF
--- a/gateway/remote_openclaw.go
+++ b/gateway/remote_openclaw.go
@@ -1718,14 +1718,11 @@ func shellPathValuePreservingHomeExpansion(path string) string {
 	if trimmed == "" {
 		return shellSingleQuote("")
 	}
-	if trimmed == "$HOME" {
+	if trimmed == "$HOME" || trimmed == "$HOME/" {
 		return `"$HOME"`
 	}
 	if strings.HasPrefix(trimmed, "$HOME/") {
 		suffix := strings.TrimPrefix(trimmed, "$HOME/")
-		if suffix == "" {
-			return `"$HOME"`
-		}
 		return `"$HOME"/` + shellSingleQuote(suffix)
 	}
 	return shellSingleQuote(trimmed)

--- a/gateway/remote_openclaw_test.go
+++ b/gateway/remote_openclaw_test.go
@@ -144,8 +144,12 @@ func TestShellPathValuePreservingHomeExpansion(t *testing.T) {
 		in   string
 		want string
 	}{
+		{name: "empty", in: "", want: "''"},
+		{name: "whitespace", in: "  ", want: "''"},
 		{name: "home only", in: "$HOME", want: `"$HOME"`},
+		{name: "home with slash", in: "$HOME/", want: `"$HOME"`},
 		{name: "home subpath", in: "$HOME/.picoclaw/memory", want: `"$HOME"/'.picoclaw/memory'`},
+		{name: "home subpath with single quote", in: "$HOME/foo'bar", want: `"$HOME"/'foo'\''bar'`},
 		{name: "plain path", in: "/tmp/memory path", want: `'/tmp/memory path'`},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- fix a post-merge regression from #1510 where memory path assignment in remote run/chat prevented `$HOME` expansion
- keep shell hardening while preserving env expansion by splitting `$HOME` prefix and safely quoting only the suffix
- add regression tests for wrapper command generation and path value builder

## Root cause
In `wrapRemoteCommandWithMemoryContract`, switching to full single-quote assignment (`mem_path='/Users/ChenYu/...`) made `$HOME` literal, changing runtime memory location semantics.\n\n## Changes\n- `gateway/remote_openclaw.go`\n  - add `shellPathValuePreservingHomeExpansion`\n  - use it in `wrapRemoteCommandWithMemoryContract`\n- `gateway/remote_openclaw_test.go`\n  - add tests:\n    - `TestWrapRemoteCommandWithMemoryContractPreservesHomeExpansion`\n    - `TestShellPathValuePreservingHomeExpansion`\n\n## Verification\n- `cd gateway && go test ./...`\n\nRelated feedback: https://github.com/Keith-CY/carrier/pull/1510#pullrequestreview-3871710778