### PR TITLE
fix(gateway): stabilize remote SSH check env for uid-only runtime

### DIFF
--- a/gateway/remote_ssh.go
+++ b/gateway/remote_ssh.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,6 +36,7 @@ var knownHostEntryRemover = defaultKnownHostEntryRemover
 
 func defaultSSHExecRunner(ctx context.Context, args []string) (remoteExecResult, error) {
 	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Env = ensureSSHProcessEnv(os.Environ())
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -60,6 +63,7 @@ func defaultSSHExecRunner(ctx context.Context, args []string) (remoteExecResult,
 
 func defaultSSHExecStreamRunner(ctx context.Context, args []string, onChunk func(remoteStreamChunk)) (remoteExecResult, error) {
 	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Env = ensureSSHProcessEnv(os.Environ())
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return remoteExecResult{}, fmt.Errorf("prepare ssh stdout pipe: %w", err)
@@ -315,6 +319,62 @@ func wrapRemoteCommandForSSH(command string) string {
 	}
 	script := "export LC_ALL=C LANG=C; export PATH=\"$HOME/.npm-global/bin:$HOME/.local/bin:$PATH\"; " + cmd
 	return "bash -lc " + shellSingleQuote(script)
+}
+
+func ensureSSHProcessEnv(env []string) []string {
+	out := append([]string{}, env...)
+	if !hasNonEmptyEnv(out, "HOME") {
+		home := strings.TrimSpace(os.Getenv("HOME"))
+		if home == "" {
+			if resolved, err := os.UserHomeDir(); err == nil {
+				home = strings.TrimSpace(resolved)
+			}
+		}
+		if home == "" {
+			if runtime.GOOS == "windows" {
+				if profile := strings.TrimSpace(os.Getenv("USERPROFILE")); profile != "" {
+					home = profile
+				} else if drive, path := strings.TrimSpace(os.Getenv("HOMEDRIVE")), strings.TrimSpace(os.Getenv("HOMEPATH")); drive != "" && path != "" {
+					home = filepath.Clean(drive + path)
+				}
+			} else {
+				switch user := strings.TrimSpace(os.Getenv("USER")); user {
+				case "root", "":
+					home = "/root"
+				default:
+					home = filepath.Join("/home", user)
+				}
+			}
+		}
+		if home == "" {
+			home = "/tmp"
+		}
+		out = append(out, "HOME="+home)
+	}
+	if !hasNonEmptyEnv(out, "USER") {
+		if user := strings.TrimSpace(os.Getenv("USER")); user != "" {
+			out = append(out, "USER="+user)
+		}
+	}
+	if !hasNonEmptyEnv(out, "LOGNAME") {
+		if logname := strings.TrimSpace(os.Getenv("LOGNAME")); logname != "" {
+			out = append(out, "LOGNAME="+logname)
+		}
+	}
+	return out
+}
+
+func hasNonEmptyEnv(env []string, key string) bool {
+	prefix := key + "="
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		if strings.TrimSpace(strings.TrimPrefix(entry, prefix)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldRepairKnownHostMismatch(result remoteExecResult, err error) bool {

--- a/gateway/remote_ssh_test.go
+++ b/gateway/remote_ssh_test.go
@@ -333,3 +333,37 @@ func TestRunRemoteCommandWithRetryStopsOnNonRetryableFailure(t *testing.T) {
 		t.Fatalf("expected exit code from failed command, got %d", res.ExitCode)
 	}
 }
+
+func TestEnsureSSHProcessEnvAddsHomeWhenMissing(t *testing.T) {
+	t.Setenv("HOME", "/tmp/carrier-home")
+	got := ensureSSHProcessEnv([]string{"PATH=/usr/bin"})
+	home, ok := lookupEnvValue(got, "HOME")
+	if !ok {
+		t.Fatalf("expected HOME to be added")
+	}
+	if home != "/tmp/carrier-home" {
+		t.Fatalf("expected HOME=/tmp/carrier-home, got %q", home)
+	}
+}
+
+func TestEnsureSSHProcessEnvPreservesExistingHome(t *testing.T) {
+	got := ensureSSHProcessEnv([]string{"HOME=/already-set", "PATH=/usr/bin"})
+	home, ok := lookupEnvValue(got, "HOME")
+	if !ok {
+		t.Fatalf("expected HOME to exist")
+	}
+	if home != "/already-set" {
+		t.Fatalf("expected HOME to stay /already-set, got %q", home)
+	}
+}
+
+func lookupEnvValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		return strings.TrimPrefix(entry, prefix), true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary
- ensure SSH subprocesses in gateway remote execution always get a stable user env (HOME/USER/LOGNAME)
- prevent remote host check from failing with No user exists for uid 501
- add tests for HOME injection and preserving existing HOME

## Validation
- built patched binary from this branch
- ran carrier remote add openclaw with docker-vps target
- remote add passed full reconnect flow and no longer fails at SSH connectivity check
