### PR TITLE
ci: remove redundant if/else in Windows Compress-Archive step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,11 +365,7 @@ jobs:
 
           # Release package should contain a distributable artifact (Tauri bundle or CLI binary).
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            if [[ -d "dist/${package_source}" ]]; then
-              pwsh -NoProfile -Command "Compress-Archive -Path 'dist/${package_source}' -DestinationPath 'dist/${package_file}' -Force"
-            else
-              pwsh -NoProfile -Command "Compress-Archive -Path 'dist/${package_source}' -DestinationPath 'dist/${package_file}' -Force"
-            fi
+            pwsh -NoProfile -Command "Compress-Archive -Path 'dist/${package_source}' -DestinationPath 'dist/${package_file}' -Force"
           else
             if [[ -d "dist/${package_source}" ]]; then
               (cd dist && zip -r "${package_file}" "${package_source}")


### PR DESCRIPTION
## Summary

Fixes #1546

Both branches of the `if [[ -d ... ]] / else` conditional for the Windows `pwsh` `Compress-Archive` call in `release.yml` executed the exact same command. Since `Compress-Archive -Path` handles both files and directories natively, the conditional is unnecessary.

## Change

Remove the redundant `if [[ -d ... ]] / else` wrapper around the Windows `Compress-Archive` command in `.github/workflows/release.yml`, leaving a single unconditional call — consistent with how `e2e-packaged-binary.yml` already handles it.