### PR TITLE
feat: complete baseagent parity control plane

### DIFF
--- a/baseagent/agent_loop.go
+++ b/baseagent/agent_loop.go
@@ -8,12 +8,16 @@ import (
 
 // AgentLoop orchestrates tool routing, provider fallback, and session tracking.
 type AgentLoop struct {
-	svc       AgentService
-	tools     *ToolRegistry
-	providers *ProviderManager
-	sessions  *SessionManager
-	bus       *MessageBus
-	channels  *ChannelManager
+	svc               AgentService
+	tools             *ToolRegistry
+	providers         *ProviderManager
+	sessions          *SessionManager
+	bus               *MessageBus
+	channels          *ChannelManager
+	executionTools    *ExecutionToolRegistry
+	structuredTools   *structuredToolSurface
+	maxToolIterations int
+	skillsLoader      SkillsLoader
 }
 
 func NewAgentLoop(
@@ -36,16 +40,21 @@ func NewAgentLoop(
 		bus = NewMessageBus(0, 0, 0)
 	}
 	return &AgentLoop{
-		svc:       svc,
-		tools:     tools,
-		providers: providers,
-		sessions:  sessions,
-		bus:       bus,
+		svc:               svc,
+		tools:             tools,
+		providers:         providers,
+		sessions:          sessions,
+		bus:               bus,
+		maxToolIterations: defaultMaxToolIterations,
 	}
 }
 
 func (l *AgentLoop) SetChannelManager(cm *ChannelManager) {
 	l.channels = cm
+}
+
+func (l *AgentLoop) SetSkillsLoader(loader SkillsLoader) {
+	l.skillsLoader = loader
 }
 
 func (l *AgentLoop) ProcessChat(ctx context.Context, req ChatRequest) (ChatResponse, error) {
@@ -69,6 +78,25 @@ func (l *AgentLoop) ProcessChat(ctx context.Context, req ChatRequest) (ChatRespo
 		},
 	})
 	l.sessions.AddMessage(sessionKey, "user", message)
+	skillSummary := ""
+	if l.skillsLoader != nil {
+		skillSummary = strings.TrimSpace(l.skillsLoader.RelevantSkillsSummary(ctx, message))
+	}
+
+	if resp, handled, err := l.handlePendingApprovalInput(ctx, sessionKey, message); handled {
+		if err != nil {
+			l.bus.PublishEvent(LoopEvent{
+				Type:    EventError,
+				Name:    "pending_approval_failed",
+				Message: err.Error(),
+				Metadata: map[string]string{
+					"request_id": requestID,
+				},
+			})
+			return ChatResponse{}, err
+		}
+		return l.finalizeResponse(sessionKey, channel, chatID, requestID, resp), nil
+	}
 
 	if resp, handled, err := l.tools.RouteMessage(ctx, message); handled {
 		if err != nil {
@@ -90,11 +118,27 @@ func (l *AgentLoop) ProcessChat(ctx context.Context, req ChatRequest) (ChatRespo
 		return l.finalizeResponse(sessionKey, channel, chatID, requestID, resp), nil
 	}
 
+	if resp, handled, err := l.processStructuredChat(ctx, sessionKey, l.sessions.History(sessionKey), skillSummary); handled {
+		if err != nil {
+			l.bus.PublishEvent(LoopEvent{
+				Type:    EventError,
+				Name:    "structured_tool_loop_failed",
+				Message: err.Error(),
+				Metadata: map[string]string{
+					"request_id": requestID,
+				},
+			})
+			return ChatResponse{}, err
+		}
+		return l.finalizeResponse(sessionKey, channel, chatID, requestID, resp), nil
+	}
+
 	reply, err := l.providers.Reply(ctx, ProviderRequest{
-		SystemPrompt: baseAgentSystemPrompt,
-		UserMessage:  message,
-		History:      l.sessions.History(sessionKey),
-		Tools:        l.tools.ListToolDescriptors(),
+		SystemPrompt:    composeSkillAwareSystemPrompt(baseAgentSystemPrompt, skillSummary),
+		UserMessage:     message,
+		History:         l.sessions.History(sessionKey),
+		Tools:           l.tools.ListToolDescriptors(),
+		StructuredTools: l.tools.ListStructuredToolDescriptors(),
 	})
 	if err != nil {
 		l.bus.PublishEvent(LoopEvent{
@@ -137,6 +181,45 @@ func (l *AgentLoop) bestEffortAgentStatus(ctx context.Context, rawMessage string
 	return ChatResponse{}, false
 }
 
+func (l *AgentLoop) handlePendingApprovalInput(ctx context.Context, sessionKey, message string) (ChatResponse, bool, error) {
+	if l == nil || l.sessions == nil {
+		return ChatResponse{}, false, nil
+	}
+	pending := l.sessions.PendingApproval(sessionKey)
+	if pending == nil {
+		return ChatResponse{}, false, nil
+	}
+
+	switch {
+	case isApprovalRejection(message):
+		resp, err := l.RespondPendingApproval(ctx, sessionKey, pending.ID, ApprovalDecisionReject)
+		return resp, true, err
+	case !isApprovalConfirmation(message):
+		return ChatResponse{}, false, nil
+	default:
+		resp, err := l.RespondPendingApproval(ctx, sessionKey, pending.ID, ApprovalDecisionConfirm)
+		return resp, true, err
+	}
+}
+
+func isApprovalConfirmation(message string) bool {
+	switch strings.ToLower(strings.TrimSpace(message)) {
+	case "confirm", "approve", "approved", "yes", "yes please", "proceed":
+		return true
+	default:
+		return false
+	}
+}
+
+func isApprovalRejection(message string) bool {
+	switch strings.ToLower(strings.TrimSpace(message)) {
+	case "cancel", "reject", "decline", "no", "no thanks":
+		return true
+	default:
+		return false
+	}
+}
+
 func (l *AgentLoop) finalizeResponse(sessionKey, channel, chatID, requestID string, resp ChatResponse) ChatResponse {
 	if strings.TrimSpace(resp.Message) == "" {
 		resp.Message = "Done."
@@ -164,6 +247,10 @@ func (l *AgentLoop) finalizeResponse(sessionKey, channel, chatID, requestID stri
 		},
 	})
 	return resp
+}
+
+func ResolveSessionKey(provider, chatID string) string {
+	return resolveSessionKey(provider, chatID)
 }
 
 func resolveSessionKey(provider, chatID string) string {

--- a/baseagent/approval_flow.go
+++ b/baseagent/approval_flow.go
@@ -1,0 +1,93 @@
+package baseagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type ApprovalDecision string
+
+const (
+	ApprovalDecisionConfirm ApprovalDecision = "confirm"
+	ApprovalDecisionReject  ApprovalDecision = "reject"
+)
+
+var (
+	ErrPendingApprovalNotFound = errors.New("pending approval not found")
+	ErrInvalidApprovalDecision = errors.New("invalid approval decision")
+)
+
+func (r *Runtime) RespondPendingApproval(ctx context.Context, sessionKey, approvalID string, decision ApprovalDecision) (ChatResponse, error) {
+	if r == nil || r.loop == nil {
+		return ChatResponse{}, fmt.Errorf("base agent runtime is unavailable")
+	}
+	return r.loop.RespondPendingApproval(ctx, sessionKey, approvalID, decision)
+}
+
+func (l *AgentLoop) RespondPendingApproval(ctx context.Context, sessionKey, approvalID string, decision ApprovalDecision) (ChatResponse, error) {
+	if l == nil || l.sessions == nil {
+		return ChatResponse{}, ErrPendingApprovalNotFound
+	}
+
+	normalized, err := normalizeApprovalDecision(decision)
+	if err != nil {
+		return ChatResponse{}, err
+	}
+
+	switch normalized {
+	case ApprovalDecisionReject:
+		pending, ok := l.sessions.ConsumePendingApproval(sessionKey, approvalID)
+		if !ok {
+			return ChatResponse{}, ErrPendingApprovalNotFound
+		}
+		l.sessions.RecordApprovalDecision(sessionKey, pending, approvalDecisionRejected)
+		return ChatResponse{
+			Message: fmt.Sprintf("Canceled pending approval for %s.", pending.ToolName),
+			Action:  "approval_cancel",
+		}, nil
+	case ApprovalDecisionConfirm:
+		if l.structuredTools == nil {
+			return ChatResponse{}, fmt.Errorf("structured tool surface is unavailable")
+		}
+
+		pending, ok := l.sessions.ConsumePendingApproval(sessionKey, approvalID)
+		if !ok {
+			return ChatResponse{}, ErrPendingApprovalNotFound
+		}
+		l.sessions.RecordApprovalDecision(sessionKey, pending, approvalDecisionConfirmed)
+		result := l.structuredTools.ExecuteApproved(ctx, pending.ToolName, pending.Arguments)
+		toolOutput := renderStructuredToolResultOutput(pending.ToolName, result)
+		l.sessions.AddStructuredToolMessage(sessionKey, StructuredToolMessage{
+			Role:             "tool",
+			Content:          toolOutput,
+			ToolName:         strings.TrimSpace(pending.ToolName),
+			ToolResultStatus: normalizeExecutionToolResultStatus(result),
+			ToolPolicyReason: strings.TrimSpace(result.PolicyReason),
+			ToolPolicyRuleID: strings.TrimSpace(result.PolicyRuleID),
+		})
+
+		if resp, handled, err := l.processStructuredChat(ctx, sessionKey, l.sessions.History(sessionKey), ""); handled {
+			resp.Action = "approval_confirm"
+			return resp, err
+		}
+		return ChatResponse{
+			Message: toolOutput,
+			Action:  "approval_confirm",
+		}, nil
+	default:
+		return ChatResponse{}, ErrInvalidApprovalDecision
+	}
+}
+
+func normalizeApprovalDecision(decision ApprovalDecision) (ApprovalDecision, error) {
+	switch ApprovalDecision(strings.ToLower(strings.TrimSpace(string(decision)))) {
+	case ApprovalDecisionConfirm:
+		return ApprovalDecisionConfirm, nil
+	case ApprovalDecisionReject:
+		return ApprovalDecisionReject, nil
+	default:
+		return "", ErrInvalidApprovalDecision
+	}
+}

--- a/baseagent/approval_flow_test.go
+++ b/baseagent/approval_flow_test.go
@@ -1,0 +1,181 @@
+package baseagent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newApprovalRuntimeForTest(t *testing.T) *Runtime {
+	t.Helper()
+
+	provider := &scriptedToolAwareProvider{
+		name: "approval-runtime",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_start",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{
+				Content: "please confirm the pending start",
+			},
+			{
+				Content: "confirmed and started openclaw",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+	return rt
+}
+
+func TestRuntimeRespondPendingApprovalConfirmsSpecificApproval(t *testing.T) {
+	rt := newApprovalRuntimeForTest(t)
+	_, _ = rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "approval-api",
+		Message:  "perform maintenance planning",
+	})
+
+	pending := rt.sessions.PendingApprovals("cli:approval-api")
+	if len(pending) != 1 {
+		t.Fatalf("expected exactly one pending approval, got %+v", pending)
+	}
+	resp, err := rt.RespondPendingApproval(context.Background(), "cli:approval-api", pending[0].ID, ApprovalDecisionConfirm)
+
+	if err != nil || resp.Action != "approval_confirm" {
+		t.Fatalf("expected approval confirm path, got resp=%+v err=%v", resp, err)
+	}
+}
+
+func TestRuntimeRespondPendingApprovalRejectsSpecificApproval(t *testing.T) {
+	rt := newApprovalRuntimeForTest(t)
+	_, _ = rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "approval-reject",
+		Message:  "perform maintenance planning",
+	})
+
+	pending := rt.sessions.PendingApprovals("cli:approval-reject")
+	if len(pending) != 1 {
+		t.Fatalf("expected exactly one pending approval, got %+v", pending)
+	}
+
+	resp, err := rt.RespondPendingApproval(context.Background(), "cli:approval-reject", pending[0].ID, ApprovalDecisionReject)
+	if err != nil {
+		t.Fatalf("reject pending approval: %v", err)
+	}
+	if resp.Action != "approval_cancel" {
+		t.Fatalf("expected approval_cancel action, got %+v", resp)
+	}
+	if got := rt.sessions.PendingApproval("cli:approval-reject"); got != nil {
+		t.Fatalf("expected pending approval to be cleared, got %+v", got)
+	}
+}
+
+func TestRuntimeRespondPendingApprovalRejectsInvalidDecision(t *testing.T) {
+	rt := newApprovalRuntimeForTest(t)
+	_, _ = rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "approval-invalid",
+		Message:  "perform maintenance planning",
+	})
+
+	pending := rt.sessions.PendingApprovals("cli:approval-invalid")
+	if len(pending) != 1 {
+		t.Fatalf("expected exactly one pending approval, got %+v", pending)
+	}
+
+	_, err := rt.RespondPendingApproval(context.Background(), "cli:approval-invalid", pending[0].ID, ApprovalDecision("later"))
+	if !errors.Is(err, ErrInvalidApprovalDecision) {
+		t.Fatalf("expected invalid decision error, got %v", err)
+	}
+}
+
+func TestRuntimeRespondPendingApprovalFailsWhenApprovalMissing(t *testing.T) {
+	rt := newApprovalRuntimeForTest(t)
+	_, _ = rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "approval-missing",
+		Message:  "perform maintenance planning",
+	})
+
+	_, err := rt.RespondPendingApproval(context.Background(), "cli:approval-missing", "approval-missing", ApprovalDecisionConfirm)
+	if !errors.Is(err, ErrPendingApprovalNotFound) {
+		t.Fatalf("expected pending approval not found, got %v", err)
+	}
+}
+
+func TestSessionManagerConsumePendingApprovalOnlySucceedsOnce(t *testing.T) {
+	sm := NewSessionManager(8)
+	sm.SetPendingApproval("cli:atomic", &PendingToolApproval{
+		ID:       "approval-1",
+		ToolName: "agent_start",
+	})
+
+	var wg sync.WaitGroup
+	results := make(chan *PendingToolApproval, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pending, _ := sm.ConsumePendingApproval("cli:atomic", "approval-1")
+			results <- pending
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	for pending := range results {
+		if pending != nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one successful consume, got %d", successes)
+	}
+	if got := sm.PendingApproval("cli:atomic"); got != nil {
+		t.Fatalf("expected pending approval to be cleared after consume, got %+v", got)
+	}
+}
+
+func TestRuntimeRejectsExpiredApproval(t *testing.T) {
+	rt := newApprovalRuntimeForTest(t)
+	now := time.Now().UTC()
+	rt.sessions.SetPendingApprovals("cli:expired", []*PendingToolApproval{
+		{
+			ID:          "approval-expired",
+			ToolName:    "agent_start",
+			RequestedAt: now.Add(-10 * time.Minute),
+			ExpiresAt:   now.Add(-time.Minute),
+			Reason:      "Agent lifecycle mutation requires confirmation.",
+			RuleID:      structuredPolicyRuleAgentConfirmation,
+		},
+	})
+
+	_, err := rt.RespondPendingApproval(context.Background(), "cli:expired", "approval-expired", ApprovalDecisionConfirm)
+	if !errors.Is(err, ErrPendingApprovalNotFound) {
+		t.Fatalf("expected missing approval error for expired approval, got %v", err)
+	}
+
+	audit := rt.sessions.ApprovalAudit("cli:expired")
+	if len(audit) != 1 || audit[0].Decision != approvalDecisionExpired {
+		t.Fatalf("expected expired approval audit entry, got %+v", audit)
+	}
+}

--- a/baseagent/approval_store_test.go
+++ b/baseagent/approval_store_test.go
@@ -1,0 +1,39 @@
+package baseagent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionManagerStoresMultiplePendingApprovalsWithExpiry(t *testing.T) {
+	sm := NewSessionManager(8)
+	now := time.Now().UTC()
+	sm.SetPendingApprovals("cli:multi", []*PendingToolApproval{
+		{ID: "a1", ToolName: "exec", RequestedAt: now, ExpiresAt: now.Add(5 * time.Minute)},
+		{ID: "a2", ToolName: "agent_start", RequestedAt: now, ExpiresAt: now.Add(5 * time.Minute)},
+	})
+
+	got := sm.PendingApprovals("cli:multi")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 pending approvals, got %+v", got)
+	}
+}
+
+func TestSessionManagerPrunesExpiredPendingApprovalsIntoAudit(t *testing.T) {
+	sm := NewSessionManager(8)
+	now := time.Now().UTC()
+	sm.SetPendingApprovals("cli:expiry", []*PendingToolApproval{
+		{ID: "expired", ToolName: "exec", RequestedAt: now.Add(-10 * time.Minute), ExpiresAt: now.Add(-time.Minute), Reason: "Shell execution requires confirmation.", RuleID: structuredPolicyRuleExecConfirmationNeeded},
+		{ID: "live", ToolName: "agent_start", RequestedAt: now, ExpiresAt: now.Add(5 * time.Minute)},
+	})
+
+	got := sm.PendingApprovals("cli:expiry")
+	if len(got) != 1 || got[0].ID != "live" {
+		t.Fatalf("expected only live approval to remain pending, got %+v", got)
+	}
+
+	audit := sm.ApprovalAudit("cli:expiry")
+	if len(audit) != 1 || audit[0].ID != "expired" || audit[0].Decision != approvalDecisionExpired {
+		t.Fatalf("expected expired approval to be recorded in audit, got %+v", audit)
+	}
+}

--- a/baseagent/boundary_spec.go
+++ b/baseagent/boundary_spec.go
@@ -41,16 +41,25 @@ type RepairPolicy struct {
 	HighRiskRequiresConfirmation bool     `json:"high_risk_requires_confirmation"`
 }
 
+type StructuredToolPolicySpec struct {
+	MetadataReadDecision      string `json:"metadata_read_decision"`
+	OperationalReadDecision   string `json:"operational_read_decision"`
+	WorkspaceReadDecision     string `json:"workspace_read_decision"`
+	WorkspaceMutationDecision string `json:"workspace_mutation_decision"`
+	HighRiskDecision          string `json:"high_risk_decision"`
+}
+
 type BoundarySpec struct {
-	SchemaVersion    string                    `json:"schema_version"`
-	AssistantRole    string                    `json:"assistant_role"`
-	InScope          []string                  `json:"in_scope"`
-	OutOfScope       []string                  `json:"out_of_scope"`
-	BoundarySources  []string                  `json:"boundary_sources"`
-	DesignPrinciples []string                  `json:"design_principles"`
-	CommandPolicies  CommandPolicies           `json:"command_policies"`
-	WorkflowPolicies map[string]WorkflowPolicy `json:"workflow_policies"`
-	RepairPolicy     RepairPolicy              `json:"repair_policy"`
+	SchemaVersion        string                    `json:"schema_version"`
+	AssistantRole        string                    `json:"assistant_role"`
+	InScope              []string                  `json:"in_scope"`
+	OutOfScope           []string                  `json:"out_of_scope"`
+	BoundarySources      []string                  `json:"boundary_sources"`
+	DesignPrinciples     []string                  `json:"design_principles"`
+	StructuredToolPolicy StructuredToolPolicySpec  `json:"structured_tool_policy"`
+	CommandPolicies      CommandPolicies           `json:"command_policies"`
+	WorkflowPolicies     map[string]WorkflowPolicy `json:"workflow_policies"`
+	RepairPolicy         RepairPolicy              `json:"repair_policy"`
 }
 
 //go:embed spec/baseagent-boundary.v1.json
@@ -101,6 +110,9 @@ func ValidateBoundarySpec(spec BoundarySpec) error {
 	}
 	if len(spec.DesignPrinciples) == 0 {
 		return fmt.Errorf("design_principles must not be empty")
+	}
+	if err := ValidateStructuredToolPolicySpec(spec.StructuredToolPolicy); err != nil {
+		return err
 	}
 	if !isValidChatPolicyMode(spec.CommandPolicies.ChatInstall) {
 		return fmt.Errorf("command_policies.chat_install has invalid mode %q", spec.CommandPolicies.ChatInstall)
@@ -157,6 +169,14 @@ func (s BoundarySpec) RenderSummary() string {
 	lines = append(lines, prefixLines(spec.BoundarySources)...)
 	lines = append(lines, "Design principles:")
 	lines = append(lines, prefixLines(spec.DesignPrinciples)...)
+	lines = append(lines, "Structured tool policy:")
+	lines = append(lines,
+		fmt.Sprintf("- metadata_read=%s", spec.StructuredToolPolicy.MetadataReadDecision),
+		fmt.Sprintf("- operational_read=%s", spec.StructuredToolPolicy.OperationalReadDecision),
+		fmt.Sprintf("- workspace_read=%s", spec.StructuredToolPolicy.WorkspaceReadDecision),
+		fmt.Sprintf("- workspace_mutation=%s", spec.StructuredToolPolicy.WorkspaceMutationDecision),
+		fmt.Sprintf("- high_risk=%s", spec.StructuredToolPolicy.HighRiskDecision),
+	)
 	lines = append(lines,
 		fmt.Sprintf("Chat install policy: %s", spec.CommandPolicies.ChatInstall),
 		fmt.Sprintf("Chat onboard policy: %s", spec.CommandPolicies.ChatOnboard),
@@ -190,28 +210,65 @@ func isValidChatPolicyMode(mode string) bool {
 	}
 }
 
+func ValidateStructuredToolPolicySpec(spec StructuredToolPolicySpec) error {
+	if !isValidStructuredToolDecisionMode(spec.MetadataReadDecision) {
+		return fmt.Errorf("structured_tool_policy.metadata_read_decision has invalid mode %q", spec.MetadataReadDecision)
+	}
+	if !isValidStructuredToolDecisionMode(spec.OperationalReadDecision) {
+		return fmt.Errorf("structured_tool_policy.operational_read_decision has invalid mode %q", spec.OperationalReadDecision)
+	}
+	if !isValidStructuredToolDecisionMode(spec.WorkspaceReadDecision) {
+		return fmt.Errorf("structured_tool_policy.workspace_read_decision has invalid mode %q", spec.WorkspaceReadDecision)
+	}
+	if !isValidStructuredToolDecisionMode(spec.WorkspaceMutationDecision) {
+		return fmt.Errorf("structured_tool_policy.workspace_mutation_decision has invalid mode %q", spec.WorkspaceMutationDecision)
+	}
+	if !isValidStructuredToolDecisionMode(spec.HighRiskDecision) {
+		return fmt.Errorf("structured_tool_policy.high_risk_decision has invalid mode %q", spec.HighRiskDecision)
+	}
+	return nil
+}
+
+func isValidStructuredToolDecisionMode(mode string) bool {
+	switch parseStructuredToolDecision(mode) {
+	case structuredToolDecisionAllow, structuredToolDecisionAsk, structuredToolDecisionDeny:
+		return true
+	default:
+		return false
+	}
+}
+
 func fallbackBoundarySpec() BoundarySpec {
 	return BoundarySpec{
 		SchemaVersion: boundarySpecSchemaV1,
-		AssistantRole: "Carrier product-specific assistant for controlled agent installation and maintenance.",
+		AssistantRole: "Carrier product-specific assistant for controlled agent maintenance and bounded workspace automation.",
 		InScope: []string{
 			"Understand user intent and map it to approved install/maintenance workflows.",
 			"Run policy-bounded lifecycle operations for agent instances.",
+			"Inspect, create, edit, append, and list files inside the configured workspace root.",
+			"Run bounded shell commands inside the configured workspace root when a chat task needs local execution.",
 			"Collect logs and escalate unresolved failures with diagnose artifacts.",
 		},
 		OutOfScope: []string{
-			"Arbitrary free-form shell execution outside approved workflows.",
+			"Arbitrary shell or file execution outside the configured workspace root.",
 			"Automatic destructive changes without explicit user confirmation.",
 		},
 		BoundarySources: []string{
 			"System/runtime constraints.",
-			"Tool and command allowlists.",
+			"Tool allowlists, workspace confinement, and execution safety guards.",
 			"Daemon API contracts and workflow checks.",
 		},
 		DesignPrinciples: []string{
 			"Least privilege by default.",
-			"Deterministic command surface.",
+			"Deterministic command surface with workspace confinement.",
 			"Auditability for lifecycle and repair operations.",
+		},
+		StructuredToolPolicy: StructuredToolPolicySpec{
+			MetadataReadDecision:      string(structuredToolDecisionAllow),
+			OperationalReadDecision:   string(structuredToolDecisionAllow),
+			WorkspaceReadDecision:     string(structuredToolDecisionAllow),
+			WorkspaceMutationDecision: string(structuredToolDecisionAllow),
+			HighRiskDecision:          string(structuredToolDecisionAsk),
 		},
 		CommandPolicies: CommandPolicies{
 			ChatInstall:                      chatPolicyRequiresHostBinding,

--- a/baseagent/boundary_spec_test.go
+++ b/baseagent/boundary_spec_test.go
@@ -1,6 +1,7 @@
 package baseagent
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -25,6 +26,7 @@ func TestBoundarySpec_RenderSummary(t *testing.T) {
 	wants := []string{
 		"BaseAgent boundaries:",
 		"Chat install policy:",
+		"Structured tool policy:",
 		"Workflow policies:",
 		"install_openclaw_remote_vps",
 	}
@@ -32,6 +34,17 @@ func TestBoundarySpec_RenderSummary(t *testing.T) {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("summary missing %q\nsummary:\n%s", want, summary)
 		}
+	}
+}
+
+func TestStructuredToolSurfaceReadsPolicyFromBoundarySpec(t *testing.T) {
+	spec := ActiveBoundarySpec()
+	spec.StructuredToolPolicy.HighRiskDecision = string(structuredToolDecisionDeny)
+
+	surface := newStructuredToolSurfaceWithPolicy(NewToolRegistry(), NewExecutionToolRegistry(t.TempDir()), nil, spec.StructuredToolPolicy)
+	result := surface.Execute(context.Background(), "exec", map[string]any{"command": "go test ./..."})
+	if result.Status != ExecutionToolResultStatusDeny {
+		t.Fatalf("expected boundary policy to drive deny, got %+v", result)
 	}
 }
 
@@ -43,6 +56,13 @@ func TestParseBoundarySpec_RejectsInvalidChatInstallMode(t *testing.T) {
 		"out_of_scope":["b"],
 		"boundary_sources":["c"],
 		"design_principles":["d"],
+		"structured_tool_policy":{
+			"metadata_read_decision":"allow",
+			"operational_read_decision":"allow",
+			"workspace_read_decision":"allow",
+			"workspace_mutation_decision":"allow",
+			"high_risk_decision":"ask"
+		},
 		"command_policies":{"chat_install":"invalid","chat_onboard":"disabled","requires_explicit_host_for_remote_workflows":true},
 		"workflow_policies":{"wf":{"enabled":true,"requires_host_binding":true,"requires_preflight":true,"max_attempts":1,"auto_escalate_to_diagnose":true,"high_risk_actions_require_confirmation":true}},
 		"repair_policy":{"max_auto_repair_rounds":1,"high_risk_path_prefixes":["/etc"],"blocked_substrings":[],"high_risk_requires_confirmation":true}

--- a/baseagent/builtin_tools.go
+++ b/baseagent/builtin_tools.go
@@ -26,6 +26,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "list_agents",
 		Description: "List currently registered agents and health/runtime status.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			if lower == "/agents" || lower == "/list agents" || lower == "/agents list" {
@@ -50,6 +54,19 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "agent_action",
 		Description: "Run an agent lifecycle action (start/stop/status/logs/upgrade/diagnose/uninstall).",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]any{
+					"type": "string",
+					"enum": []string{"start", "stop", "status", "logs", "upgrade", "diagnose", "uninstall"},
+				},
+				"agent_id": map[string]any{
+					"type": "string",
+				},
+			},
+			"required": []string{"action", "agent_id"},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			return matchAgentActionInvocation(input)
 		},
@@ -76,6 +93,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "help",
 		Description: "Show base-agent usage commands.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			switch lower {
@@ -92,6 +113,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "list_tools",
 		Description: "List internal tool capabilities available to base-agent.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			if lower == "/tools" || lower == "list tools" || lower == "show tools" {
@@ -100,8 +125,12 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 			return ToolInvocation{}, false
 		},
 		Run: func(_ context.Context, _ ToolInvocation) (ChatResponse, error) {
+			summary := registry.RenderToolSummary()
+			if rt != nil {
+				summary = rt.renderToolSummary()
+			}
 			return ChatResponse{
-				Message: registry.RenderToolSummary(),
+				Message: summary,
 				Action:  "tools",
 			}, nil
 		},
@@ -110,6 +139,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "list_providers",
 		Description: "List configured provider backends and current active provider.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			if lower == "/providers" || lower == "list providers" || lower == "show providers" {
@@ -143,6 +176,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "list_sessions",
 		Description: "Show recent chat sessions and compaction state.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			if lower == "/sessions" || lower == "list sessions" || lower == "show sessions" {
@@ -176,6 +213,10 @@ func newBuiltinToolRegistry(rt *Runtime, providers *ProviderManager, sessions *S
 	mustRegisterTool(registry, ToolSpec{
 		Name:        "show_boundaries",
 		Description: "Explain base-agent capability boundaries, sources, and design rationale.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
 		Match: func(input string) (ToolInvocation, bool) {
 			lower := strings.ToLower(strings.TrimSpace(input))
 			if lower == "/boundaries" || lower == "show boundaries" || lower == "list boundaries" || lower == "what are your boundaries" {

--- a/baseagent/controlplane_providers.go
+++ b/baseagent/controlplane_providers.go
@@ -2,13 +2,63 @@ package baseagent
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 const maxProviderHistoryMessageLength = 220
+
+type ProviderErrorKind string
+
+const (
+	ProviderErrorRetriable    ProviderErrorKind = "retriable"
+	ProviderErrorNonRetriable ProviderErrorKind = "non_retriable"
+)
+
+type classifiedProviderError struct {
+	kind ProviderErrorKind
+	err  error
+}
+
+func (e *classifiedProviderError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *classifiedProviderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func (e *classifiedProviderError) Kind() ProviderErrorKind {
+	if e == nil {
+		return ProviderErrorRetriable
+	}
+	return e.kind
+}
+
+func RetriableProviderError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &classifiedProviderError{kind: ProviderErrorRetriable, err: err}
+}
+
+func NonRetriableProviderError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &classifiedProviderError{kind: ProviderErrorNonRetriable, err: err}
+}
 
 // ToolDescriptor is a compact tool description used in provider prompting.
 type ToolDescriptor struct {
@@ -18,10 +68,11 @@ type ToolDescriptor struct {
 
 // ProviderRequest is the normalized provider request envelope for agent replies.
 type ProviderRequest struct {
-	SystemPrompt string
-	UserMessage  string
-	History      []ConversationMessage
-	Tools        []ToolDescriptor
+	SystemPrompt    string
+	UserMessage     string
+	History         []ConversationMessage
+	Tools           []ToolDescriptor
+	StructuredTools []StructuredToolDescriptor
 }
 
 // Provider abstracts a chat backend.
@@ -108,11 +159,17 @@ type ProviderManager struct {
 	mu        sync.RWMutex
 	providers map[string]Provider
 	active    string
+	cooldown  time.Duration
+	now       func() time.Time
+	blocked   map[string]time.Time
 }
 
 func NewProviderManager(defaultProvider Provider) *ProviderManager {
 	pm := &ProviderManager{
 		providers: map[string]Provider{},
+		cooldown:  time.Minute,
+		now:       time.Now,
+		blocked:   map[string]time.Time{},
 	}
 	if defaultProvider != nil {
 		name := strings.ToLower(strings.TrimSpace(defaultProvider.Name()))
@@ -186,14 +243,188 @@ func (pm *ProviderManager) Reply(ctx context.Context, req ProviderRequest) (stri
 	if pm == nil {
 		return "", fmt.Errorf("provider manager is nil")
 	}
-	pm.mu.RLock()
-	active := pm.active
-	provider := pm.providers[active]
-	pm.mu.RUnlock()
-	if provider == nil {
+	if err := providerContextError(ctx); err != nil {
+		return "", err
+	}
+	candidates := pm.availableProviders()
+	if len(candidates) == 0 {
 		return "", fmt.Errorf("no active provider is configured")
 	}
-	return provider.Reply(ctx, req)
+	var lastErr error
+	for _, candidate := range candidates {
+		if err := providerContextError(ctx); err != nil {
+			return "", err
+		}
+		reply, err := candidate.provider.Reply(ctx, req)
+		if err == nil && strings.TrimSpace(reply) != "" {
+			pm.markProviderSuccess(candidate.name)
+			return strings.TrimSpace(reply), nil
+		}
+		if err != nil {
+			if ctxErr := context.Cause(ctx); ctxErr != nil {
+				return "", ctxErr
+			}
+			pm.markProviderFailure(candidate.name, err)
+			lastErr = err
+			continue
+		}
+		pm.markProviderFailure(candidate.name, nil)
+		lastErr = fmt.Errorf("provider %s returned no content", candidate.name)
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("provider chain returned no content")
+}
+
+func (pm *ProviderManager) ReplyWithTools(ctx context.Context, req StructuredToolRequest) (StructuredToolReply, error) {
+	if pm == nil {
+		return StructuredToolReply{}, fmt.Errorf("provider manager is nil")
+	}
+	if err := providerContextError(ctx); err != nil {
+		return StructuredToolReply{}, err
+	}
+	candidates := pm.availableProviders()
+	if len(candidates) == 0 {
+		return StructuredToolReply{}, fmt.Errorf("no active provider is configured")
+	}
+	var lastErr error
+	for _, candidate := range candidates {
+		if err := providerContextError(ctx); err != nil {
+			return StructuredToolReply{}, err
+		}
+		reply, err := pm.replyWithToolsFromProvider(ctx, candidate.provider, req)
+		if err == nil && structuredReplyHasContent(reply) {
+			pm.markProviderSuccess(candidate.name)
+			return reply, nil
+		}
+		if err != nil {
+			if ctxErr := context.Cause(ctx); ctxErr != nil {
+				return StructuredToolReply{}, ctxErr
+			}
+			pm.markProviderFailure(candidate.name, err)
+			lastErr = err
+			continue
+		}
+		pm.markProviderFailure(candidate.name, nil)
+		lastErr = fmt.Errorf("provider %s returned no tool reply", candidate.name)
+	}
+	if lastErr != nil {
+		return StructuredToolReply{}, lastErr
+	}
+	return StructuredToolReply{}, fmt.Errorf("provider chain returned no tool reply")
+}
+
+type providerCandidate struct {
+	name     string
+	provider Provider
+}
+
+func (pm *ProviderManager) availableProviders() []providerCandidate {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	now := time.Now()
+	if pm.now != nil {
+		now = pm.now()
+	}
+
+	orderedNames := make([]string, 0, len(pm.providers))
+	for name := range pm.providers {
+		orderedNames = append(orderedNames, name)
+	}
+	sort.Strings(orderedNames)
+
+	candidates := make([]providerCandidate, 0, len(orderedNames))
+	appendCandidate := func(name string) {
+		provider := pm.providers[name]
+		if provider == nil {
+			return
+		}
+		if until, ok := pm.blocked[name]; ok && until.After(now) {
+			return
+		}
+		candidates = append(candidates, providerCandidate{name: name, provider: provider})
+	}
+
+	active := strings.TrimSpace(pm.active)
+	if active != "" {
+		appendCandidate(active)
+	}
+	for _, name := range orderedNames {
+		if name == active {
+			continue
+		}
+		appendCandidate(name)
+	}
+	return candidates
+}
+
+func (pm *ProviderManager) markProviderFailure(name string, err error) {
+	if pm == nil {
+		return
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	if !providerErrorShouldCooldown(err) {
+		delete(pm.blocked, name)
+		return
+	}
+	if pm.cooldown <= 0 {
+		return
+	}
+	now := time.Now()
+	if pm.now != nil {
+		now = pm.now()
+	}
+	pm.blocked[name] = now.Add(pm.cooldown)
+}
+
+func (pm *ProviderManager) markProviderSuccess(name string) {
+	if pm == nil {
+		return
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.blocked, name)
+	if name != "" {
+		pm.active = name
+	}
+}
+
+func (pm *ProviderManager) replyWithToolsFromProvider(ctx context.Context, provider Provider, req StructuredToolRequest) (StructuredToolReply, error) {
+	if aware, ok := provider.(ToolAwareProvider); ok {
+		return aware.ReplyWithTools(ctx, req)
+	}
+	return replyWithToolsViaTextProvider(ctx, provider, req)
+}
+
+func structuredReplyHasContent(reply StructuredToolReply) bool {
+	if strings.TrimSpace(reply.Content) != "" {
+		return true
+	}
+	return len(reply.ToolCalls) > 0
+}
+
+func providerContextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+func providerErrorShouldCooldown(err error) bool {
+	if err == nil {
+		return true
+	}
+	var classified *classifiedProviderError
+	if errors.As(err, &classified) {
+		return classified.Kind() != ProviderErrorNonRetriable
+	}
+	return true
 }
 
 // LLMProviderAdapter wraps baseagent requestLLMCompletion as a provider.
@@ -227,26 +458,56 @@ func (p *LLMProviderAdapter) Reply(ctx context.Context, req ProviderRequest) (st
 	if history := renderProviderHistory(req.History, p.historyWindow); history != "" {
 		prompt = "Conversation context:\n" + history + "\n\nCurrent user message:\n" + user
 	}
-	if len(req.Tools) > 0 {
-		toolLines := make([]string, 0, len(req.Tools))
-		for _, t := range req.Tools {
-			name := strings.TrimSpace(t.Name)
-			if name == "" {
-				continue
-			}
-			desc := strings.TrimSpace(t.Description)
-			if desc == "" {
-				toolLines = append(toolLines, "- "+name)
-			} else {
-				toolLines = append(toolLines, "- "+name+": "+desc)
-			}
-		}
+	toolLines := renderStructuredToolLines(req.StructuredTools)
+	if len(toolLines) == 0 {
+		toolLines = renderCompactToolLines(req.Tools)
+	}
+	if len(toolLines) > 0 {
 		if len(toolLines) > 0 {
 			prompt += "\n\nAvailable built-in tools:\n" + strings.Join(toolLines, "\n")
 		}
 	}
 
 	return requestLLMCompletionForProvider(ctx, p.name, req.SystemPrompt, prompt)
+}
+
+func renderCompactToolLines(tools []ToolDescriptor) []string {
+	lines := make([]string, 0, len(tools))
+	for _, t := range tools {
+		name := strings.TrimSpace(t.Name)
+		if name == "" {
+			continue
+		}
+		desc := strings.TrimSpace(t.Description)
+		if desc == "" {
+			lines = append(lines, "- "+name)
+		} else {
+			lines = append(lines, "- "+name+": "+desc)
+		}
+	}
+	return lines
+}
+
+func renderStructuredToolLines(tools []StructuredToolDescriptor) []string {
+	lines := make([]string, 0, len(tools))
+	for _, t := range tools {
+		name := strings.TrimSpace(t.Name)
+		if name == "" {
+			continue
+		}
+		line := "- " + name
+		desc := strings.TrimSpace(t.Description)
+		if desc != "" {
+			line += ": " + desc
+		}
+		if len(t.Parameters) > 0 {
+			if raw, err := json.Marshal(t.Parameters); err == nil {
+				line += " | parameters=" + string(raw)
+			}
+		}
+		lines = append(lines, line)
+	}
+	return lines
 }
 
 func renderProviderHistory(history []ConversationMessage, window int) string {

--- a/baseagent/controlplane_sessions.go
+++ b/baseagent/controlplane_sessions.go
@@ -1,7 +1,10 @@
 package baseagent
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -12,6 +15,8 @@ const (
 	defaultSessionMaxMessages = 48
 	maxSessionSummaryBytes    = 4096
 	maxCompactNoteContentSize = 140
+	defaultPendingApprovalTTL = 15 * time.Minute
+	maxApprovalAuditEntries   = 32
 )
 
 // ConversationMessage is a normalized message representation stored per session.
@@ -21,13 +26,35 @@ type ConversationMessage struct {
 	Timestamp time.Time
 }
 
+type PendingToolApproval struct {
+	ID          string
+	ToolName    string
+	Arguments   map[string]any
+	RequestedAt time.Time
+	ExpiresAt   time.Time
+	ResolvedAt  time.Time
+	Decision    string
+	Reason      string
+	RuleID      string
+}
+
+const (
+	approvalDecisionConfirmed = "confirmed"
+	approvalDecisionRejected  = "rejected"
+	approvalDecisionExpired   = "expired"
+)
+
 // ConversationSession contains the per-session transcript and compacted summary.
 type ConversationSession struct {
-	Key       string
-	Messages  []ConversationMessage
-	Summary   string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Key                string
+	Messages           []ConversationMessage
+	StructuredMessages []StructuredToolMessage
+	Summary            string
+	PendingApproval    *PendingToolApproval
+	PendingApprovals   []*PendingToolApproval
+	ApprovalAudit      []*PendingToolApproval
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 // SessionStats summarizes session utilization.
@@ -43,6 +70,7 @@ type SessionManager struct {
 	mu          sync.RWMutex
 	sessions    map[string]*ConversationSession
 	maxMessages int
+	storageDir  string
 }
 
 func NewSessionManager(maxMessages int) *SessionManager {
@@ -53,6 +81,17 @@ func NewSessionManager(maxMessages int) *SessionManager {
 		sessions:    map[string]*ConversationSession{},
 		maxMessages: maxMessages,
 	}
+}
+
+func NewSessionManagerWithStorage(maxMessages int, storageDir string) *SessionManager {
+	sm := NewSessionManager(maxMessages)
+	sm.storageDir = strings.TrimSpace(storageDir)
+	if sm.storageDir == "" {
+		return sm
+	}
+	_ = os.MkdirAll(sm.storageDir, 0o755)
+	sm.loadFromStorage()
+	return sm
 }
 
 func (sm *SessionManager) AddMessage(sessionKey, role, content string) {
@@ -70,13 +109,34 @@ func (sm *SessionManager) AddMessage(sessionKey, role, content string) {
 	defer sm.mu.Unlock()
 
 	s := sm.getOrCreateLocked(sessionKey, now)
-	s.Messages = append(s.Messages, ConversationMessage{
-		Role:      role,
-		Content:   strings.TrimSpace(content),
-		Timestamp: now,
-	})
+	sm.appendStructuredMessageLocked(s, StructuredToolMessage{
+		Role:    role,
+		Content: strings.TrimSpace(content),
+	}, now)
 	s.UpdatedAt = now
 	sm.compactLocked(s)
+	sm.persistSessionLocked(s)
+}
+
+func (sm *SessionManager) AddStructuredToolMessage(sessionKey string, msg StructuredToolMessage) {
+	if sm == nil {
+		return
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	msg = normalizeStructuredToolMessage(msg)
+	if sessionKey == "" || msg.Role == "" {
+		return
+	}
+
+	now := time.Now().UTC()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	s := sm.getOrCreateLocked(sessionKey, now)
+	sm.appendStructuredMessageLocked(s, msg, now)
+	s.UpdatedAt = now
+	sm.compactLocked(s)
+	sm.persistSessionLocked(s)
 }
 
 func (sm *SessionManager) History(sessionKey string) []ConversationMessage {
@@ -93,6 +153,20 @@ func (sm *SessionManager) History(sessionKey string) []ConversationMessage {
 	out := make([]ConversationMessage, len(s.Messages))
 	copy(out, s.Messages)
 	return out
+}
+
+func (sm *SessionManager) StructuredHistory(sessionKey string) []StructuredToolMessage {
+	if sm == nil {
+		return nil
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	s, ok := sm.sessions[sessionKey]
+	if !ok {
+		return nil
+	}
+	return cloneStructuredToolMessages(s.StructuredMessages)
 }
 
 func (sm *SessionManager) Summary(sessionKey string) string {
@@ -120,6 +194,199 @@ func (sm *SessionManager) SetSummary(sessionKey, summary string) {
 	s := sm.getOrCreateLocked(sessionKey, now)
 	s.Summary = truncateSummary(summary)
 	s.UpdatedAt = now
+	sm.persistSessionLocked(s)
+}
+
+func (sm *SessionManager) PendingApproval(sessionKey string) *PendingToolApproval {
+	pending := sm.PendingApprovals(sessionKey)
+	if len(pending) == 0 {
+		return nil
+	}
+	return pending[0]
+}
+
+func (sm *SessionManager) PendingApprovals(sessionKey string) []*PendingToolApproval {
+	if sm == nil {
+		return nil
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return nil
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	s, ok := sm.sessions[sessionKey]
+	if !ok {
+		return nil
+	}
+	now := time.Now().UTC()
+	if sm.pruneExpiredApprovalsLocked(s, now) {
+		s.UpdatedAt = now
+		sm.persistSessionLocked(s)
+	}
+	return clonePendingToolApprovals(s.PendingApprovals)
+}
+
+func (sm *SessionManager) ConsumePendingApproval(sessionKey, approvalID string) (*PendingToolApproval, bool) {
+	if sm == nil {
+		return nil, false
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	approvalID = strings.TrimSpace(approvalID)
+	if sessionKey == "" || approvalID == "" {
+		return nil, false
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	s, ok := sm.sessions[sessionKey]
+	if !ok {
+		return nil, false
+	}
+	now := time.Now().UTC()
+	sm.pruneExpiredApprovalsLocked(s, now)
+	for idx, pending := range s.PendingApprovals {
+		if strings.TrimSpace(pending.ID) != approvalID {
+			continue
+		}
+		consumed := clonePendingToolApproval(pending)
+		s.PendingApprovals = append(s.PendingApprovals[:idx], s.PendingApprovals[idx+1:]...)
+		s.PendingApproval = nil
+		s.UpdatedAt = now
+		sm.persistSessionLocked(s)
+		return consumed, true
+	}
+	return nil, false
+}
+
+func (sm *SessionManager) SetPendingApproval(sessionKey string, pending *PendingToolApproval) {
+	if sm == nil {
+		return
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	now := time.Now().UTC()
+	s := sm.getOrCreateLocked(sessionKey, now)
+	normalized := normalizePendingToolApproval(pending, now)
+	if normalized == nil {
+		return
+	}
+	replaced := false
+	for idx, existing := range s.PendingApprovals {
+		if strings.TrimSpace(existing.ID) != normalized.ID {
+			continue
+		}
+		s.PendingApprovals[idx] = normalized
+		replaced = true
+		break
+	}
+	if !replaced {
+		s.PendingApprovals = append(s.PendingApprovals, normalized)
+	}
+	sm.pruneExpiredApprovalsLocked(s, now)
+	s.PendingApproval = nil
+	s.UpdatedAt = now
+	sm.persistSessionLocked(s)
+}
+
+func (sm *SessionManager) SetPendingApprovals(sessionKey string, pendings []*PendingToolApproval) {
+	if sm == nil {
+		return
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	now := time.Now().UTC()
+	s := sm.getOrCreateLocked(sessionKey, now)
+	normalizedList := make([]*PendingToolApproval, 0, len(pendings))
+	for _, pending := range pendings {
+		normalized := normalizePendingToolApproval(pending, now)
+		if normalized == nil {
+			continue
+		}
+		normalizedList = append(normalizedList, normalized)
+	}
+	s.PendingApprovals = normalizedList
+	sm.pruneExpiredApprovalsLocked(s, now)
+	s.PendingApproval = nil
+	s.UpdatedAt = now
+	sm.persistSessionLocked(s)
+}
+
+func (sm *SessionManager) ClearPendingApproval(sessionKey string) {
+	if sm == nil {
+		return
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	s, ok := sm.sessions[sessionKey]
+	if !ok || len(s.PendingApprovals) == 0 {
+		return
+	}
+	s.PendingApprovals = nil
+	s.PendingApproval = nil
+	s.UpdatedAt = time.Now().UTC()
+	sm.persistSessionLocked(s)
+}
+
+func (sm *SessionManager) ApprovalAudit(sessionKey string) []*PendingToolApproval {
+	if sm == nil {
+		return nil
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return nil
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	s, ok := sm.sessions[sessionKey]
+	if !ok {
+		return nil
+	}
+	now := time.Now().UTC()
+	if sm.pruneExpiredApprovalsLocked(s, now) {
+		s.UpdatedAt = now
+		sm.persistSessionLocked(s)
+	}
+	return clonePendingToolApprovals(s.ApprovalAudit)
+}
+
+func (sm *SessionManager) RecordApprovalDecision(sessionKey string, pending *PendingToolApproval, decision string) {
+	if sm == nil {
+		return
+	}
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	now := time.Now().UTC()
+	s := sm.getOrCreateLocked(sessionKey, now)
+	sm.appendApprovalAuditLocked(s, resolvedPendingToolApproval(pending, decision, now))
+	s.PendingApproval = nil
+	s.UpdatedAt = now
+	sm.persistSessionLocked(s)
 }
 
 func (sm *SessionManager) ListStats(limit int) []SessionStats {
@@ -152,10 +419,13 @@ func (sm *SessionManager) getOrCreateLocked(sessionKey string, now time.Time) *C
 		return s
 	}
 	s := &ConversationSession{
-		Key:       sessionKey,
-		Messages:  []ConversationMessage{},
-		CreatedAt: now,
-		UpdatedAt: now,
+		Key:                sessionKey,
+		Messages:           []ConversationMessage{},
+		StructuredMessages: []StructuredToolMessage{},
+		PendingApprovals:   []*PendingToolApproval{},
+		ApprovalAudit:      []*PendingToolApproval{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 	sm.sessions[sessionKey] = s
 	return s
@@ -169,6 +439,11 @@ func (sm *SessionManager) compactLocked(s *ConversationSession) {
 	dropped := make([]ConversationMessage, dropCount)
 	copy(dropped, s.Messages[:dropCount])
 	s.Messages = append([]ConversationMessage(nil), s.Messages[dropCount:]...)
+	if len(s.StructuredMessages) <= dropCount {
+		s.StructuredMessages = nil
+	} else {
+		s.StructuredMessages = append([]StructuredToolMessage(nil), s.StructuredMessages[dropCount:]...)
+	}
 
 	compactNote := buildSessionCompactNote(dropped)
 	if compactNote == "" {
@@ -210,4 +485,283 @@ func truncateSummary(summary string) string {
 		return summary
 	}
 	return summary[:maxSessionSummaryBytes] + "..."
+}
+
+func (sm *SessionManager) loadFromStorage() {
+	if sm == nil || strings.TrimSpace(sm.storageDir) == "" {
+		return
+	}
+	entries, err := os.ReadDir(sm.storageDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(sm.storageDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var session ConversationSession
+		if err := json.Unmarshal(raw, &session); err != nil {
+			continue
+		}
+		filename, ok := sessionStorageFilename(session.Key)
+		if !ok || entry.Name() != filename {
+			continue
+		}
+		normalizeLoadedConversationSession(&session)
+		session.Summary = truncateSummary(session.Summary)
+		now := time.Now().UTC()
+		if sm.pruneExpiredApprovalsLocked(&session, now) {
+			session.UpdatedAt = now
+		}
+		sm.sessions[session.Key] = &session
+	}
+}
+
+func (sm *SessionManager) persistSessionLocked(session *ConversationSession) {
+	if sm == nil || session == nil || strings.TrimSpace(sm.storageDir) == "" {
+		return
+	}
+	persisted := *session
+	persisted.PendingApproval = nil
+	persisted.PendingApprovals = clonePendingToolApprovals(session.PendingApprovals)
+	persisted.ApprovalAudit = clonePendingToolApprovals(session.ApprovalAudit)
+	raw, err := json.MarshalIndent(&persisted, "", "  ")
+	if err != nil {
+		return
+	}
+	filename, ok := sessionStorageFilename(session.Key)
+	if !ok {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(sm.storageDir, filename), raw, 0o600)
+}
+
+func sessionStorageFilename(sessionKey string) (string, bool) {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" || sessionKey == "." || sessionKey == ".." {
+		return "", false
+	}
+	if strings.Contains(sessionKey, "/") || strings.Contains(sessionKey, "\\") {
+		return "", false
+	}
+
+	filename := strings.NewReplacer(":", "_").Replace(sessionKey)
+	filename = strings.TrimSpace(filename)
+	if filename == "" || filename == "." || filename == ".." {
+		return "", false
+	}
+	return filename + ".json", true
+}
+
+func clonePendingToolApproval(pending *PendingToolApproval) *PendingToolApproval {
+	if pending == nil {
+		return nil
+	}
+	return &PendingToolApproval{
+		ID:          strings.TrimSpace(pending.ID),
+		ToolName:    strings.TrimSpace(pending.ToolName),
+		Arguments:   cloneToolSchema(pending.Arguments),
+		RequestedAt: pending.RequestedAt,
+		ExpiresAt:   pending.ExpiresAt,
+		ResolvedAt:  pending.ResolvedAt,
+		Decision:    strings.TrimSpace(pending.Decision),
+		Reason:      strings.TrimSpace(pending.Reason),
+		RuleID:      strings.TrimSpace(pending.RuleID),
+	}
+}
+
+func clonePendingToolApprovals(pending []*PendingToolApproval) []*PendingToolApproval {
+	if len(pending) == 0 {
+		return nil
+	}
+	out := make([]*PendingToolApproval, 0, len(pending))
+	for _, item := range pending {
+		if cloned := clonePendingToolApproval(item); cloned != nil {
+			out = append(out, cloned)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizePendingToolApproval(pending *PendingToolApproval, now time.Time) *PendingToolApproval {
+	normalized := clonePendingToolApproval(pending)
+	if normalized == nil {
+		return nil
+	}
+	if normalized.ID == "" || normalized.ToolName == "" {
+		return nil
+	}
+	if normalized.RequestedAt.IsZero() {
+		normalized.RequestedAt = now
+	}
+	if normalized.ExpiresAt.IsZero() {
+		normalized.ExpiresAt = normalized.RequestedAt.Add(defaultPendingApprovalTTL)
+	}
+	normalized.ResolvedAt = time.Time{}
+	normalized.Decision = ""
+	return normalized
+}
+
+func resolvedPendingToolApproval(pending *PendingToolApproval, decision string, now time.Time) *PendingToolApproval {
+	normalized := clonePendingToolApproval(pending)
+	if normalized == nil {
+		return nil
+	}
+	normalized.Decision = strings.TrimSpace(decision)
+	if normalized.ResolvedAt.IsZero() {
+		normalized.ResolvedAt = now
+	}
+	return normalized
+}
+
+func (sm *SessionManager) appendApprovalAuditLocked(session *ConversationSession, pending *PendingToolApproval) {
+	if session == nil || pending == nil {
+		return
+	}
+	session.ApprovalAudit = append(session.ApprovalAudit, pending)
+	if len(session.ApprovalAudit) > maxApprovalAuditEntries {
+		session.ApprovalAudit = clonePendingToolApprovals(session.ApprovalAudit[len(session.ApprovalAudit)-maxApprovalAuditEntries:])
+	}
+}
+
+func (sm *SessionManager) pruneExpiredApprovalsLocked(session *ConversationSession, now time.Time) bool {
+	if session == nil || len(session.PendingApprovals) == 0 {
+		return false
+	}
+	changed := false
+	remaining := make([]*PendingToolApproval, 0, len(session.PendingApprovals))
+	for _, pending := range session.PendingApprovals {
+		normalized := normalizePendingToolApproval(pending, now)
+		if normalized == nil {
+			changed = true
+			continue
+		}
+		if !normalized.ExpiresAt.IsZero() && !normalized.ExpiresAt.After(now) {
+			sm.appendApprovalAuditLocked(session, resolvedPendingToolApproval(normalized, approvalDecisionExpired, now))
+			changed = true
+			continue
+		}
+		remaining = append(remaining, normalized)
+	}
+	session.PendingApprovals = remaining
+	session.PendingApproval = nil
+	return changed
+}
+
+func (sm *SessionManager) appendStructuredMessageLocked(s *ConversationSession, msg StructuredToolMessage, now time.Time) {
+	if s == nil {
+		return
+	}
+	msg = normalizeStructuredToolMessage(msg)
+	if msg.Role == "" {
+		return
+	}
+	s.Messages = append(s.Messages, ConversationMessage{
+		Role:      msg.Role,
+		Content:   strings.TrimSpace(msg.Content),
+		Timestamp: now,
+	})
+	s.StructuredMessages = append(s.StructuredMessages, msg)
+}
+
+func normalizeLoadedConversationSession(session *ConversationSession) {
+	if session == nil {
+		return
+	}
+	if len(session.StructuredMessages) == 0 && len(session.Messages) > 0 {
+		session.StructuredMessages = structuredMessagesFromConversationHistory(session.Messages)
+	}
+	if len(session.Messages) == 0 && len(session.StructuredMessages) > 0 {
+		session.Messages = flattenStructuredMessages(session.StructuredMessages)
+	}
+	if len(session.StructuredMessages) > 0 && len(session.Messages) > len(session.StructuredMessages) {
+		session.Messages = append([]ConversationMessage(nil), session.Messages[:len(session.StructuredMessages)]...)
+	}
+	if len(session.Messages) > 0 && len(session.StructuredMessages) > len(session.Messages) {
+		session.StructuredMessages = cloneStructuredToolMessages(session.StructuredMessages[:len(session.Messages)])
+	}
+	session.StructuredMessages = cloneStructuredToolMessages(session.StructuredMessages)
+	if len(session.PendingApprovals) == 0 && session.PendingApproval != nil {
+		session.PendingApprovals = []*PendingToolApproval{clonePendingToolApproval(session.PendingApproval)}
+	}
+	session.PendingApproval = nil
+	session.PendingApprovals = clonePendingToolApprovals(session.PendingApprovals)
+	session.ApprovalAudit = clonePendingToolApprovals(session.ApprovalAudit)
+}
+
+func normalizeStructuredToolMessage(msg StructuredToolMessage) StructuredToolMessage {
+	msg.Role = strings.TrimSpace(strings.ToLower(msg.Role))
+	msg.Content = strings.TrimSpace(msg.Content)
+	msg.ToolCallID = strings.TrimSpace(msg.ToolCallID)
+	msg.ToolName = strings.TrimSpace(msg.ToolName)
+	msg.ToolPolicyReason = strings.TrimSpace(msg.ToolPolicyReason)
+	msg.ToolPolicyRuleID = strings.TrimSpace(msg.ToolPolicyRuleID)
+	msg.ToolCalls = cloneStructuredToolCalls(msg.ToolCalls)
+	if msg.ToolResultStatus != "" {
+		msg.ToolResultStatus = ExecutionToolResultStatus(strings.TrimSpace(string(msg.ToolResultStatus)))
+	}
+	return msg
+}
+
+func structuredMessagesFromConversationHistory(history []ConversationMessage) []StructuredToolMessage {
+	out := make([]StructuredToolMessage, 0, len(history))
+	for _, msg := range history {
+		role := strings.TrimSpace(strings.ToLower(msg.Role))
+		if role == "" {
+			continue
+		}
+		out = append(out, StructuredToolMessage{
+			Role:    role,
+			Content: strings.TrimSpace(msg.Content),
+		})
+	}
+	return out
+}
+
+func flattenStructuredMessages(history []StructuredToolMessage) []ConversationMessage {
+	out := make([]ConversationMessage, 0, len(history))
+	for _, msg := range history {
+		normalized := normalizeStructuredToolMessage(msg)
+		if normalized.Role == "" {
+			continue
+		}
+		out = append(out, ConversationMessage{
+			Role:    normalized.Role,
+			Content: normalized.Content,
+		})
+	}
+	return out
+}
+
+func cloneStructuredToolMessages(history []StructuredToolMessage) []StructuredToolMessage {
+	if len(history) == 0 {
+		return nil
+	}
+	out := make([]StructuredToolMessage, 0, len(history))
+	for _, msg := range history {
+		out = append(out, normalizeStructuredToolMessage(msg))
+	}
+	return out
+}
+
+func cloneStructuredToolCalls(calls []StructuredToolCall) []StructuredToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]StructuredToolCall, len(calls))
+	for i, call := range calls {
+		out[i] = StructuredToolCall{
+			ID:        strings.TrimSpace(call.ID),
+			Name:      strings.TrimSpace(call.Name),
+			Arguments: cloneToolSchema(call.Arguments),
+		}
+	}
+	return out
 }

--- a/baseagent/controlplane_test.go
+++ b/baseagent/controlplane_test.go
@@ -3,6 +3,8 @@ package baseagent
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -95,6 +97,78 @@ func TestToolRegistryRoutesFirstMatch(t *testing.T) {
 	}
 }
 
+func TestToolRegistryListStructuredToolDescriptorsIncludesSchemaInOrder(t *testing.T) {
+	reg := NewToolRegistry()
+	alphaSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"target": map[string]any{"type": "string"},
+		},
+		"required": []string{"target"},
+	}
+	_ = reg.RegisterTool(ToolSpec{
+		Name:        "alpha",
+		Description: "first",
+		Parameters:  alphaSchema,
+		Match:       func(string) (ToolInvocation, bool) { return ToolInvocation{}, false },
+		Run:         func(context.Context, ToolInvocation) (ChatResponse, error) { return ChatResponse{}, nil },
+	})
+	_ = reg.RegisterTool(ToolSpec{
+		Name:        "beta",
+		Description: "second",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"count": map[string]any{"type": "integer"},
+			},
+		},
+		Match: func(string) (ToolInvocation, bool) { return ToolInvocation{}, false },
+		Run:   func(context.Context, ToolInvocation) (ChatResponse, error) { return ChatResponse{}, nil },
+	})
+
+	descriptors := reg.ListStructuredToolDescriptors()
+	if len(descriptors) != 2 {
+		t.Fatalf("expected 2 structured descriptors, got %d", len(descriptors))
+	}
+	if descriptors[0].Name != "alpha" || descriptors[1].Name != "beta" {
+		t.Fatalf("expected registration order to be preserved, got %+v", descriptors)
+	}
+	if !reflect.DeepEqual(descriptors[0].Parameters, alphaSchema) {
+		t.Fatalf("unexpected schema export for alpha: %+v", descriptors[0].Parameters)
+	}
+}
+
+func TestToolRegistryListStructuredToolDescriptorsReturnsDeepCopy(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.RegisterTool(ToolSpec{
+		Name:        "alpha",
+		Description: "first",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"target": map[string]any{"type": "string"},
+			},
+		},
+		Match: func(string) (ToolInvocation, bool) { return ToolInvocation{}, false },
+		Run:   func(context.Context, ToolInvocation) (ChatResponse, error) { return ChatResponse{}, nil },
+	})
+
+	exported := reg.ListStructuredToolDescriptors()
+	exported[0].Parameters["type"] = "mutated"
+	exportedProps := exported[0].Parameters["properties"].(map[string]any)
+	exportedProps["target"] = map[string]any{"type": "integer"}
+
+	fresh := reg.ListStructuredToolDescriptors()
+	if fresh[0].Parameters["type"] != "object" {
+		t.Fatalf("expected registry schema to remain unchanged, got %+v", fresh[0].Parameters)
+	}
+	props := fresh[0].Parameters["properties"].(map[string]any)
+	target := props["target"].(map[string]any)
+	if target["type"] != "string" {
+		t.Fatalf("expected nested schema to remain unchanged, got %+v", fresh[0].Parameters)
+	}
+}
+
 type providerFake struct {
 	name string
 	out  string
@@ -102,6 +176,19 @@ type providerFake struct {
 
 func (p providerFake) Name() string { return p.name }
 func (p providerFake) Reply(_ context.Context, _ ProviderRequest) (string, error) {
+	return p.out, nil
+}
+
+type capturingProviderFake struct {
+	name     string
+	out      string
+	requests []ProviderRequest
+}
+
+func (p *capturingProviderFake) Name() string { return p.name }
+
+func (p *capturingProviderFake) Reply(_ context.Context, req ProviderRequest) (string, error) {
+	p.requests = append(p.requests, req)
 	return p.out, nil
 }
 
@@ -122,6 +209,48 @@ func TestProviderManagerRouting(t *testing.T) {
 	}
 }
 
+func TestAgentLoopPassesStructuredToolSchemasToProvider(t *testing.T) {
+	reg := NewToolRegistry()
+	if err := reg.RegisterTool(ToolSpec{
+		Name:        "custom_tool",
+		Description: "custom tool",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"target": map[string]any{"type": "string"},
+			},
+		},
+		Match: func(string) (ToolInvocation, bool) { return ToolInvocation{}, false },
+		Run:   func(context.Context, ToolInvocation) (ChatResponse, error) { return ChatResponse{}, nil },
+	}); err != nil {
+		t.Fatalf("register custom tool: %v", err)
+	}
+
+	provider := &capturingProviderFake{name: "capture", out: "provider reply"}
+	loop := NewAgentLoop(nil, reg, NewProviderManager(provider), NewSessionManager(8), NewMessageBus(8, 8, 8))
+
+	resp, err := loop.ProcessChat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "unit",
+		Message:  "hello",
+	})
+	if err != nil {
+		t.Fatalf("ProcessChat failed: %v", err)
+	}
+	if resp.Message != "provider reply" {
+		t.Fatalf("unexpected provider reply: %+v", resp)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected 1 provider request, got %d", len(provider.requests))
+	}
+	if len(provider.requests[0].StructuredTools) != 1 {
+		t.Fatalf("expected structured tool descriptors to be passed through, got %+v", provider.requests[0].StructuredTools)
+	}
+	if provider.requests[0].StructuredTools[0].Name != "custom_tool" {
+		t.Fatalf("unexpected structured tool descriptor: %+v", provider.requests[0].StructuredTools[0])
+	}
+}
+
 type providerErrFake struct {
 	name string
 	err  error
@@ -130,6 +259,75 @@ type providerErrFake struct {
 func (p providerErrFake) Name() string { return p.name }
 func (p providerErrFake) Reply(_ context.Context, _ ProviderRequest) (string, error) {
 	return "", p.err
+}
+
+type providerToolAwareFake struct {
+	name       string
+	reply      StructuredToolReply
+	replyCalls int
+	textCalls  int
+}
+
+func (p *providerToolAwareFake) Name() string { return p.name }
+
+func (p *providerToolAwareFake) Reply(_ context.Context, _ ProviderRequest) (string, error) {
+	p.textCalls++
+	return "", nil
+}
+
+func (p *providerToolAwareFake) ReplyWithTools(_ context.Context, _ StructuredToolRequest) (StructuredToolReply, error) {
+	p.replyCalls++
+	return p.reply, nil
+}
+
+type providerToolAwareSequenceFake struct {
+	name       string
+	results    []providerToolAwareSequenceResult
+	replyCalls int
+	textCalls  int
+}
+
+type providerToolAwareSequenceResult struct {
+	reply StructuredToolReply
+	err   error
+}
+
+func (p *providerToolAwareSequenceFake) Name() string { return p.name }
+
+func (p *providerToolAwareSequenceFake) Reply(_ context.Context, _ ProviderRequest) (string, error) {
+	p.textCalls++
+	return "", fmt.Errorf("unexpected text reply for %s", p.name)
+}
+
+func (p *providerToolAwareSequenceFake) ReplyWithTools(_ context.Context, _ StructuredToolRequest) (StructuredToolReply, error) {
+	idx := p.replyCalls
+	p.replyCalls++
+	if idx >= len(p.results) {
+		return StructuredToolReply{}, fmt.Errorf("no scripted tool result for %s call %d", p.name, idx)
+	}
+	return p.results[idx].reply, p.results[idx].err
+}
+
+type providerSequenceFake struct {
+	name    string
+	results []providerSequenceResult
+	calls   int
+}
+
+type providerSequenceResult struct {
+	reply string
+	err   error
+}
+
+func (p *providerSequenceFake) Name() string { return p.name }
+
+func (p *providerSequenceFake) Reply(_ context.Context, _ ProviderRequest) (string, error) {
+	idx := p.calls
+	p.calls++
+	if idx >= len(p.results) {
+		return "", fmt.Errorf("no scripted result for %s call %d", p.name, idx)
+	}
+	return p.results[idx].reply, p.results[idx].err
 }
 
 func TestChainProviderFallback(t *testing.T) {
@@ -144,6 +342,425 @@ func TestChainProviderFallback(t *testing.T) {
 	}
 	if reply != "fallback reply" {
 		t.Fatalf("unexpected chain reply: %q", reply)
+	}
+}
+
+func TestProviderManagerReplyWithToolsPrefersToolAwareProvider(t *testing.T) {
+	provider := &providerToolAwareFake{
+		name: "tool-aware",
+		reply: StructuredToolReply{
+			Content: "tool aware response",
+		},
+	}
+
+	pm := NewProviderManager(provider)
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		SystemPrompt: "system",
+		Messages: []StructuredToolMessage{
+			{Role: "user", Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplyWithTools failed: %v", err)
+	}
+	if reply.Content != "tool aware response" {
+		t.Fatalf("unexpected tool-aware response: %+v", reply)
+	}
+	if provider.replyCalls != 1 || provider.textCalls != 0 {
+		t.Fatalf("expected tool-aware path only, got replyCalls=%d textCalls=%d", provider.replyCalls, provider.textCalls)
+	}
+}
+
+func TestProviderManagerReplyFallsBackAfterProviderError(t *testing.T) {
+	primary := &providerSequenceFake{
+		name: "alpha",
+		results: []providerSequenceResult{
+			{err: errors.New("rate limit")},
+		},
+	}
+	fallback := &providerSequenceFake{
+		name: "beta",
+		results: []providerSequenceResult{
+			{reply: "fallback reply"},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	pm.now = func() time.Time { return time.Unix(100, 0) }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.Reply(context.Background(), ProviderRequest{UserMessage: "hi"})
+	if err != nil {
+		t.Fatalf("Reply failed: %v", err)
+	}
+	if reply != "fallback reply" {
+		t.Fatalf("unexpected fallback reply: %q", reply)
+	}
+	if pm.ActiveProviderName() != "beta" {
+		t.Fatalf("expected active provider to switch to fallback, got %q", pm.ActiveProviderName())
+	}
+	if primary.calls != 1 || fallback.calls != 1 {
+		t.Fatalf("unexpected provider call counts: primary=%d fallback=%d", primary.calls, fallback.calls)
+	}
+}
+
+func TestProviderManagerReplySkipsCooldownProvider(t *testing.T) {
+	primary := &providerSequenceFake{
+		name: "alpha",
+		results: []providerSequenceResult{
+			{err: errors.New("rate limit")},
+			{reply: "should not be used during cooldown"},
+		},
+	}
+	fallback := &providerSequenceFake{
+		name: "beta",
+		results: []providerSequenceResult{
+			{reply: "fallback-1"},
+			{reply: "fallback-2"},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	now := time.Unix(200, 0)
+	pm.now = func() time.Time { return now }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.Reply(context.Background(), ProviderRequest{UserMessage: "first"})
+	if err != nil || reply != "fallback-1" {
+		t.Fatalf("unexpected first fallback reply: %q err=%v", reply, err)
+	}
+
+	if err := pm.SetActiveProvider("alpha"); err != nil {
+		t.Fatalf("reset active provider: %v", err)
+	}
+	reply, err = pm.Reply(context.Background(), ProviderRequest{UserMessage: "second"})
+	if err != nil || reply != "fallback-2" {
+		t.Fatalf("unexpected second fallback reply: %q err=%v", reply, err)
+	}
+	if primary.calls != 1 {
+		t.Fatalf("expected cooldown to skip primary on second call, got %d calls", primary.calls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsFallsBackAfterProviderError(t *testing.T) {
+	primary := &providerToolAwareSequenceFake{
+		name: "alpha",
+		results: []providerToolAwareSequenceResult{
+			{err: errors.New("rate limit")},
+		},
+	}
+	fallback := &providerToolAwareSequenceFake{
+		name: "beta",
+		results: []providerToolAwareSequenceResult{
+			{reply: StructuredToolReply{Content: "fallback tool reply"}},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	pm.now = func() time.Time { return time.Unix(300, 0) }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("ReplyWithTools failed: %v", err)
+	}
+	if reply.Content != "fallback tool reply" {
+		t.Fatalf("unexpected fallback tool reply: %+v", reply)
+	}
+	if pm.ActiveProviderName() != "beta" {
+		t.Fatalf("expected active provider to switch to fallback, got %q", pm.ActiveProviderName())
+	}
+	if primary.replyCalls != 1 || fallback.replyCalls != 1 {
+		t.Fatalf("unexpected provider call counts: primary=%d fallback=%d", primary.replyCalls, fallback.replyCalls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsSkipsCooldownProvider(t *testing.T) {
+	primary := &providerToolAwareSequenceFake{
+		name: "alpha",
+		results: []providerToolAwareSequenceResult{
+			{err: errors.New("rate limit")},
+			{reply: StructuredToolReply{Content: "should not be used during cooldown"}},
+		},
+	}
+	fallback := &providerToolAwareSequenceFake{
+		name: "beta",
+		results: []providerToolAwareSequenceResult{
+			{reply: StructuredToolReply{Content: "fallback-1"}},
+			{reply: StructuredToolReply{Content: "fallback-2"}},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	now := time.Unix(400, 0)
+	pm.now = func() time.Time { return now }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "first"}},
+	})
+	if err != nil || reply.Content != "fallback-1" {
+		t.Fatalf("unexpected first fallback reply: %+v err=%v", reply, err)
+	}
+
+	if err := pm.SetActiveProvider("alpha"); err != nil {
+		t.Fatalf("reset active provider: %v", err)
+	}
+	reply, err = pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "second"}},
+	})
+	if err != nil || reply.Content != "fallback-2" {
+		t.Fatalf("unexpected second fallback reply: %+v err=%v", reply, err)
+	}
+	if primary.replyCalls != 1 {
+		t.Fatalf("expected cooldown to skip primary on second call, got %d calls", primary.replyCalls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsFallsBackFromMalformedTextProvider(t *testing.T) {
+	primary := &providerSequenceFake{
+		name: "alpha",
+		results: []providerSequenceResult{
+			{reply: `{"content":"broken"`},
+		},
+	}
+	fallback := &providerSequenceFake{
+		name: "beta",
+		results: []providerSequenceResult{
+			{reply: `{"content":"fallback from text","tool_calls":[]}`},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	pm.now = func() time.Time { return time.Unix(450, 0) }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("ReplyWithTools failed: %v", err)
+	}
+	if reply.Content != "fallback from text" {
+		t.Fatalf("unexpected fallback reply: %+v", reply)
+	}
+	if pm.ActiveProviderName() != "beta" {
+		t.Fatalf("expected active provider to switch to fallback, got %q", pm.ActiveProviderName())
+	}
+	if primary.calls != 1 || fallback.calls != 1 {
+		t.Fatalf("unexpected provider call counts: primary=%d fallback=%d", primary.calls, fallback.calls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsRetriesTextProviderAfterCooldownExpires(t *testing.T) {
+	primary := &providerSequenceFake{
+		name: "alpha",
+		results: []providerSequenceResult{
+			{reply: `{"content":"broken"`},
+			{reply: `{"content":"primary recovered","tool_calls":[]}`},
+		},
+	}
+	fallback := &providerSequenceFake{
+		name: "beta",
+		results: []providerSequenceResult{
+			{reply: `{"content":"fallback-1","tool_calls":[]}`},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	now := time.Unix(500, 0)
+	pm.now = func() time.Time { return now }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "first"}},
+	})
+	if err != nil || reply.Content != "fallback-1" {
+		t.Fatalf("unexpected first fallback reply: %+v err=%v", reply, err)
+	}
+
+	if err := pm.SetActiveProvider("alpha"); err != nil {
+		t.Fatalf("reset active provider: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+
+	reply, err = pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "second"}},
+	})
+	if err != nil {
+		t.Fatalf("ReplyWithTools after cooldown failed: %v", err)
+	}
+	if reply.Content != "primary recovered" {
+		t.Fatalf("unexpected recovered reply: %+v", reply)
+	}
+	if primary.calls != 2 {
+		t.Fatalf("expected primary to be retried after cooldown expiry, got %d calls", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Fatalf("expected fallback to be used only once, got %d calls", fallback.calls)
+	}
+	if pm.ActiveProviderName() != "alpha" {
+		t.Fatalf("expected active provider to switch back to primary, got %q", pm.ActiveProviderName())
+	}
+}
+
+func TestProviderManagerReplyDoesNotCooldownNonRetriableErrors(t *testing.T) {
+	primary := &providerSequenceFake{
+		name: "alpha",
+		results: []providerSequenceResult{
+			{err: NonRetriableProviderError(errors.New("invalid request"))},
+			{reply: "primary recovered"},
+		},
+	}
+	fallback := &providerSequenceFake{
+		name: "beta",
+		results: []providerSequenceResult{
+			{reply: "fallback-1"},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	now := time.Unix(550, 0)
+	pm.now = func() time.Time { return now }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.Reply(context.Background(), ProviderRequest{UserMessage: "first"})
+	if err != nil || reply != "fallback-1" {
+		t.Fatalf("unexpected first fallback reply: %q err=%v", reply, err)
+	}
+
+	if err := pm.SetActiveProvider("alpha"); err != nil {
+		t.Fatalf("reset active provider: %v", err)
+	}
+	reply, err = pm.Reply(context.Background(), ProviderRequest{UserMessage: "second"})
+	if err != nil {
+		t.Fatalf("second reply failed: %v", err)
+	}
+	if reply != "primary recovered" {
+		t.Fatalf("expected primary to be retried after non-retriable error, got %q", reply)
+	}
+	if primary.calls != 2 {
+		t.Fatalf("expected primary to be called twice, got %d", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Fatalf("expected fallback to be used once, got %d", fallback.calls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsDoesNotCooldownNonRetriableErrors(t *testing.T) {
+	primary := &providerToolAwareSequenceFake{
+		name: "alpha",
+		results: []providerToolAwareSequenceResult{
+			{err: NonRetriableProviderError(errors.New("invalid tool schema"))},
+			{reply: StructuredToolReply{Content: "primary recovered"}},
+		},
+	}
+	fallback := &providerToolAwareSequenceFake{
+		name: "beta",
+		results: []providerToolAwareSequenceResult{
+			{reply: StructuredToolReply{Content: "fallback-1"}},
+		},
+	}
+
+	pm := NewProviderManager(primary)
+	pm.cooldown = time.Minute
+	now := time.Unix(600, 0)
+	pm.now = func() time.Time { return now }
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	reply, err := pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "first"}},
+	})
+	if err != nil || reply.Content != "fallback-1" {
+		t.Fatalf("unexpected first fallback reply: %+v err=%v", reply, err)
+	}
+
+	if err := pm.SetActiveProvider("alpha"); err != nil {
+		t.Fatalf("reset active provider: %v", err)
+	}
+	reply, err = pm.ReplyWithTools(context.Background(), StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "second"}},
+	})
+	if err != nil {
+		t.Fatalf("second tool reply failed: %v", err)
+	}
+	if reply.Content != "primary recovered" {
+		t.Fatalf("expected primary tool provider to be retried after non-retriable error, got %+v", reply)
+	}
+	if primary.replyCalls != 2 {
+		t.Fatalf("expected primary tool provider to be called twice, got %d", primary.replyCalls)
+	}
+	if fallback.replyCalls != 1 {
+		t.Fatalf("expected fallback tool provider to be used once, got %d", fallback.replyCalls)
+	}
+}
+
+func TestProviderManagerReplyHonorsCanceledContextBeforeCallingProviders(t *testing.T) {
+	primary := &providerSequenceFake{name: "alpha", results: []providerSequenceResult{{reply: "should not run"}}}
+	fallback := &providerSequenceFake{name: "beta", results: []providerSequenceResult{{reply: "should not run"}}}
+
+	pm := NewProviderManager(primary)
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := pm.Reply(ctx, ProviderRequest{UserMessage: "stop"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if primary.calls != 0 || fallback.calls != 0 {
+		t.Fatalf("expected canceled context to skip providers, got primary=%d fallback=%d", primary.calls, fallback.calls)
+	}
+}
+
+func TestProviderManagerReplyWithToolsHonorsCanceledContextBeforeCallingProviders(t *testing.T) {
+	primary := &providerToolAwareSequenceFake{name: "alpha", results: []providerToolAwareSequenceResult{{reply: StructuredToolReply{Content: "should not run"}}}}
+	fallback := &providerToolAwareSequenceFake{name: "beta", results: []providerToolAwareSequenceResult{{reply: StructuredToolReply{Content: "should not run"}}}}
+
+	pm := NewProviderManager(primary)
+	if err := pm.RegisterProvider(fallback); err != nil {
+		t.Fatalf("register fallback: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := pm.ReplyWithTools(ctx, StructuredToolRequest{
+		Messages: []StructuredToolMessage{{Role: "user", Content: "stop"}},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if primary.replyCalls != 0 || fallback.replyCalls != 0 {
+		t.Fatalf("expected canceled context to skip providers, got primary=%d fallback=%d", primary.replyCalls, fallback.replyCalls)
 	}
 }
 
@@ -238,5 +855,35 @@ func TestRuntimeMetadataCommands(t *testing.T) {
 	}
 	if resp.Action != "boundaries" || !strings.Contains(resp.Message, "BaseAgent boundaries") {
 		t.Fatalf("unexpected boundaries response: %+v", resp)
+	}
+}
+
+func TestRuntimeMetadataCommandsIncludeWorkspaceTools(t *testing.T) {
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(t.TempDir()))
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{Provider: "cli", ChatID: "unit", Message: "/tools"})
+	if err != nil {
+		t.Fatalf("tools command failed: %v", err)
+	}
+	if !strings.Contains(resp.Message, "Workspace tools") {
+		t.Fatalf("expected workspace tools section, got: %q", resp.Message)
+	}
+	if !strings.Contains(resp.Message, "append_file") || !strings.Contains(resp.Message, "exec") {
+		t.Fatalf("expected execution tool descriptors in summary, got: %q", resp.Message)
+	}
+}
+
+func TestRuntimeMetadataCommandsIncludeBuiltInToolSchemas(t *testing.T) {
+	rt := NewRuntime(&runtimeServiceFake{}, nil)
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{Provider: "cli", ChatID: "unit", Message: "/tools"})
+	if err != nil {
+		t.Fatalf("tools command failed: %v", err)
+	}
+	if !strings.Contains(resp.Message, "agent_action") {
+		t.Fatalf("expected built-in tool name in summary, got: %q", resp.Message)
+	}
+	if !strings.Contains(resp.Message, "parameters=") || !strings.Contains(resp.Message, `"agent_id":{"type":"string"}`) {
+		t.Fatalf("expected built-in tool schema in summary, got: %q", resp.Message)
 	}
 }

--- a/baseagent/controlplane_tools.go
+++ b/baseagent/controlplane_tools.go
@@ -25,6 +25,7 @@ type ToolRunner func(ctx context.Context, call ToolInvocation) (ChatResponse, er
 type ToolSpec struct {
 	Name        string
 	Description string
+	Parameters  map[string]any
 	Match       ToolMatcher
 	Run         ToolRunner
 }
@@ -59,6 +60,7 @@ func (r *ToolRegistry) RegisterTool(spec ToolSpec) error {
 	}
 
 	spec.Name = name
+	spec.Parameters = cloneToolSchema(spec.Parameters)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.byName[name]; !exists {
@@ -133,6 +135,24 @@ func (r *ToolRegistry) ListToolDescriptors() []ToolDescriptor {
 	return out
 }
 
+func (r *ToolRegistry) ListStructuredToolDescriptors() []StructuredToolDescriptor {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]StructuredToolDescriptor, 0, len(r.byName))
+	for _, name := range r.order {
+		spec := r.byName[name]
+		out = append(out, StructuredToolDescriptor{
+			Name:        spec.Name,
+			Description: spec.Description,
+			Parameters:  cloneToolSchema(spec.Parameters),
+		})
+	}
+	return out
+}
+
 func (r *ToolRegistry) ListToolNames() []string {
 	if r == nil {
 		return nil
@@ -144,19 +164,13 @@ func (r *ToolRegistry) ListToolNames() []string {
 }
 
 func (r *ToolRegistry) RenderToolSummary() string {
-	descriptors := r.ListToolDescriptors()
+	descriptors := r.ListStructuredToolDescriptors()
 	if len(descriptors) == 0 {
 		return "No tools are registered."
 	}
 	lines := make([]string, 0, len(descriptors)+1)
 	lines = append(lines, fmt.Sprintf("Available tools (%d):", len(descriptors)))
-	for _, d := range descriptors {
-		if strings.TrimSpace(d.Description) == "" {
-			lines = append(lines, "- "+d.Name)
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("- %s: %s", d.Name, d.Description))
-	}
+	lines = append(lines, renderStructuredToolLines(descriptors)...)
 	return strings.Join(lines, "\n")
 }
 
@@ -164,4 +178,46 @@ func (r *ToolRegistry) SortedToolNames() []string {
 	names := r.ListToolNames()
 	sort.Strings(names)
 	return names
+}
+
+func cloneToolSchema(schema map[string]any) map[string]any {
+	if len(schema) == 0 {
+		return nil
+	}
+	cloned, ok := cloneToolSchemaValue(schema).(map[string]any)
+	if !ok {
+		return nil
+	}
+	return cloned
+}
+
+func cloneToolSchemaValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = cloneToolSchemaValue(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = cloneToolSchemaValue(typed[i])
+		}
+		return out
+	case []string:
+		out := make([]string, len(typed))
+		copy(out, typed)
+		return out
+	case []int:
+		out := make([]int, len(typed))
+		copy(out, typed)
+		return out
+	case []bool:
+		out := make([]bool, len(typed))
+		copy(out, typed)
+		return out
+	default:
+		return typed
+	}
 }

--- a/baseagent/coverage_round95_test.go
+++ b/baseagent/coverage_round95_test.go
@@ -2,6 +2,8 @@ package baseagent
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -135,3 +137,61 @@ func TestLLMProviderNameAndHistoryRenderingBranches(t *testing.T) {
 	}
 }
 
+func TestLLMProviderAdapterIncludesStructuredToolSchemasInPrompt(t *testing.T) {
+	var gotUserPrompt string
+
+	server := newLocalhostServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var payload struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if len(payload.Messages) < 2 {
+			t.Fatalf("expected at least 2 messages, got %+v", payload.Messages)
+		}
+		gotUserPrompt = payload.Messages[1].Content
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	writeDefaultModelConfig(t, "openai", "openai/gpt-5.3", "OPENAI_API_KEY")
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("CARRIER_OPENAI_BASE_URL", server.URL)
+
+	provider := NewLLMProviderAdapter("openai", 0)
+	_, err := provider.Reply(context.Background(), ProviderRequest{
+		SystemPrompt: "system",
+		UserMessage:  "hello",
+		StructuredTools: []StructuredToolDescriptor{
+			{
+				Name:        "agent_action",
+				Description: "Run an agent lifecycle action.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"agent_id": map[string]any{"type": "string"},
+						"action":   map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("provider reply failed: %v", err)
+	}
+	if !strings.Contains(gotUserPrompt, "Available built-in tools") {
+		t.Fatalf("expected built-in tools section, got %q", gotUserPrompt)
+	}
+	if !strings.Contains(gotUserPrompt, "agent_action") || !strings.Contains(gotUserPrompt, `parameters={"properties":{"action":{"type":"string"},"agent_id":{"type":"string"}},"type":"object"}`) {
+		t.Fatalf("expected structured tool schema in prompt, got %q", gotUserPrompt)
+	}
+}

--- a/baseagent/cron_service.go
+++ b/baseagent/cron_service.go
@@ -1,0 +1,75 @@
+package baseagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CronJob struct {
+	ID         string    `json:"id"`
+	SessionKey string    `json:"sessionKey"`
+	Prompt     string    `json:"prompt"`
+	NextRunAt  time.Time `json:"nextRunAt"`
+}
+
+type CronService struct {
+	mu      sync.Mutex
+	jobs    map[string]CronJob
+	execute func(context.Context, CronJob) error
+}
+
+func NewCronService(execute func(context.Context, CronJob) error) *CronService {
+	return &CronService{
+		jobs:    map[string]CronJob{},
+		execute: execute,
+	}
+}
+
+func (s *CronService) Schedule(ctx context.Context, job CronJob) (CronJob, error) {
+	if s == nil {
+		return CronJob{}, fmt.Errorf("cron service is unavailable")
+	}
+	job.SessionKey = strings.TrimSpace(job.SessionKey)
+	job.Prompt = strings.TrimSpace(job.Prompt)
+	if job.SessionKey == "" {
+		return CronJob{}, fmt.Errorf("session key is required")
+	}
+	if job.Prompt == "" {
+		return CronJob{}, fmt.Errorf("prompt is required")
+	}
+	if job.ID == "" {
+		job.ID = fmt.Sprintf("cron-%d", time.Now().UTC().UnixNano())
+	}
+	if job.NextRunAt.IsZero() {
+		job.NextRunAt = time.Now().UTC()
+	}
+
+	s.mu.Lock()
+	s.jobs[job.ID] = job
+	s.mu.Unlock()
+
+	if !job.NextRunAt.After(time.Now().UTC()) && s.execute != nil {
+		if err := s.execute(ctx, job); err != nil {
+			return CronJob{}, err
+		}
+	}
+	return job, nil
+}
+
+func cronChatRequestForSessionKey(sessionKey, prompt string) ChatRequest {
+	sessionKey = strings.TrimSpace(sessionKey)
+	provider := "cron"
+	chatID := sessionKey
+	if parts := strings.SplitN(sessionKey, ":", 2); len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != "" {
+		provider = strings.TrimSpace(parts[0])
+		chatID = strings.TrimSpace(parts[1])
+	}
+	return ChatRequest{
+		Provider: provider,
+		ChatID:   chatID,
+		Message:  strings.TrimSpace(prompt),
+	}
+}

--- a/baseagent/cron_service_test.go
+++ b/baseagent/cron_service_test.go
@@ -1,0 +1,79 @@
+package baseagent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCronJobReentersStructuredLoopWithSessionContext(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "cron-runtime",
+		replies: []StructuredToolReply{
+			{Content: "cron run complete"},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	job, err := rt.ScheduleJob(context.Background(), CronJob{
+		SessionKey: "cli:cron-check",
+		Prompt:     "perform maintenance planning",
+	})
+	if err != nil {
+		t.Fatalf("schedule job: %v", err)
+	}
+	if job.ID == "" {
+		t.Fatalf("expected scheduled cron job id, got %+v", job)
+	}
+
+	history := rt.sessions.History("cli:cron-check")
+	if len(history) == 0 {
+		t.Fatalf("expected cron job to reenter session history, got %+v", history)
+	}
+}
+
+func TestCronJobRespectsPendingApprovalPolicy(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "cron-pending",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_start",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{Content: "cron requires confirmation"},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	if _, err := rt.ScheduleJob(context.Background(), CronJob{
+		SessionKey: "cli:cron-pending",
+		Prompt:     "perform maintenance planning",
+	}); err != nil {
+		t.Fatalf("schedule job: %v", err)
+	}
+
+	pending := rt.sessions.PendingApprovals("cli:cron-pending")
+	if len(pending) != 1 || pending[0].ToolName != "agent_start" {
+		t.Fatalf("expected cron job to preserve pending approval policy, got %+v", pending)
+	}
+}

--- a/baseagent/execution_prompt.go
+++ b/baseagent/execution_prompt.go
@@ -1,0 +1,7 @@
+package baseagent
+
+const baseAgentExecutionPrompt = "You are Carrier's base agent with workspace tools enabled. " +
+	"Answer in the user's language. " +
+	"Use tools when file inspection, file edits, directory listing, or command execution are needed. " +
+	"Prefer the smallest safe action that completes the task. " +
+	"Return direct answers when no tool is needed."

--- a/baseagent/execution_tools.go
+++ b/baseagent/execution_tools.go
@@ -1,0 +1,607 @@
+package baseagent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultExecTimeoutSeconds = 30
+	maxExecutionOutputBytes   = 8192
+)
+
+type ExecutionToolResultStatus string
+
+const (
+	ExecutionToolResultStatusOK    ExecutionToolResultStatus = "ok"
+	ExecutionToolResultStatusError ExecutionToolResultStatus = "error"
+	ExecutionToolResultStatusAsk   ExecutionToolResultStatus = "ask"
+	ExecutionToolResultStatusDeny  ExecutionToolResultStatus = "deny"
+)
+
+type ExecutionToolResult struct {
+	Output       string
+	FilesTouched []string
+	Stdout       string
+	Stderr       string
+	ExitCode     int
+	IsError      bool
+	Status       ExecutionToolResultStatus
+	PolicyReason string
+	PolicyRuleID string
+}
+
+type StructuredToolDescriptor struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+}
+
+type executionToolFunc func(ctx context.Context, args map[string]any) ExecutionToolResult
+
+type executionToolSpec struct {
+	Descriptor StructuredToolDescriptor
+	Run        executionToolFunc
+}
+
+type ExecutionToolRegistry struct {
+	workspaceRoot string
+	tools         map[string]executionToolSpec
+	denyPatterns  []*regexp.Regexp
+}
+
+func NewExecutionToolRegistry(workspaceRoot string) *ExecutionToolRegistry {
+	root := strings.TrimSpace(workspaceRoot)
+	if root != "" {
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
+		}
+	}
+
+	registry := &ExecutionToolRegistry{
+		workspaceRoot: root,
+		tools:         map[string]executionToolSpec{},
+		denyPatterns: []*regexp.Regexp{
+			regexp.MustCompile(`\brm\s+-[rf]{1,2}\b`),
+			regexp.MustCompile(`\bmkfs\b`),
+			regexp.MustCompile(`\bdd\s+if=`),
+			regexp.MustCompile(`\bshutdown\b`),
+			regexp.MustCompile(`\breboot\b`),
+			regexp.MustCompile(`\bsudo\b`),
+		},
+	}
+
+	registry.tools["write_file"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "write_file",
+			Description: "Write content to a file inside the execution workspace.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":    map[string]any{"type": "string", "description": "Path to the target file."},
+					"content": map[string]any{"type": "string", "description": "New file content."},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		Run: registry.writeFile,
+	}
+	registry.tools["append_file"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "append_file",
+			Description: "Append content to a file inside the execution workspace, creating it when needed.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":    map[string]any{"type": "string", "description": "Path to the target file."},
+					"content": map[string]any{"type": "string", "description": "Content to append to the file."},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		Run: registry.appendFile,
+	}
+	registry.tools["read_file"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "read_file",
+			Description: "Read a file from the execution workspace.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":   map[string]any{"type": "string", "description": "Path to the file to read."},
+					"offset": map[string]any{"type": "integer", "description": "Optional zero-based line offset for paginated reads."},
+					"limit":  map[string]any{"type": "integer", "description": "Optional maximum number of lines to return."},
+				},
+				"required": []string{"path"},
+			},
+		},
+		Run: registry.readFile,
+	}
+	registry.tools["edit_file"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "edit_file",
+			Description: "Replace one exact text span inside a file in the execution workspace.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":     map[string]any{"type": "string", "description": "Path to the target file."},
+					"old_text": map[string]any{"type": "string", "description": "Exact text to replace."},
+					"new_text": map[string]any{"type": "string", "description": "Replacement text."},
+				},
+				"required": []string{"path", "old_text", "new_text"},
+			},
+		},
+		Run: registry.editFile,
+	}
+	registry.tools["list_dir"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "list_dir",
+			Description: "List files and subdirectories inside a workspace directory.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":   map[string]any{"type": "string", "description": "Directory path. Defaults to the workspace root."},
+					"offset": map[string]any{"type": "integer", "description": "Optional zero-based entry offset for paginated directory listings."},
+					"limit":  map[string]any{"type": "integer", "description": "Optional maximum number of entries to return."},
+				},
+			},
+		},
+		Run: registry.listDir,
+	}
+	registry.tools["exec"] = executionToolSpec{
+		Descriptor: StructuredToolDescriptor{
+			Name:        "exec",
+			Description: "Execute a shell command inside the execution workspace, subject to safety guards.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command":         map[string]any{"type": "string", "description": "Shell command to execute."},
+					"timeout_seconds": map[string]any{"type": "integer", "description": "Optional timeout in seconds. Defaults to 30 seconds."},
+				},
+				"required": []string{"command"},
+			},
+		},
+		Run: registry.execCommand,
+	}
+	return registry
+}
+
+func (r *ExecutionToolRegistry) Execute(ctx context.Context, name string, args map[string]any) ExecutionToolResult {
+	tool, ok := r.tools[strings.TrimSpace(name)]
+	if !ok {
+		return executionError(fmt.Sprintf("unknown tool %q", name))
+	}
+	return tool.Run(ctx, args)
+}
+
+func (r *ExecutionToolRegistry) Descriptors() []StructuredToolDescriptor {
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]StructuredToolDescriptor, 0, len(names))
+	for _, name := range names {
+		out = append(out, r.tools[name].Descriptor)
+	}
+	return out
+}
+
+func (r *ExecutionToolRegistry) writeFile(_ context.Context, args map[string]any) ExecutionToolResult {
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return executionError("path is required")
+	}
+	content, ok := args["content"].(string)
+	if !ok {
+		return executionError("content is required")
+	}
+
+	resolved, err := r.resolveWorkspacePath(path)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return executionError(fmt.Sprintf("create parent directory: %v", err))
+	}
+	if err := os.WriteFile(resolved, []byte(content), 0o600); err != nil {
+		return executionError(fmt.Sprintf("write file: %v", err))
+	}
+	return ExecutionToolResult{
+		Output:       fmt.Sprintf("wrote %s", resolved),
+		FilesTouched: []string{resolved},
+	}
+}
+
+func (r *ExecutionToolRegistry) appendFile(_ context.Context, args map[string]any) ExecutionToolResult {
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return executionError("path is required")
+	}
+	content, ok := args["content"].(string)
+	if !ok {
+		return executionError("content is required")
+	}
+
+	resolved, err := r.resolveWorkspacePath(path)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return executionError(fmt.Sprintf("create parent directory: %v", err))
+	}
+	file, err := os.OpenFile(resolved, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return executionError(fmt.Sprintf("open append target: %v", err))
+	}
+	defer file.Close()
+	if _, err := file.WriteString(content); err != nil {
+		return executionError(fmt.Sprintf("append file: %v", err))
+	}
+	return ExecutionToolResult{
+		Output:       fmt.Sprintf("appended %s", resolved),
+		FilesTouched: []string{resolved},
+	}
+}
+
+func (r *ExecutionToolRegistry) readFile(_ context.Context, args map[string]any) ExecutionToolResult {
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return executionError("path is required")
+	}
+	resolved, err := r.resolveWorkspacePath(path)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	raw, err := os.ReadFile(resolved)
+	if err != nil {
+		return executionError(fmt.Sprintf("read file: %v", err))
+	}
+	offset, err := readOptionalIntArg(args, "offset", 0)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	limit, err := readOptionalIntArg(args, "limit", 0)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	content := paginateTextByLines(string(raw), offset, limit)
+	return ExecutionToolResult{
+		Output: content,
+	}
+}
+
+func (r *ExecutionToolRegistry) editFile(_ context.Context, args map[string]any) ExecutionToolResult {
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return executionError("path is required")
+	}
+	oldText, ok := args["old_text"].(string)
+	if !ok || oldText == "" {
+		return executionError("old_text is required")
+	}
+	newText, ok := args["new_text"].(string)
+	if !ok {
+		return executionError("new_text is required")
+	}
+
+	resolved, err := r.resolveWorkspacePath(path)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	raw, err := os.ReadFile(resolved)
+	if err != nil {
+		return executionError(fmt.Sprintf("read file: %v", err))
+	}
+	content := string(raw)
+	if !strings.Contains(content, oldText) {
+		return executionError("old_text not found in file")
+	}
+	if strings.Count(content, oldText) > 1 {
+		return executionError("old_text appears multiple times")
+	}
+	updated := strings.Replace(content, oldText, newText, 1)
+	if err := os.WriteFile(resolved, []byte(updated), 0o600); err != nil {
+		return executionError(fmt.Sprintf("write edited file: %v", err))
+	}
+	return ExecutionToolResult{
+		Output:       fmt.Sprintf("edited %s", resolved),
+		FilesTouched: []string{resolved},
+	}
+}
+
+func (r *ExecutionToolRegistry) listDir(_ context.Context, args map[string]any) ExecutionToolResult {
+	path, _ := args["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		path = "."
+	}
+	resolved, err := r.resolveWorkspacePath(path)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	entries, err := os.ReadDir(resolved)
+	if err != nil {
+		return executionError(fmt.Sprintf("list directory: %v", err))
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			name += "/"
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	offset, err := readOptionalIntArg(args, "offset", 0)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	limit, err := readOptionalIntArg(args, "limit", 0)
+	if err != nil {
+		return executionError(err.Error())
+	}
+	names = paginateStrings(names, offset, limit)
+	return ExecutionToolResult{Output: strings.Join(names, "\n")}
+}
+
+func (r *ExecutionToolRegistry) execCommand(ctx context.Context, args map[string]any) ExecutionToolResult {
+	command, ok := args["command"].(string)
+	if !ok || strings.TrimSpace(command) == "" {
+		return executionError("command is required")
+	}
+	if guardErr := r.guardCommand(command); guardErr != "" {
+		return executionError(guardErr)
+	}
+
+	cmdCtx := ctx
+	cancel := func() {}
+	timeoutSeconds := defaultExecTimeoutSeconds
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		timeoutSeconds, err := readOptionalIntArg(args, "timeout_seconds", defaultExecTimeoutSeconds)
+		if err != nil {
+			return executionError(err.Error())
+		}
+		if timeoutSeconds <= 0 {
+			timeoutSeconds = defaultExecTimeoutSeconds
+		}
+		cmdCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
+	}
+	defer cancel()
+
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(cmdCtx, "powershell", "-NoProfile", "-NonInteractive", "-Command", command)
+	} else {
+		cmd = exec.CommandContext(cmdCtx, "sh", "-c", command)
+	}
+	if r.workspaceRoot != "" {
+		cmd.Dir = r.workspaceRoot
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := ExecutionToolResult{
+		Output: strings.TrimSpace(stdout.String()),
+		Stdout: strings.TrimSpace(stdout.String()),
+		Stderr: strings.TrimSpace(stderr.String()),
+	}
+	if result.Output == "" && result.Stderr != "" {
+		result.Output = result.Stderr
+	}
+	result.Output = truncateExecutionOutput(result.Output)
+	result.Stdout = truncateExecutionOutput(result.Stdout)
+	result.Stderr = truncateExecutionOutput(result.Stderr)
+
+	if err == nil {
+		return result
+	}
+	if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
+		result.IsError = true
+		result.Output = fmt.Sprintf("command timed out after %ds", timeoutSeconds)
+		return result
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitCode()
+		result.IsError = true
+		if result.Output == "" {
+			result.Output = strings.TrimSpace(exitErr.Error())
+		}
+		return result
+	}
+
+	result.IsError = true
+	if result.Output == "" {
+		result.Output = err.Error()
+	}
+	return result
+}
+
+func (r *ExecutionToolRegistry) resolveWorkspacePath(rawPath string) (string, error) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if r.workspaceRoot == "" {
+		return "", fmt.Errorf("workspace root is not configured")
+	}
+
+	root := r.workspaceRoot
+	resolved := trimmed
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(root, resolved)
+	}
+	resolved = filepath.Clean(resolved)
+
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return "", fmt.Errorf("path resolution failed: %w", err)
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path escapes workspace root")
+	}
+	if err := ensurePathInsideWorkspace(root, resolved); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func (r *ExecutionToolRegistry) guardCommand(command string) string {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	for _, pattern := range r.denyPatterns {
+		if pattern.MatchString(lower) {
+			return "command denied by execution safety policy"
+		}
+	}
+	return ""
+}
+
+func executionError(message string) ExecutionToolResult {
+	return ExecutionToolResult{
+		Output:  strings.TrimSpace(message),
+		IsError: true,
+		Status:  ExecutionToolResultStatusError,
+	}
+}
+
+func executionAsk(message string) ExecutionToolResult {
+	return ExecutionToolResult{
+		Output:  strings.TrimSpace(message),
+		IsError: true,
+		Status:  ExecutionToolResultStatusAsk,
+	}
+}
+
+func executionDeny(message string) ExecutionToolResult {
+	return ExecutionToolResult{
+		Output:  strings.TrimSpace(message),
+		IsError: true,
+		Status:  ExecutionToolResultStatusDeny,
+	}
+}
+
+func applyStructuredPolicyMetadata(result ExecutionToolResult, decision StructuredPolicyDecision) ExecutionToolResult {
+	if strings.TrimSpace(result.PolicyReason) == "" {
+		result.PolicyReason = strings.TrimSpace(decision.Reason)
+	}
+	if strings.TrimSpace(result.PolicyRuleID) == "" {
+		result.PolicyRuleID = strings.TrimSpace(decision.RuleID)
+	}
+	return result
+}
+
+func executionAskWithPolicy(message string, decision StructuredPolicyDecision) ExecutionToolResult {
+	return applyStructuredPolicyMetadata(executionAsk(message), decision)
+}
+
+func executionDenyWithPolicy(message string, decision StructuredPolicyDecision) ExecutionToolResult {
+	return applyStructuredPolicyMetadata(executionDeny(message), decision)
+}
+
+func readOptionalIntArg(args map[string]any, key string, fallback int) (int, error) {
+	if args == nil {
+		return fallback, nil
+	}
+	value, ok := args[key]
+	if !ok || value == nil {
+		return fallback, nil
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed, nil
+	case int32:
+		return int(typed), nil
+	case int64:
+		return int(typed), nil
+	case float64:
+		return int(typed), nil
+	default:
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+}
+
+func paginateTextByLines(content string, offset, limit int) string {
+	lines := strings.Split(content, "\n")
+	if offset >= len(lines) {
+		return "[END OF FILE - no content at this offset]"
+	}
+	sliced := paginateStrings(lines, offset, limit)
+	return strings.Join(sliced, "\n")
+}
+
+func paginateStrings(items []string, offset, limit int) []string {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(items) {
+		return []string{}
+	}
+	items = items[offset:]
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items
+}
+
+func ensurePathInsideWorkspace(root, resolved string) error {
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		realRoot = root
+	}
+
+	probe := resolved
+	for {
+		info, err := os.Lstat(probe)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || info.IsDir() || !info.IsDir() {
+				break
+			}
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			break
+		}
+		probe = parent
+	}
+
+	realProbe, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		return fmt.Errorf("path escapes workspace root")
+	}
+	rel, err := filepath.Rel(realRoot, realProbe)
+	if err != nil {
+		return fmt.Errorf("path resolution failed: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path escapes workspace root")
+	}
+	return nil
+}
+
+func truncateExecutionOutput(content string) string {
+	content = strings.TrimSpace(content)
+	if len(content) <= maxExecutionOutputBytes {
+		return content
+	}
+	suffix := "\n[truncated output]"
+	if maxExecutionOutputBytes <= len(suffix) {
+		return suffix
+	}
+	return content[:maxExecutionOutputBytes-len(suffix)] + suffix
+}

--- a/baseagent/execution_tools_test.go
+++ b/baseagent/execution_tools_test.go
@@ -1,0 +1,476 @@
+package baseagent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecutionToolRegistryFileRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	registry := NewExecutionToolRegistry(root)
+
+	writeResult := registry.Execute(context.Background(), "write_file", map[string]any{
+		"path":    "notes/hello.txt",
+		"content": "hello from baseagent",
+	})
+	if writeResult.IsError {
+		t.Fatalf("write_file returned error: %+v", writeResult)
+	}
+	if len(writeResult.FilesTouched) != 1 || writeResult.FilesTouched[0] != filepath.Join(root, "notes", "hello.txt") {
+		t.Fatalf("unexpected files_touched: %+v", writeResult.FilesTouched)
+	}
+
+	readResult := registry.Execute(context.Background(), "read_file", map[string]any{
+		"path": "notes/hello.txt",
+	})
+	if readResult.IsError {
+		t.Fatalf("read_file returned error: %+v", readResult)
+	}
+	if !strings.Contains(readResult.Output, "hello from baseagent") {
+		t.Fatalf("unexpected read output: %q", readResult.Output)
+	}
+
+	editResult := registry.Execute(context.Background(), "edit_file", map[string]any{
+		"path":     "notes/hello.txt",
+		"old_text": "baseagent",
+		"new_text": "tool loop",
+	})
+	if editResult.IsError {
+		t.Fatalf("edit_file returned error: %+v", editResult)
+	}
+
+	listResult := registry.Execute(context.Background(), "list_dir", map[string]any{
+		"path": "notes",
+	})
+	if listResult.IsError {
+		t.Fatalf("list_dir returned error: %+v", listResult)
+	}
+	if !strings.Contains(listResult.Output, "hello.txt") {
+		t.Fatalf("unexpected list output: %q", listResult.Output)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "notes", "hello.txt"))
+	if err != nil {
+		t.Fatalf("read edited file: %v", err)
+	}
+	if string(raw) != "hello from tool loop" {
+		t.Fatalf("unexpected final file content: %q", string(raw))
+	}
+}
+
+func TestExecutionToolRegistryAppendAndPagination(t *testing.T) {
+	root := t.TempDir()
+	registry := NewExecutionToolRegistry(root)
+
+	writeResult := registry.Execute(context.Background(), "write_file", map[string]any{
+		"path":    "notes/log.txt",
+		"content": "line-1\nline-2",
+	})
+	if writeResult.IsError {
+		t.Fatalf("write_file returned error: %+v", writeResult)
+	}
+
+	appendResult := registry.Execute(context.Background(), "append_file", map[string]any{
+		"path":    "notes/log.txt",
+		"content": "\nline-3\nline-4",
+	})
+	if appendResult.IsError {
+		t.Fatalf("append_file returned error: %+v", appendResult)
+	}
+
+	readResult := registry.Execute(context.Background(), "read_file", map[string]any{
+		"path":   "notes/log.txt",
+		"offset": 1,
+		"limit":  2,
+	})
+	if readResult.IsError {
+		t.Fatalf("read_file returned error: %+v", readResult)
+	}
+	if readResult.Output != "line-2\nline-3" {
+		t.Fatalf("unexpected paginated read output: %q", readResult.Output)
+	}
+
+	listResult := registry.Execute(context.Background(), "list_dir", map[string]any{
+		"path":   "notes",
+		"offset": 0,
+		"limit":  1,
+	})
+	if listResult.IsError {
+		t.Fatalf("list_dir returned error: %+v", listResult)
+	}
+	if listResult.Output != "log.txt" {
+		t.Fatalf("unexpected paginated list output: %q", listResult.Output)
+	}
+}
+
+func TestExecutionToolRegistryExecBlocksDangerousCommand(t *testing.T) {
+	registry := NewExecutionToolRegistry(t.TempDir())
+
+	result := registry.Execute(context.Background(), "exec", map[string]any{
+		"command": "rm -rf /",
+	})
+	if !result.IsError {
+		t.Fatalf("expected blocked exec command, got %+v", result)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "denied") {
+		t.Fatalf("unexpected exec output: %q", result.Output)
+	}
+}
+
+func TestExecutionToolRegistryReadFileRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	leak := filepath.Join(workspace, "leak.txt")
+	if err := os.Symlink(secret, leak); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	registry := NewExecutionToolRegistry(workspace)
+	result := registry.Execute(context.Background(), "read_file", map[string]any{
+		"path": "leak.txt",
+	})
+	if !result.IsError {
+		t.Fatalf("expected symlink escape to be blocked, got %+v", result)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "workspace") &&
+		!strings.Contains(strings.ToLower(result.Output), "escape") &&
+		!strings.Contains(strings.ToLower(result.Output), "denied") {
+		t.Fatalf("unexpected symlink escape output: %q", result.Output)
+	}
+}
+
+func TestExecutionToolRegistryWriteFileRejectsSymlinkParentEscape(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	link := filepath.Join(workspace, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	registry := NewExecutionToolRegistry(workspace)
+	result := registry.Execute(context.Background(), "write_file", map[string]any{
+		"path":    "escape/payload.txt",
+		"content": "should stay inside workspace",
+	})
+	if !result.IsError {
+		t.Fatalf("expected symlink parent escape to be blocked, got %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "payload.txt")); err == nil {
+		t.Fatal("write_file escaped workspace via symlink parent")
+	}
+}
+
+func TestExecutionToolRegistryReadFileOffsetBeyondEOF(t *testing.T) {
+	root := t.TempDir()
+	registry := NewExecutionToolRegistry(root)
+
+	writeResult := registry.Execute(context.Background(), "write_file", map[string]any{
+		"path":    "notes/short.txt",
+		"content": "line-1\nline-2",
+	})
+	if writeResult.IsError {
+		t.Fatalf("write_file returned error: %+v", writeResult)
+	}
+
+	readResult := registry.Execute(context.Background(), "read_file", map[string]any{
+		"path":   "notes/short.txt",
+		"offset": 10,
+		"limit":  2,
+	})
+	if readResult.IsError {
+		t.Fatalf("read_file should return EOF marker, got error: %+v", readResult)
+	}
+	if readResult.Output != "[END OF FILE - no content at this offset]" {
+		t.Fatalf("unexpected EOF read output: %q", readResult.Output)
+	}
+}
+
+func TestExecutionToolRegistryExecTimeout(t *testing.T) {
+	registry := NewExecutionToolRegistry(t.TempDir())
+
+	result := registry.Execute(context.Background(), "exec", map[string]any{
+		"command":         "sleep 2",
+		"timeout_seconds": 1,
+	})
+	if !result.IsError {
+		t.Fatalf("expected timeout to be reported as error, got %+v", result)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "timed out") {
+		t.Fatalf("unexpected timeout output: %q", result.Output)
+	}
+}
+
+func TestExecutionToolRegistryExecTruncatesLongOutput(t *testing.T) {
+	registry := NewExecutionToolRegistry(t.TempDir())
+
+	result := registry.Execute(context.Background(), "exec", map[string]any{
+		"command": "python3 -c \"print('x' * 12000)\"",
+	})
+	if result.IsError {
+		t.Fatalf("expected long output command to succeed, got %+v", result)
+	}
+	if len(result.Output) > 9000 {
+		t.Fatalf("expected truncated output, got len=%d", len(result.Output))
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "truncated") {
+		t.Fatalf("expected truncation marker, got %q", result.Output)
+	}
+}
+
+func TestExecutionToolRegistryEditFileValidationFailures(t *testing.T) {
+	root := t.TempDir()
+	registry := NewExecutionToolRegistry(root)
+
+	writeResult := registry.Execute(context.Background(), "write_file", map[string]any{
+		"path":    "notes/repeated.txt",
+		"content": "test test test",
+	})
+	if writeResult.IsError {
+		t.Fatalf("write_file returned error: %+v", writeResult)
+	}
+
+	t.Run("old text missing", func(t *testing.T) {
+		result := registry.Execute(context.Background(), "edit_file", map[string]any{
+			"path":     "notes/repeated.txt",
+			"old_text": "missing",
+			"new_text": "done",
+		})
+		if !result.IsError {
+			t.Fatalf("expected missing old_text to fail, got %+v", result)
+		}
+		if !strings.Contains(result.Output, "not found") {
+			t.Fatalf("unexpected missing old_text output: %q", result.Output)
+		}
+	})
+
+	t.Run("multiple matches", func(t *testing.T) {
+		result := registry.Execute(context.Background(), "edit_file", map[string]any{
+			"path":     "notes/repeated.txt",
+			"old_text": "test",
+			"new_text": "done",
+		})
+		if !result.IsError {
+			t.Fatalf("expected multiple matches to fail, got %+v", result)
+		}
+		if !strings.Contains(result.Output, "multiple") {
+			t.Fatalf("unexpected multiple match output: %q", result.Output)
+		}
+	})
+}
+
+func TestExecutionToolRegistryExecReportsStderrAndExitCode(t *testing.T) {
+	registry := NewExecutionToolRegistry(t.TempDir())
+
+	result := registry.Execute(context.Background(), "exec", map[string]any{
+		"command": "echo boom >&2; exit 7",
+	})
+	if !result.IsError {
+		t.Fatalf("expected command failure, got %+v", result)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("unexpected exit code: %+v", result)
+	}
+	if !strings.Contains(result.Stderr, "boom") || !strings.Contains(result.Output, "boom") {
+		t.Fatalf("expected stderr to be surfaced, got %+v", result)
+	}
+}
+
+func TestExecutionToolRegistryDescriptors(t *testing.T) {
+	registry := NewExecutionToolRegistry(t.TempDir())
+	descriptors := registry.Descriptors()
+	if len(descriptors) < 6 {
+		t.Fatalf("expected core execution descriptors, got %d", len(descriptors))
+	}
+
+	seen := map[string]StructuredToolDescriptor{}
+	for _, descriptor := range descriptors {
+		seen[descriptor.Name] = descriptor
+	}
+
+	if seen["write_file"].Description == "" || seen["write_file"].Parameters == nil {
+		t.Fatalf("write_file descriptor should include description and parameters: %+v", seen["write_file"])
+	}
+	if seen["append_file"].Description == "" || seen["append_file"].Parameters == nil {
+		t.Fatalf("append_file descriptor should include description and parameters: %+v", seen["append_file"])
+	}
+	if seen["exec"].Description == "" || seen["exec"].Parameters == nil {
+		t.Fatalf("exec descriptor should include description and parameters: %+v", seen["exec"])
+	}
+}
+
+func TestNewSessionManagerWithStorageRoundTripsHistoryAndSummary(t *testing.T) {
+	dir := t.TempDir()
+	sessionKey := "cli:test"
+
+	first := NewSessionManagerWithStorage(8, dir)
+	first.AddMessage(sessionKey, "user", "hello")
+	first.AddMessage(sessionKey, "assistant", "world")
+	first.SetSummary(sessionKey, "short summary")
+
+	second := NewSessionManagerWithStorage(8, dir)
+	history := second.History(sessionKey)
+	if len(history) != 2 {
+		t.Fatalf("expected 2 persisted messages, got %d", len(history))
+	}
+	if history[0].Content != "hello" || history[1].Content != "world" {
+		t.Fatalf("unexpected persisted history: %+v", history)
+	}
+	if got := second.Summary(sessionKey); got != "short summary" {
+		t.Fatalf("unexpected persisted summary: %q", got)
+	}
+}
+
+func TestNewSessionManagerWithStorageSkipsUnsafeKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	first := NewSessionManagerWithStorage(8, dir)
+	first.AddMessage(".", "user", "should not persist")
+
+	second := NewSessionManagerWithStorage(8, dir)
+	if history := second.History("."); len(history) != 0 {
+		t.Fatalf("expected unsafe key to be skipped during persistence, got %+v", history)
+	}
+}
+
+func TestNewSessionManagerWithStorageSkipsCorruptedJSONAndLoadsValidSessions(t *testing.T) {
+	dir := t.TempDir()
+	sessionKey := "cli:good"
+
+	first := NewSessionManagerWithStorage(8, dir)
+	first.AddMessage(sessionKey, "user", "hello")
+	first.SetSummary(sessionKey, "valid summary")
+
+	if err := os.WriteFile(filepath.Join(dir, "broken.json"), []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("write broken session file: %v", err)
+	}
+
+	second := NewSessionManagerWithStorage(8, dir)
+	history := second.History(sessionKey)
+	if len(history) != 1 || history[0].Content != "hello" {
+		t.Fatalf("unexpected persisted history after corrupted file: %+v", history)
+	}
+	if got := second.Summary(sessionKey); got != "valid summary" {
+		t.Fatalf("unexpected persisted summary after corrupted file: %q", got)
+	}
+}
+
+func TestNewSessionManagerWithStorageReloadsCompactedSummary(t *testing.T) {
+	dir := t.TempDir()
+	sessionKey := "cli:compact"
+
+	first := NewSessionManagerWithStorage(2, dir)
+	first.AddMessage(sessionKey, "user", "one")
+	first.AddMessage(sessionKey, "assistant", "two")
+	first.AddMessage(sessionKey, "user", "three")
+	first.AddMessage(sessionKey, "assistant", "four")
+
+	second := NewSessionManagerWithStorage(2, dir)
+	history := second.History(sessionKey)
+	if len(history) != 2 {
+		t.Fatalf("expected compacted history to persist with 2 messages, got %d", len(history))
+	}
+	summary := second.Summary(sessionKey)
+	if !strings.Contains(summary, "[Compacted 1 earlier messages]") || !strings.Contains(summary, "- assistant: two") {
+		t.Fatalf("expected compacted summary to persist, got %q", summary)
+	}
+}
+
+func TestNewSessionManagerWithStorageTruncatesOversizedSummaryOnLoad(t *testing.T) {
+	dir := t.TempDir()
+	sessionKey := "cli:oversized"
+	filename, ok := sessionStorageFilename(sessionKey)
+	if !ok {
+		t.Fatalf("expected valid filename for session key")
+	}
+
+	session := ConversationSession{
+		Key:       sessionKey,
+		Summary:   strings.Repeat("s", maxSessionSummaryBytes+128),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	raw, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), raw, 0o600); err != nil {
+		t.Fatalf("write oversized session file: %v", err)
+	}
+
+	reloaded := NewSessionManagerWithStorage(8, dir)
+	summary := reloaded.Summary(sessionKey)
+	if len(summary) > maxSessionSummaryBytes+3 {
+		t.Fatalf("expected reloaded summary to be truncated, got length %d", len(summary))
+	}
+	if !strings.HasSuffix(summary, "...") {
+		t.Fatalf("expected reloaded truncated summary to end with ellipsis, got %q", summary[len(summary)-10:])
+	}
+}
+
+func TestNewSessionManagerWithStorageRoundTripsPendingApproval(t *testing.T) {
+	dir := t.TempDir()
+	sessionKey := "cli:approval"
+	requestedAt := time.Now().UTC().Round(0)
+	expiresAt := requestedAt.Add(15 * time.Minute)
+
+	first := NewSessionManagerWithStorage(8, dir)
+	first.SetPendingApprovals(sessionKey, []*PendingToolApproval{
+		{
+			ID:          "approval-1",
+			ToolName:    "exec",
+			Arguments:   map[string]any{"command": "go test ./..."},
+			RequestedAt: requestedAt,
+			ExpiresAt:   expiresAt,
+			Reason:      "Shell execution requires confirmation.",
+			RuleID:      structuredPolicyRuleExecConfirmationNeeded,
+		},
+		{
+			ID:          "approval-2",
+			ToolName:    "agent_start",
+			RequestedAt: requestedAt,
+			ExpiresAt:   expiresAt,
+			Reason:      "Agent lifecycle mutation requires confirmation.",
+			RuleID:      structuredPolicyRuleAgentConfirmation,
+		},
+	})
+
+	second := NewSessionManagerWithStorage(8, dir)
+	pending := second.PendingApprovals(sessionKey)
+	if len(pending) != 2 {
+		t.Fatalf("expected pending approvals to persist, got %+v", pending)
+	}
+	if pending[0].ID != "approval-1" || pending[0].ToolName != "exec" {
+		t.Fatalf("unexpected first pending approval metadata: %+v", pending[0])
+	}
+	if pending[0].RequestedAt.IsZero() || !pending[0].RequestedAt.Equal(requestedAt) || !pending[0].ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("unexpected first pending approval timestamps: %+v", pending[0])
+	}
+	if command, _ := pending[0].Arguments["command"].(string); command != "go test ./..." {
+		t.Fatalf("unexpected first pending approval args: %+v", pending[0].Arguments)
+	}
+	if pending[0].RuleID != structuredPolicyRuleExecConfirmationNeeded || pending[0].Reason == "" {
+		t.Fatalf("expected first pending approval audit metadata to persist, got %+v", pending[0])
+	}
+}

--- a/baseagent/mcp_manager.go
+++ b/baseagent/mcp_manager.go
@@ -1,0 +1,78 @@
+package baseagent
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+type MCPManager interface {
+	ListStructuredTools() []StructuredToolDescriptor
+	ExecuteTool(ctx context.Context, name string, args map[string]any) ExecutionToolResult
+}
+
+type staticMCPTool struct {
+	descriptor StructuredToolDescriptor
+	run        func(context.Context, map[string]any) ExecutionToolResult
+}
+
+type StaticMCPManager struct {
+	mu    sync.RWMutex
+	tools map[string]staticMCPTool
+}
+
+func NewStaticMCPManager() *StaticMCPManager {
+	return &StaticMCPManager{
+		tools: map[string]staticMCPTool{},
+	}
+}
+
+func (m *StaticMCPManager) RegisterTool(name string, descriptor StructuredToolDescriptor, run func(context.Context, map[string]any) ExecutionToolResult) {
+	if m == nil || run == nil {
+		return
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	descriptor.Name = name
+	descriptor.Parameters = cloneToolSchema(descriptor.Parameters)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tools[name] = staticMCPTool{
+		descriptor: descriptor,
+		run:        run,
+	}
+}
+
+func (m *StaticMCPManager) ListStructuredTools() []StructuredToolDescriptor {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]StructuredToolDescriptor, 0, len(m.tools))
+	for _, tool := range m.tools {
+		out = append(out, StructuredToolDescriptor{
+			Name:        tool.descriptor.Name,
+			Description: tool.descriptor.Description,
+			Parameters:  cloneToolSchema(tool.descriptor.Parameters),
+		})
+	}
+	return out
+}
+
+func (m *StaticMCPManager) ExecuteTool(ctx context.Context, name string, args map[string]any) ExecutionToolResult {
+	if m == nil {
+		return executionError("mcp manager is unavailable")
+	}
+	m.mu.RLock()
+	tool, ok := m.tools[strings.TrimSpace(name)]
+	m.mu.RUnlock()
+	if !ok {
+		return executionError("unknown mcp tool")
+	}
+	return tool.run(ctx, args)
+}

--- a/baseagent/mcp_manager_test.go
+++ b/baseagent/mcp_manager_test.go
@@ -1,0 +1,65 @@
+package baseagent
+
+import (
+	"context"
+	"testing"
+)
+
+func containsStructuredTool(tools []StructuredToolDescriptor, name string) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMCPToolsAppearInStructuredSurfaceUnderPolicy(t *testing.T) {
+	mgr := NewStaticMCPManager()
+	mgr.RegisterTool("repo_search", StructuredToolDescriptor{
+		Name:        "repo_search",
+		Description: "Search the repository index.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+			"required": []string{"query"},
+		},
+	}, func(context.Context, map[string]any) ExecutionToolResult {
+		return ExecutionToolResult{Output: "found"}
+	})
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMCPManager(mgr))
+	got := rt.loop.structuredTools.Descriptors()
+
+	if !containsStructuredTool(got, "repo_search") {
+		t.Fatalf("expected MCP tool descriptor, got %+v", got)
+	}
+}
+
+func TestMCPToolExecutionRespectsPolicyDecision(t *testing.T) {
+	mgr := NewStaticMCPManager()
+	mgr.RegisterTool("repo_write", StructuredToolDescriptor{
+		Name:        "repo_write",
+		Description: "Write to the repository index.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{"type": "string"},
+			},
+			"required": []string{"path"},
+		},
+	}, func(context.Context, map[string]any) ExecutionToolResult {
+		return ExecutionToolResult{Output: "wrote"}
+	})
+
+	policy := ActiveBoundarySpec().StructuredToolPolicy
+	policy.HighRiskDecision = string(structuredToolDecisionDeny)
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMCPManager(mgr), WithStructuredToolPolicy(policy))
+	result := rt.loop.structuredTools.Execute(context.Background(), "repo_write", map[string]any{"path": "README.md"})
+	if result.Status != ExecutionToolResultStatusDeny {
+		t.Fatalf("expected MCP tool execution to respect policy deny, got %+v", result)
+	}
+}

--- a/baseagent/policy.go
+++ b/baseagent/policy.go
@@ -116,6 +116,17 @@ func activeRepairPolicy() RepairPolicy {
 	return ActiveBoundarySpec().RepairPolicy
 }
 
+func isStructuredExecCommandDenied(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	if usesSudo(command) {
+		return true
+	}
+	return isBlockedRepairCommand(command, activeRepairPolicy().BlockedSubstrings)
+}
+
 func usesSudo(command string) bool {
 	parts := strings.Fields(command)
 	if len(parts) > 0 && (parts[0] == "sudo" || filepath.Base(parts[0]) == "sudo") {

--- a/baseagent/runtime.go
+++ b/baseagent/runtime.go
@@ -5,6 +5,7 @@ import (
 	"carrier/shared/config"
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -77,20 +78,40 @@ type Runtime struct {
 	providers *ProviderManager
 	sessions  *SessionManager
 	loop      *AgentLoop
+	cron      *CronService
 
-	mu          sync.Mutex
-	initialized bool
-	activeID    string
+	mu                sync.Mutex
+	initialized       bool
+	activeID          string
+	workspaceRoot     string
+	maxToolIterations int
+	structuredToolPolicyOverride *StructuredToolPolicySpec
+	mcpManager                  MCPManager
+	skillsLoader                SkillsLoader
 }
 
-func NewRuntime(svc AgentService, memStore MemoryStore) *Runtime {
+func NewRuntime(svc AgentService, memStore MemoryStore, opts ...RuntimeOption) *Runtime {
 	r := &Runtime{
-		svc:      svc,
-		memory:   memStore,
-		activeID: baseAgentActiveMemoryV1ID,
+		svc:               svc,
+		memory:            memStore,
+		activeID:          baseAgentActiveMemoryV1ID,
+		maxToolIterations: defaultMaxToolIterations,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+	structuredToolPolicy := ActiveBoundarySpec().StructuredToolPolicy
+	if r.structuredToolPolicyOverride != nil {
+		structuredToolPolicy = *r.structuredToolPolicyOverride
 	}
 	r.bus = NewMessageBus(0, 0, 0)
-	r.sessions = NewSessionManager(0)
+	if r.workspaceRoot != "" {
+		r.sessions = NewSessionManagerWithStorage(0, filepath.Join(r.workspaceRoot, ".baseagent", "sessions"))
+	} else {
+		r.sessions = NewSessionManager(0)
+	}
 	r.providers = NewProviderManager(nil)
 	for _, provider := range catalog.ListProviders() {
 		mustRegisterProvider(r.providers, NewLLMProviderAdapter(provider.ID, 8))
@@ -102,6 +123,16 @@ func NewRuntime(svc AgentService, memStore MemoryStore) *Runtime {
 	r.channels = NewChannelManager(r.bus)
 	r.loop = NewAgentLoop(r.svc, r.tools, r.providers, r.sessions, r.bus)
 	r.loop.SetChannelManager(r.channels)
+	r.loop.SetSkillsLoader(r.skillsLoader)
+	if r.workspaceRoot != "" {
+		r.loop.SetExecutionTools(NewExecutionToolRegistry(r.workspaceRoot), r.maxToolIterations, structuredToolPolicy, r.mcpManager)
+	} else {
+		r.loop.SetExecutionTools(nil, r.maxToolIterations, structuredToolPolicy, r.mcpManager)
+	}
+	r.cron = NewCronService(func(ctx context.Context, job CronJob) error {
+		_, err := r.Chat(ctx, cronChatRequestForSessionKey(job.SessionKey, job.Prompt))
+		return err
+	})
 	return r
 }
 
@@ -176,6 +207,13 @@ func (r *Runtime) Chat(ctx context.Context, req ChatRequest) (ChatResponse, erro
 		}, healNote, healed, backupRef), nil
 	}
 	return withMemoryNote(resp, healNote, healed, backupRef), nil
+}
+
+func (r *Runtime) ScheduleJob(ctx context.Context, job CronJob) (CronJob, error) {
+	if r == nil || r.cron == nil {
+		return CronJob{}, fmt.Errorf("cron service is unavailable")
+	}
+	return r.cron.Schedule(ctx, job)
 }
 
 func wantsListAgents(lower string) bool {
@@ -264,11 +302,31 @@ func (r *Runtime) executeAgentAction(ctx context.Context, action, agentID string
 }
 
 func baseAgentHelpText() string {
-	return "Base agent manages local agents: `list agents` or `/agents`, `uninstall <agent>`, `start <agent>`, `stop <agent>`, `status <agent>`, `logs <agent>`, `upgrade <agent>`, `diagnose <agent>`. Metadata commands: `/tools`, `/providers`, `/sessions`, `/boundaries`. For install/onboard, use Carrier CLI/TUI (`carrier install <agent>`, `carrier onboard`) or WebUI."
+	return "Base agent manages local agents: `list agents` or `/agents`, `uninstall <agent>`, `start <agent>`, `stop <agent>`, `status <agent>`, `logs <agent>`, `upgrade <agent>`, `diagnose <agent>`. Metadata commands: `/tools`, `/providers`, `/sessions`, `/boundaries`. When workspace tools are enabled, chat can use `read_file`, `write_file`, `append_file`, `edit_file`, `list_dir`, and bounded `exec` inside the current project workspace. For install/onboard, use Carrier CLI/TUI (`carrier install <agent>`, `carrier onboard`) or WebUI."
 }
 
 func baseAgentBoundariesText() string {
 	return ActiveBoundarySpec().RenderSummary()
+}
+
+func (r *Runtime) renderToolSummary() string {
+	if r == nil || r.tools == nil {
+		return "No tools are registered."
+	}
+
+	lines := []string{r.tools.RenderToolSummary()}
+	if r.loop == nil || r.loop.executionTools == nil {
+		return strings.Join(lines, "\n")
+	}
+
+	descriptors := r.loop.executionTools.Descriptors()
+	if len(descriptors) == 0 {
+		return strings.Join(lines, "\n")
+	}
+
+	lines = append(lines, "", fmt.Sprintf("Workspace tools (%d):", len(descriptors)))
+	lines = append(lines, renderStructuredToolLines(descriptors)...)
+	return strings.Join(lines, "\n")
 }
 
 func withMemoryNote(resp ChatResponse, note string, healed bool, backupRef string) ChatResponse {

--- a/baseagent/runtime_coverage_test.go
+++ b/baseagent/runtime_coverage_test.go
@@ -18,6 +18,7 @@ type runtimeServiceFake struct {
 	upgrades  map[string]UpgradeResult
 	diagnoses map[string]string
 	errs      map[string]error
+	callLog   []string
 }
 
 func (f *runtimeServiceFake) ListAgents() []AgentState {
@@ -25,18 +26,22 @@ func (f *runtimeServiceFake) ListAgents() []AgentState {
 }
 
 func (f *runtimeServiceFake) Install(_ context.Context, agentID string) error {
+	f.record("install", agentID)
 	return f.err("install", agentID)
 }
 
 func (f *runtimeServiceFake) Uninstall(_ context.Context, agentID string) error {
+	f.record("uninstall", agentID)
 	return f.err("uninstall", agentID)
 }
 
 func (f *runtimeServiceFake) Start(_ context.Context, agentID string) error {
+	f.record("start", agentID)
 	return f.err("start", agentID)
 }
 
 func (f *runtimeServiceFake) Stop(_ context.Context, agentID string) error {
+	f.record("stop", agentID)
 	return f.err("stop", agentID)
 }
 
@@ -58,6 +63,7 @@ func (f *runtimeServiceFake) Logs(agentID string, _ int) ([]string, error) {
 }
 
 func (f *runtimeServiceFake) Upgrade(_ context.Context, agentID string) (UpgradeResult, error) {
+	f.record("upgrade", agentID)
 	if err := f.err("upgrade", agentID); err != nil {
 		return UpgradeResult{}, err
 	}
@@ -68,6 +74,7 @@ func (f *runtimeServiceFake) Upgrade(_ context.Context, agentID string) (Upgrade
 }
 
 func (f *runtimeServiceFake) Diagnose(agentID string) (string, error) {
+	f.record("diagnose", agentID)
 	if err := f.err("diagnose", agentID); err != nil {
 		return "", err
 	}
@@ -88,6 +95,13 @@ func (f *runtimeServiceFake) err(action, agentID string) error {
 		return err
 	}
 	return nil
+}
+
+func (f *runtimeServiceFake) record(action, agentID string) {
+	if f == nil {
+		return
+	}
+	f.callLog = append(f.callLog, action+":"+agentID)
 }
 
 var errMemoryMissing = errors.New("memory entry not found")

--- a/baseagent/runtime_options.go
+++ b/baseagent/runtime_options.go
@@ -1,0 +1,47 @@
+package baseagent
+
+import "path/filepath"
+
+const defaultMaxToolIterations = 4
+
+type RuntimeOption func(*Runtime)
+
+func WithWorkspaceRoot(path string) RuntimeOption {
+	return func(r *Runtime) {
+		if path != "" {
+			r.workspaceRoot = filepath.Clean(path)
+		}
+	}
+}
+
+func WithMaxToolIterations(iterations int) RuntimeOption {
+	return func(r *Runtime) {
+		if iterations > 0 {
+			r.maxToolIterations = iterations
+		}
+	}
+}
+
+func WithStructuredToolPolicy(policy StructuredToolPolicySpec) RuntimeOption {
+	return func(r *Runtime) {
+		r.structuredToolPolicyOverride = &StructuredToolPolicySpec{
+			MetadataReadDecision:      policy.MetadataReadDecision,
+			OperationalReadDecision:   policy.OperationalReadDecision,
+			WorkspaceReadDecision:     policy.WorkspaceReadDecision,
+			WorkspaceMutationDecision: policy.WorkspaceMutationDecision,
+			HighRiskDecision:          policy.HighRiskDecision,
+		}
+	}
+}
+
+func WithMCPManager(manager MCPManager) RuntimeOption {
+	return func(r *Runtime) {
+		r.mcpManager = manager
+	}
+}
+
+func WithSkillsLoader(loader SkillsLoader) RuntimeOption {
+	return func(r *Runtime) {
+		r.skillsLoader = loader
+	}
+}

--- a/baseagent/runtime_structured_loop_test.go
+++ b/baseagent/runtime_structured_loop_test.go
@@ -1,0 +1,881 @@
+package baseagent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type scriptedToolAwareProvider struct {
+	name       string
+	replies    []StructuredToolReply
+	requests   []StructuredToolRequest
+	replyCalls int
+	textCalls  int
+}
+
+func (p *scriptedToolAwareProvider) Name() string { return p.name }
+
+func (p *scriptedToolAwareProvider) Reply(_ context.Context, _ ProviderRequest) (string, error) {
+	p.textCalls++
+	return "", nil
+}
+
+func (p *scriptedToolAwareProvider) ReplyWithTools(_ context.Context, req StructuredToolRequest) (StructuredToolReply, error) {
+	p.requests = append(p.requests, req)
+	p.replyCalls++
+	reply := p.replies[0]
+	p.replies = p.replies[1:]
+	return reply, nil
+}
+
+type scriptedTextProvider struct {
+	name     string
+	replies  []string
+	requests []ProviderRequest
+}
+
+func (p *scriptedTextProvider) Name() string { return p.name }
+
+func (p *scriptedTextProvider) Reply(_ context.Context, req ProviderRequest) (string, error) {
+	p.requests = append(p.requests, req)
+	reply := p.replies[0]
+	p.replies = p.replies[1:]
+	return reply, nil
+}
+
+func TestRuntimeChatUsesToolAwareProviderLoop(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "scripted",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "write_file",
+						Arguments: map[string]any{
+							"path":    "generated.txt",
+							"content": "hello from structured loop",
+						},
+					},
+				},
+			},
+			{
+				Content: "created generated.txt",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "structured",
+		Message:  "create generated.txt",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "created generated.txt" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "generated.txt"))
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	if string(raw) != "hello from structured loop" {
+		t.Fatalf("unexpected file content: %q", string(raw))
+	}
+
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected 2 provider requests, got %d", len(provider.requests))
+	}
+	if len(provider.requests[1].Messages) == 0 {
+		t.Fatalf("expected tool result in second provider request")
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" {
+		t.Fatalf("unexpected final tool message: %+v", last)
+	}
+}
+
+func TestRuntimeChatUsesTextProviderStructuredFallback(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedTextProvider{
+		name: "scripted-text",
+		replies: []string{
+			`{"tool_calls":[{"name":"write_file","arguments":{"path":"fallback.txt","content":"created through text provider"}}]}`,
+			`{"content":"created fallback.txt","tool_calls":[]}`,
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "text-fallback",
+		Message:  "create fallback.txt",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "created fallback.txt" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "fallback.txt"))
+	if err != nil {
+		t.Fatalf("read fallback file: %v", err)
+	}
+	if string(raw) != "created through text provider" {
+		t.Fatalf("unexpected file content: %q", string(raw))
+	}
+
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected 2 provider requests, got %d", len(provider.requests))
+	}
+	if !strings.Contains(provider.requests[0].UserMessage, `"tool_calls"`) {
+		t.Fatalf("expected structured prompt in text-provider fallback, got %q", provider.requests[0].UserMessage)
+	}
+}
+
+func TestRuntimeChatStructuredLoopRecoversFromToolError(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "scripted-recover",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "read_file",
+						Arguments: map[string]any{
+							"path": "missing.txt",
+						},
+					},
+				},
+			},
+			{
+				Content: "missing file handled",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "recover",
+		Message:  "read missing.txt",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "missing file handled" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || !strings.Contains(strings.ToLower(last.Content), "read file") {
+		t.Fatalf("expected tool error to be fed back into provider, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopInjectsSessionSummary(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "summary-aware",
+		replies: []StructuredToolReply{
+			{Content: "summary seen"},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(2))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	rt.sessions.SetSummary("cli:summary", "important prior context")
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "summary",
+		Message:  "continue",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "summary seen" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 1 || len(provider.requests[0].Messages) == 0 {
+		t.Fatalf("expected initial structured request, got %+v", provider.requests)
+	}
+	first := provider.requests[0].Messages[0]
+	if first.Role != "system" || !strings.Contains(first.Content, "important prior context") {
+		t.Fatalf("expected session summary injection, got %+v", first)
+	}
+}
+
+func TestRuntimeChatStructuredLoopHandlesMultipleToolCalls(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "multi-call",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "write_file",
+						Arguments: map[string]any{
+							"path":    "one.txt",
+							"content": "one",
+						},
+					},
+					{
+						ID:   "call-2",
+						Name: "write_file",
+						Arguments: map[string]any{
+							"path":    "two.txt",
+							"content": "two",
+						},
+					},
+				},
+			},
+			{Content: "both files created"},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "multi",
+		Message:  "create two files",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "both files created" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	for _, file := range []string{"one.txt", "two.txt"} {
+		if _, err := os.Stat(filepath.Join(root, file)); err != nil {
+			t.Fatalf("expected %s to be created: %v", file, err)
+		}
+	}
+	secondReq := provider.requests[1]
+	if got := len(secondReq.Messages); got < 4 {
+		t.Fatalf("expected assistant plus two tool messages in follow-up request, got %+v", secondReq.Messages)
+	}
+	lastTwo := secondReq.Messages[len(secondReq.Messages)-2:]
+	if lastTwo[0].Role != "tool" || lastTwo[0].ToolCallID != "call-1" {
+		t.Fatalf("unexpected first tool callback message: %+v", lastTwo[0])
+	}
+	if lastTwo[1].Role != "tool" || lastTwo[1].ToolCallID != "call-2" {
+		t.Fatalf("unexpected second tool callback message: %+v", lastTwo[1])
+	}
+}
+
+func TestRuntimeChatStructuredLoopIncludesBuiltInAndWorkspaceToolDescriptors(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "descriptor-aware",
+		replies: []StructuredToolReply{
+			{Content: "done"},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(2))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "descriptor-mix",
+		Message:  "show me the available actions",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "done" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected 1 structured request, got %d", len(provider.requests))
+	}
+
+	seen := map[string]StructuredToolDescriptor{}
+	for _, descriptor := range provider.requests[0].Tools {
+		seen[descriptor.Name] = descriptor
+	}
+	if _, ok := seen["agent_status"]; !ok {
+		t.Fatalf("expected split built-in tool descriptor in structured request, got %+v", provider.requests[0].Tools)
+	}
+	if _, ok := seen["agent_action"]; ok {
+		t.Fatalf("did not expect generic agent_action descriptor in structured request, got %+v", provider.requests[0].Tools)
+	}
+	if _, ok := seen["write_file"]; !ok {
+		t.Fatalf("expected workspace tool descriptor in structured request, got %+v", provider.requests[0].Tools)
+	}
+	if _, ok := seen["exec"]; ok {
+		t.Fatalf("did not expect high-risk exec descriptor in structured request, got %+v", provider.requests[0].Tools)
+	}
+	if seen["agent_status"].Parameters == nil {
+		t.Fatalf("expected built-in descriptor schema in structured request, got %+v", seen["agent_status"])
+	}
+}
+
+func TestRuntimeChatStructuredLoopExecutesBuiltInToolCalls(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "builtin-tool-aware",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_status",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{
+				Content: "got agent status",
+			},
+		},
+	}
+
+	svc := &runtimeServiceFake{
+		agents: []AgentState{
+			{ID: "openclaw", Install: "installed", Runtime: "running", Health: "healthy"},
+		},
+		statuses: map[string]AgentState{
+			"openclaw": {ID: "openclaw", Install: "installed", Runtime: "running", Health: "healthy"},
+		},
+	}
+	rt := NewRuntime(svc, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "builtin-tool",
+		Message:  "check agent status",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "got agent status" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected tool follow-up request, got %d", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" {
+		t.Fatalf("unexpected tool callback message: %+v", last)
+	}
+	if !strings.Contains(last.Content, "openclaw") || !strings.Contains(last.Content, "runtime=running") {
+		t.Fatalf("expected built-in tool result to include agent status, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopExecutesBuiltInToolCallsWithoutWorkspaceRoot(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "builtin-only",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:        "call-1",
+						Name:      "list_agents",
+						Arguments: map[string]any{},
+					},
+				},
+			},
+			{
+				Content: "listed agents without workspace",
+			},
+		},
+	}
+
+	svc := &runtimeServiceFake{
+		agents: []AgentState{
+			{ID: "openclaw", Install: "installed", Runtime: "running", Health: "healthy"},
+		},
+	}
+	rt := NewRuntime(svc, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "builtin-noworkspace",
+		Message:  "check agent inventory",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "listed agents without workspace" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected structured loop follow-up request, got %d", len(provider.requests))
+	}
+
+	seen := map[string]StructuredToolDescriptor{}
+	for _, descriptor := range provider.requests[0].Tools {
+		seen[descriptor.Name] = descriptor
+	}
+	if _, ok := seen["list_agents"]; !ok {
+		t.Fatalf("expected built-in tool descriptor without workspace, got %+v", provider.requests[0].Tools)
+	}
+	if _, ok := seen["write_file"]; ok {
+		t.Fatalf("did not expect workspace tool descriptor without workspace root, got %+v", provider.requests[0].Tools)
+	}
+
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" {
+		t.Fatalf("unexpected tool callback message: %+v", last)
+	}
+	if !strings.Contains(last.Content, "openclaw") {
+		t.Fatalf("expected built-in tool result to include agent listing, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopAsksForHighRiskBuiltInToolCalls(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "ask-high-risk-builtin",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_start",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{
+				Content: "high risk needs confirmation",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "ask-high-risk-builtin",
+		Message:  "perform maintenance planning",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "high risk needs confirmation" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected ask callback follow-up request, got %d", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" {
+		t.Fatalf("unexpected tool callback message: %+v", last)
+	}
+	if last.ToolName != "agent_start" || last.ToolResultStatus != ExecutionToolResultStatusAsk {
+		t.Fatalf("expected structured ask metadata, got %+v", last)
+	}
+	if !strings.Contains(strings.ToLower(last.Content), "confirmation") {
+		t.Fatalf("expected high-risk ask message, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopAsksForHighRiskWorkspaceExec(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "ask-high-risk-exec",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "exec",
+						Arguments: map[string]any{
+							"command": "go test ./...",
+						},
+					},
+				},
+			},
+			{
+				Content: "exec needs confirmation",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "ask-high-risk-exec",
+		Message:  "run repository diagnostics",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "exec needs confirmation" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected ask callback follow-up request, got %d", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.Role != "tool" || last.ToolCallID != "call-1" {
+		t.Fatalf("unexpected tool callback message: %+v", last)
+	}
+	if last.ToolName != "exec" || last.ToolResultStatus != ExecutionToolResultStatusAsk {
+		t.Fatalf("expected structured ask metadata, got %+v", last)
+	}
+	if !strings.Contains(strings.ToLower(last.Content), "confirmation") {
+		t.Fatalf("expected high-risk exec ask message, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopUsesStructuredToolPolicyOverride(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "deny-high-risk-exec",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "exec",
+						Arguments: map[string]any{
+							"command": "go test ./...",
+						},
+					},
+				},
+			},
+			{
+				Content: "exec denied by override",
+			},
+		},
+	}
+
+	policy := ActiveBoundarySpec().StructuredToolPolicy
+	policy.HighRiskDecision = string(structuredToolDecisionDeny)
+
+	rt := NewRuntime(
+		&runtimeServiceFake{},
+		nil,
+		WithWorkspaceRoot(root),
+		WithMaxToolIterations(4),
+		WithStructuredToolPolicy(policy),
+	)
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "deny-high-risk-exec",
+		Message:  "run repository diagnostics",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "exec denied by override" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected deny callback follow-up request, got %d", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.ToolName != "exec" || last.ToolResultStatus != ExecutionToolResultStatusDeny {
+		t.Fatalf("expected deny metadata after runtime override, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopDeniesBlockedExecCommandByArgumentPolicy(t *testing.T) {
+	root := t.TempDir()
+	provider := &scriptedToolAwareProvider{
+		name: "deny-blocked-exec",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "exec",
+						Arguments: map[string]any{
+							"command": "rm -rf /",
+						},
+					},
+				},
+			},
+			{
+				Content: "blocked exec denied",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "deny-blocked-exec",
+		Message:  "run destructive command",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "blocked exec denied" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected deny callback follow-up request, got %d", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if last.ToolName != "exec" || last.ToolResultStatus != ExecutionToolResultStatusDeny {
+		t.Fatalf("expected argument-level deny metadata, got %+v", last)
+	}
+	if last.ToolPolicyRuleID != "exec.blocked_command" {
+		t.Fatalf("expected blocked command rule metadata, got %+v", last)
+	}
+}
+
+func TestRuntimeChatStructuredLoopConfirmExecutesPendingApproval(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "confirm-pending",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_start",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{
+				Content: "please confirm the pending start",
+			},
+			{
+				Content: "confirmed and started openclaw",
+			},
+		},
+	}
+
+	svc := &runtimeServiceFake{}
+	rt := NewRuntime(svc, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	firstResp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "confirm-pending",
+		Message:  "perform maintenance planning",
+	})
+	if err != nil {
+		t.Fatalf("first runtime chat: %v", err)
+	}
+	if firstResp.Message != "please confirm the pending start" {
+		t.Fatalf("unexpected first response: %+v", firstResp)
+	}
+	pending := rt.sessions.PendingApproval("cli:confirm-pending")
+	if pending == nil || pending.ToolName != "agent_start" {
+		t.Fatalf("expected pending approval for agent_start, got %+v", pending)
+	}
+
+	secondResp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "confirm-pending",
+		Message:  "confirm",
+	})
+	if err != nil {
+		t.Fatalf("second runtime chat: %v", err)
+	}
+	if secondResp.Message != "confirmed and started openclaw" {
+		t.Fatalf("unexpected confirmation response: %+v", secondResp)
+	}
+	if pending := rt.sessions.PendingApproval("cli:confirm-pending"); pending != nil {
+		t.Fatalf("expected pending approval to be cleared after confirm, got %+v", pending)
+	}
+	if len(svc.callLog) != 1 || svc.callLog[0] != "start:openclaw" {
+		t.Fatalf("expected confirmed tool execution, got %+v", svc.callLog)
+	}
+	if len(provider.requests) != 3 {
+		t.Fatalf("expected confirmation to resume provider loop, got %d requests", len(provider.requests))
+	}
+}
+
+func TestRuntimeChatStructuredLoopCancelClearsPendingApproval(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "cancel-pending",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "agent_start",
+						Arguments: map[string]any{
+							"agent_id": "openclaw",
+						},
+					},
+				},
+			},
+			{
+				Content: "please confirm the pending start",
+			},
+		},
+	}
+
+	svc := &runtimeServiceFake{}
+	rt := NewRuntime(svc, nil, WithMaxToolIterations(4))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	if _, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "cancel-pending",
+		Message:  "perform maintenance planning",
+	}); err != nil {
+		t.Fatalf("first runtime chat: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "cancel-pending",
+		Message:  "cancel",
+	})
+	if err != nil {
+		t.Fatalf("cancel runtime chat: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(resp.Message), "canceled pending approval") {
+		t.Fatalf("unexpected cancel response: %+v", resp)
+	}
+	if pending := rt.sessions.PendingApproval("cli:cancel-pending"); pending != nil {
+		t.Fatalf("expected pending approval to be cleared after cancel, got %+v", pending)
+	}
+	if len(svc.callLog) != 0 {
+		t.Fatalf("expected cancel to skip tool execution, got %+v", svc.callLog)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected cancel to skip provider resume, got %d requests", len(provider.requests))
+	}
+}
+
+func TestAgentLoopStructuredLoopStopsAtMaxIterations(t *testing.T) {
+	provider := &scriptedToolAwareProvider{
+		name: "infinite-tools",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{ID: "call-1", Name: "list_dir", Arguments: map[string]any{"path": "."}},
+				},
+			},
+			{
+				ToolCalls: []StructuredToolCall{
+					{ID: "call-2", Name: "list_dir", Arguments: map[string]any{"path": "."}},
+				},
+			},
+			{
+				ToolCalls: []StructuredToolCall{
+					{ID: "call-3", Name: "list_dir", Arguments: map[string]any{"path": "."}},
+				},
+			},
+		},
+	}
+
+	pm := NewProviderManager(provider)
+	sessions := NewSessionManager(8)
+	loop := NewAgentLoop(&runtimeServiceFake{}, NewToolRegistry(), pm, sessions, NewMessageBus(0, 0, 0))
+	loop.SetExecutionTools(NewExecutionToolRegistry(t.TempDir()), 2, ActiveBoundarySpec().StructuredToolPolicy, nil)
+
+	_, handled, err := loop.processStructuredChat(context.Background(), "cli:max-iterations", []ConversationMessage{
+		{Role: "user", Content: "loop forever"},
+	}, "")
+	if !handled {
+		t.Fatal("expected structured loop to handle request")
+	}
+	if err == nil || !strings.Contains(err.Error(), "max iterations") {
+		t.Fatalf("expected max iteration failure, got %v", err)
+	}
+}

--- a/baseagent/session_metadata_test.go
+++ b/baseagent/session_metadata_test.go
@@ -1,0 +1,29 @@
+package baseagent
+
+import (
+	"testing"
+)
+
+func TestSessionManagerPersistsStructuredToolMetadata(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSessionManagerWithStorage(8, dir)
+	sm.AddStructuredToolMessage("cli:meta", StructuredToolMessage{
+		Role:             "tool",
+		Content:          "needs confirmation",
+		ToolCallID:       "call-1",
+		ToolName:         "exec",
+		ToolResultStatus: ExecutionToolResultStatusAsk,
+	})
+
+	reloaded := NewSessionManagerWithStorage(8, dir)
+	got := reloaded.StructuredHistory("cli:meta")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 structured event, got %+v", got)
+	}
+	if got[0].ToolCallID != "call-1" || got[0].ToolName != "exec" || got[0].ToolResultStatus != ExecutionToolResultStatusAsk {
+		t.Fatalf("unexpected structured history metadata: %+v", got[0])
+	}
+	if got[0].Content != "needs confirmation" {
+		t.Fatalf("unexpected structured history content: %+v", got[0])
+	}
+}

--- a/baseagent/skills_loader.go
+++ b/baseagent/skills_loader.go
@@ -1,0 +1,22 @@
+package baseagent
+
+import (
+	"context"
+	"strings"
+)
+
+type SkillsLoader interface {
+	RelevantSkillsSummary(ctx context.Context, message string) string
+}
+
+func composeSkillAwareSystemPrompt(basePrompt, skillSummary string) string {
+	basePrompt = strings.TrimSpace(basePrompt)
+	skillSummary = strings.TrimSpace(skillSummary)
+	if skillSummary == "" {
+		return basePrompt
+	}
+	if basePrompt == "" {
+		return "Relevant skills summary:\n" + skillSummary
+	}
+	return basePrompt + "\n\nRelevant skills summary:\n" + skillSummary
+}

--- a/baseagent/skills_loader_test.go
+++ b/baseagent/skills_loader_test.go
@@ -1,0 +1,102 @@
+package baseagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeSkillsLoader struct {
+	summary string
+	calls   []string
+}
+
+func (f *fakeSkillsLoader) RelevantSkillsSummary(_ context.Context, message string) string {
+	f.calls = append(f.calls, message)
+	return f.summary
+}
+
+func (f *fakeSkillsLoader) WasConsulted() bool {
+	return len(f.calls) > 0
+}
+
+func TestProviderRequestIncludesRelevantSkillsSummary(t *testing.T) {
+	loader := &fakeSkillsLoader{summary: "Use go test before claiming success."}
+	provider := &scriptedTextProvider{
+		name:    "skills-text",
+		replies: []string{"done"},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithSkillsLoader(loader))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	_, _ = rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "skills",
+		Message:  "run repository diagnostics",
+	})
+
+	if !loader.WasConsulted() {
+		t.Fatal("expected skills loader to contribute provider context")
+	}
+	if len(provider.requests) != 1 || !strings.Contains(provider.requests[0].SystemPrompt, loader.summary) {
+		t.Fatalf("expected provider request to include skills summary, got %+v", provider.requests)
+	}
+}
+
+func TestStructuredLoopCarriesSkillSummaryAcrossTurns(t *testing.T) {
+	root := t.TempDir()
+	loader := &fakeSkillsLoader{summary: "Prefer bounded workspace reads before edits."}
+	provider := &scriptedToolAwareProvider{
+		name: "skills-structured",
+		replies: []StructuredToolReply{
+			{
+				ToolCalls: []StructuredToolCall{
+					{
+						ID:   "call-1",
+						Name: "list_dir",
+						Arguments: map[string]any{
+							"path": ".",
+						},
+					},
+				},
+			},
+			{
+				Content: "listed workspace",
+			},
+		},
+	}
+
+	rt := NewRuntime(&runtimeServiceFake{}, nil, WithWorkspaceRoot(root), WithMaxToolIterations(4), WithSkillsLoader(loader))
+	if err := rt.RegisterProvider(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := rt.SetActiveProvider(provider.Name()); err != nil {
+		t.Fatalf("set active provider: %v", err)
+	}
+
+	resp, err := rt.Chat(context.Background(), ChatRequest{
+		Provider: "cli",
+		ChatID:   "skills-structured",
+		Message:  "inspect the workspace",
+	})
+	if err != nil {
+		t.Fatalf("runtime chat: %v", err)
+	}
+	if resp.Message != "listed workspace" {
+		t.Fatalf("unexpected chat response: %+v", resp)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected two structured requests, got %d", len(provider.requests))
+	}
+	for _, req := range provider.requests {
+		if !strings.Contains(req.SystemPrompt, loader.summary) {
+			t.Fatalf("expected structured request to carry skills summary, got %+v", provider.requests)
+		}
+	}
+}

--- a/baseagent/spec/baseagent-boundary.v1.json
+++ b/baseagent/spec/baseagent-boundary.v1.json
@@ -1,31 +1,40 @@
 {
   "schema_version": "carrier.baseagent.boundary.v1",
-  "assistant_role": "Carrier product-specific assistant for controlled agent installation and maintenance.",
+  "assistant_role": "Carrier product-specific assistant for controlled agent maintenance and bounded workspace automation.",
   "in_scope": [
     "Understand user intent and map it to approved install/maintenance workflows.",
     "Run policy-bounded lifecycle operations for agent instances.",
+    "Inspect, create, edit, append, and list files inside the configured workspace root.",
+    "Run bounded shell commands inside the configured workspace root when a chat task needs local execution.",
     "Collect logs, summarize failures, and trigger bounded repair attempts.",
     "Escalate unresolved failures to diagnose artifact generation and consented remote handoff."
   ],
   "out_of_scope": [
-    "Arbitrary free-form shell execution outside approved workflows.",
+    "Arbitrary shell or file execution outside the configured workspace root.",
     "Executing unreviewed installer scripts or unknown binaries.",
     "Cross-host operations without an explicit host binding context.",
     "Automatic destructive changes without explicit user confirmation."
   ],
   "boundary_sources": [
     "System/runtime safety constraints and auth/session gates.",
-    "Base-agent tool allowlist and repair action policy.",
+    "Base-agent tool allowlist, workspace confinement, and execution safety policy.",
     "Gateway command allowlist and command-level authorization checks.",
     "Daemon API contracts and workflow-specific preflight checks."
   ],
   "design_principles": [
     "Least privilege by default.",
     "Deterministic command surface with explicit handlers.",
-    "Workflow-first execution over free-form command execution.",
+    "Workspace-confined execution over unrestricted host access.",
     "Auditability for every lifecycle and repair operation.",
     "Fail-safe escalation when repair policy bounds are exceeded."
   ],
+  "structured_tool_policy": {
+    "metadata_read_decision": "allow",
+    "operational_read_decision": "allow",
+    "workspace_read_decision": "allow",
+    "workspace_mutation_decision": "allow",
+    "high_risk_decision": "ask"
+  },
   "command_policies": {
     "chat_install": "requires_host_binding",
     "chat_onboard": "disabled",

--- a/baseagent/structured_loop.go
+++ b/baseagent/structured_loop.go
@@ -1,0 +1,196 @@
+package baseagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func buildStructuredSystemPrompt(skillSummary string) string {
+	return composeSkillAwareSystemPrompt(baseAgentExecutionPrompt, skillSummary)
+}
+
+func structuredToolMessagesFromHistory(summary string, history []StructuredToolMessage) []StructuredToolMessage {
+	out := make([]StructuredToolMessage, 0, len(history)+1)
+	if trimmed := strings.TrimSpace(summary); trimmed != "" {
+		out = append(out, StructuredToolMessage{
+			Role:    "system",
+			Content: "Session summary:\n" + trimmed,
+		})
+	}
+	for _, msg := range history {
+		msg = normalizeStructuredToolMessage(msg)
+		if msg.Role == "" {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func renderStructuredToolCallSummary(calls []StructuredToolCall) string {
+	if len(calls) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(calls))
+	for _, call := range calls {
+		name := strings.TrimSpace(call.Name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return "Tool call requested"
+	}
+	return "Tool call requested: " + strings.Join(names, ", ")
+}
+
+func normalizeExecutionToolResultStatus(result ExecutionToolResult) ExecutionToolResultStatus {
+	status := result.Status
+	if status != "" {
+		return status
+	}
+	if result.IsError {
+		return ExecutionToolResultStatusError
+	}
+	return ExecutionToolResultStatusOK
+}
+
+func renderStructuredToolResultOutput(toolName string, result ExecutionToolResult) string {
+	toolOutput := strings.TrimSpace(result.Output)
+	if toolOutput == "" {
+		toolOutput = strings.TrimSpace(result.Stdout)
+	}
+	if toolOutput == "" && strings.TrimSpace(result.Stderr) != "" {
+		toolOutput = strings.TrimSpace(result.Stderr)
+	}
+	if toolOutput == "" {
+		toolOutput = fmt.Sprintf("tool %s completed", strings.TrimSpace(toolName))
+	}
+	return toolOutput
+}
+
+func formatPendingApprovalToolOutput(base string, pending *PendingToolApproval) string {
+	base = strings.TrimSpace(base)
+	if pending == nil {
+		return base
+	}
+	line := fmt.Sprintf("Reply with 'confirm' to continue or 'cancel' to decline. approval_id=%s", strings.TrimSpace(pending.ID))
+	if base == "" {
+		return line
+	}
+	return base + "\n" + line
+}
+
+func (l *AgentLoop) SetExecutionTools(registry *ExecutionToolRegistry, maxIterations int, policySpec StructuredToolPolicySpec, mcpManager MCPManager) {
+	l.executionTools = registry
+	l.structuredTools = newStructuredToolSurfaceWithPolicy(l.tools, registry, mcpManager, policySpec)
+	if maxIterations <= 0 {
+		maxIterations = 6
+	}
+	l.maxToolIterations = maxIterations
+}
+
+func (l *AgentLoop) processStructuredChat(
+	ctx context.Context,
+	sessionKey string,
+	legacyHistory []ConversationMessage,
+	skillSummary string,
+) (ChatResponse, bool, error) {
+	if l == nil || l.structuredTools == nil || l.providers == nil {
+		return ChatResponse{}, false, nil
+	}
+
+	summary := ""
+	var structuredHistory []StructuredToolMessage
+	if l.sessions != nil {
+		summary = l.sessions.Summary(sessionKey)
+		structuredHistory = l.sessions.StructuredHistory(sessionKey)
+	}
+	if len(structuredHistory) == 0 {
+		structuredHistory = structuredMessagesFromConversationHistory(legacyHistory)
+	}
+	messages := structuredToolMessagesFromHistory(summary, structuredHistory)
+	turnLimit := l.maxToolIterations
+	if turnLimit <= 0 {
+		turnLimit = 6
+	}
+
+	for turn := 0; turn < turnLimit; turn++ {
+		reply, err := l.providers.ReplyWithTools(ctx, StructuredToolRequest{
+			SystemPrompt: buildStructuredSystemPrompt(skillSummary),
+			Messages:     messages,
+			Tools:        l.structuredTools.Descriptors(),
+		})
+		if err != nil {
+			return ChatResponse{}, true, err
+		}
+
+		if len(reply.ToolCalls) == 0 {
+			return ChatResponse{
+				Message: strings.TrimSpace(reply.Content),
+				Action:  "chat",
+			}, true, nil
+		}
+
+		assistantContent := strings.TrimSpace(reply.Content)
+		if assistantContent == "" {
+			assistantContent = renderStructuredToolCallSummary(reply.ToolCalls)
+		}
+		messages = append(messages, StructuredToolMessage{
+			Role:      "assistant",
+			Content:   assistantContent,
+			ToolCalls: reply.ToolCalls,
+		})
+		if l.sessions != nil {
+			l.sessions.AddStructuredToolMessage(sessionKey, StructuredToolMessage{
+				Role:      "assistant",
+				Content:   assistantContent,
+				ToolCalls: reply.ToolCalls,
+			})
+		}
+
+		for _, call := range reply.ToolCalls {
+			result := l.structuredTools.Execute(ctx, call.Name, call.Arguments)
+			status := normalizeExecutionToolResultStatus(result)
+			toolOutput := renderStructuredToolResultOutput(call.Name, result)
+			if status == ExecutionToolResultStatusAsk && l.sessions != nil {
+				requestedAt := time.Now().UTC()
+				pending := &PendingToolApproval{
+					ID:          fmt.Sprintf("approval-%d", requestedAt.UnixNano()),
+					ToolName:    strings.TrimSpace(call.Name),
+					Arguments:   cloneToolSchema(call.Arguments),
+					RequestedAt: requestedAt,
+					ExpiresAt:   requestedAt.Add(defaultPendingApprovalTTL),
+					Reason:      strings.TrimSpace(result.PolicyReason),
+					RuleID:      strings.TrimSpace(result.PolicyRuleID),
+				}
+				l.sessions.SetPendingApproval(sessionKey, pending)
+				toolOutput = formatPendingApprovalToolOutput(toolOutput, pending)
+			}
+			messages = append(messages, StructuredToolMessage{
+				Role:             "tool",
+				Content:          toolOutput,
+				ToolCallID:       call.ID,
+				ToolName:         strings.TrimSpace(call.Name),
+				ToolResultStatus: status,
+				ToolPolicyReason: strings.TrimSpace(result.PolicyReason),
+				ToolPolicyRuleID: strings.TrimSpace(result.PolicyRuleID),
+			})
+			if l.sessions != nil {
+				l.sessions.AddStructuredToolMessage(sessionKey, StructuredToolMessage{
+					Role:             "tool",
+					Content:          toolOutput,
+					ToolCallID:       call.ID,
+					ToolName:         strings.TrimSpace(call.Name),
+					ToolResultStatus: status,
+					ToolPolicyReason: strings.TrimSpace(result.PolicyReason),
+					ToolPolicyRuleID: strings.TrimSpace(result.PolicyRuleID),
+				})
+			}
+		}
+	}
+
+	return ChatResponse{}, true, fmt.Errorf("structured tool loop exceeded max iterations")
+}

--- a/baseagent/structured_policy.go
+++ b/baseagent/structured_policy.go
@@ -1,0 +1,76 @@
+package baseagent
+
+import "strings"
+
+const (
+	structuredPolicyRuleExecBlockedCommand     = "exec.blocked_command"
+	structuredPolicyRuleExecConfirmationNeeded = "exec.confirmation_required"
+	structuredPolicyRuleExecPermissionDenied   = "exec.permission_denied"
+	structuredPolicyRuleAgentConfirmation      = "agent.lifecycle_confirmation_required"
+	structuredPolicyRuleAgentPermissionDenied  = "agent.lifecycle_permission_denied"
+)
+
+type StructuredPolicyDecision struct {
+	Decision structuredToolDecision
+	Reason   string
+	RuleID   string
+}
+
+func evaluateStructuredToolPolicy(toolName string, args map[string]any, defaultDecision structuredToolDecision) StructuredPolicyDecision {
+	name := strings.TrimSpace(toolName)
+	switch name {
+	case "exec":
+		return evaluateStructuredExecPolicy(args, defaultDecision)
+	case "agent_start", "agent_stop", "agent_upgrade", "agent_uninstall", "agent_diagnose":
+		return evaluateStructuredAgentLifecyclePolicy(defaultDecision)
+	default:
+		return StructuredPolicyDecision{Decision: defaultDecision}
+	}
+}
+
+func evaluateStructuredExecPolicy(args map[string]any, defaultDecision structuredToolDecision) StructuredPolicyDecision {
+	command := strings.TrimSpace(stringifyStructuredToolArg(args["command"]))
+	if isStructuredExecCommandDenied(command) {
+		return StructuredPolicyDecision{
+			Decision: structuredToolDecisionDeny,
+			Reason:   "Command matches blocked execution policy.",
+			RuleID:   structuredPolicyRuleExecBlockedCommand,
+		}
+	}
+
+	switch defaultDecision {
+	case structuredToolDecisionAsk:
+		return StructuredPolicyDecision{
+			Decision: defaultDecision,
+			Reason:   "Shell execution requires confirmation.",
+			RuleID:   structuredPolicyRuleExecConfirmationNeeded,
+		}
+	case structuredToolDecisionDeny:
+		return StructuredPolicyDecision{
+			Decision: defaultDecision,
+			Reason:   "Shell execution is unavailable at the current permission level.",
+			RuleID:   structuredPolicyRuleExecPermissionDenied,
+		}
+	default:
+		return StructuredPolicyDecision{Decision: defaultDecision}
+	}
+}
+
+func evaluateStructuredAgentLifecyclePolicy(defaultDecision structuredToolDecision) StructuredPolicyDecision {
+	switch defaultDecision {
+	case structuredToolDecisionAsk:
+		return StructuredPolicyDecision{
+			Decision: defaultDecision,
+			Reason:   "Agent lifecycle mutation requires confirmation.",
+			RuleID:   structuredPolicyRuleAgentConfirmation,
+		}
+	case structuredToolDecisionDeny:
+		return StructuredPolicyDecision{
+			Decision: defaultDecision,
+			Reason:   "Agent lifecycle mutation is unavailable at the current permission level.",
+			RuleID:   structuredPolicyRuleAgentPermissionDenied,
+		}
+	default:
+		return StructuredPolicyDecision{Decision: defaultDecision}
+	}
+}

--- a/baseagent/structured_policy_test.go
+++ b/baseagent/structured_policy_test.go
@@ -1,0 +1,15 @@
+package baseagent
+
+import "testing"
+
+func TestStructuredPolicyClassifiesExecCommandsDifferently(t *testing.T) {
+	allow := evaluateStructuredToolPolicy("exec", map[string]any{"command": "go test ./..."}, structuredToolDecisionAsk)
+	deny := evaluateStructuredToolPolicy("exec", map[string]any{"command": "rm -rf /"}, structuredToolDecisionAsk)
+
+	if allow.Decision != structuredToolDecisionAsk || allow.RuleID == "" || allow.Reason == "" {
+		t.Fatalf("expected bounded test command to require confirmation with audit metadata, got %+v", allow)
+	}
+	if deny.Decision != structuredToolDecisionDeny || deny.RuleID == "" || deny.Reason == "" {
+		t.Fatalf("expected dangerous command deny with audit metadata, got %+v", deny)
+	}
+}

--- a/baseagent/structured_provider.go
+++ b/baseagent/structured_provider.go
@@ -1,0 +1,148 @@
+package baseagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type StructuredToolCall struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type StructuredToolMessage struct {
+	Role             string                    `json:"role"`
+	Content          string                    `json:"content,omitempty"`
+	ToolCallID       string                    `json:"toolCallId,omitempty"`
+	ToolName         string                    `json:"toolName,omitempty"`
+	ToolResultStatus ExecutionToolResultStatus `json:"toolResultStatus,omitempty"`
+	ToolPolicyReason string                    `json:"toolPolicyReason,omitempty"`
+	ToolPolicyRuleID string                    `json:"toolPolicyRuleId,omitempty"`
+	ToolCalls        []StructuredToolCall      `json:"toolCalls,omitempty"`
+}
+
+type StructuredToolRequest struct {
+	SystemPrompt string                     `json:"systemPrompt"`
+	Messages     []StructuredToolMessage    `json:"messages"`
+	Tools        []StructuredToolDescriptor `json:"tools"`
+}
+
+type StructuredToolReply struct {
+	Content   string               `json:"content"`
+	ToolCalls []StructuredToolCall `json:"tool_calls,omitempty"`
+}
+
+type ToolAwareProvider interface {
+	Provider
+	ReplyWithTools(ctx context.Context, req StructuredToolRequest) (StructuredToolReply, error)
+}
+
+func replyWithToolsViaTextProvider(ctx context.Context, provider Provider, req StructuredToolRequest) (StructuredToolReply, error) {
+	if provider == nil {
+		return StructuredToolReply{}, fmt.Errorf("provider is required")
+	}
+
+	raw, err := provider.Reply(ctx, ProviderRequest{
+		SystemPrompt: req.SystemPrompt,
+		UserMessage:  buildStructuredToolPrompt(req),
+	})
+	if err != nil {
+		return StructuredToolReply{}, err
+	}
+	return parseStructuredToolReply(raw)
+}
+
+func buildStructuredToolPrompt(req StructuredToolRequest) string {
+	lines := []string{
+		"Return JSON only.",
+		`Use this exact shape: {"content":"assistant text","tool_calls":[{"id":"call-1","name":"tool_name","arguments":{}}]}`,
+		"If no tool is needed, return an empty tool_calls array.",
+		"Do not wrap JSON in markdown fences.",
+	}
+	if len(req.Tools) > 0 {
+		lines = append(lines, "", "Available tools:")
+		for _, tool := range req.Tools {
+			params := "{}"
+			if len(tool.Parameters) > 0 {
+				if raw, err := json.Marshal(tool.Parameters); err == nil {
+					params = string(raw)
+				}
+			}
+			lines = append(lines, fmt.Sprintf("- %s: %s | parameters=%s", tool.Name, tool.Description, params))
+		}
+	}
+	lines = append(lines, "", "Conversation:")
+	for _, msg := range req.Messages {
+		if msg.ToolCallID != "" {
+			lines = append(lines, renderStructuredToolPromptMessage(msg))
+			continue
+		}
+		if len(msg.ToolCalls) > 0 {
+			raw, _ := json.Marshal(msg.ToolCalls)
+			lines = append(lines, fmt.Sprintf("%s: %s | tool_calls=%s", msg.Role, msg.Content, string(raw)))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", msg.Role, msg.Content))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderStructuredToolPromptMessage(msg StructuredToolMessage) string {
+	suffix := ""
+	if status := strings.TrimSpace(string(msg.ToolResultStatus)); status != "" {
+		suffix += fmt.Sprintf("[%s]", status)
+	}
+	if name := strings.TrimSpace(msg.ToolName); name != "" {
+		suffix += fmt.Sprintf("[%s]", name)
+	}
+	if ruleID := strings.TrimSpace(msg.ToolPolicyRuleID); ruleID != "" {
+		suffix += fmt.Sprintf("[rule=%s]", ruleID)
+	}
+	if reason := strings.TrimSpace(msg.ToolPolicyReason); reason != "" {
+		suffix += fmt.Sprintf("[reason=%s]", reason)
+	}
+	return fmt.Sprintf("%s(%s)%s: %s", msg.Role, msg.ToolCallID, suffix, msg.Content)
+}
+
+func parseStructuredToolReply(raw string) (StructuredToolReply, error) {
+	trimmed := strings.TrimSpace(raw)
+	candidate := strings.TrimSpace(extractJSONCandidate(raw))
+	if candidate == "" {
+		if looksLikeStructuredReply(trimmed) {
+			return StructuredToolReply{}, fmt.Errorf("parse structured tool reply: invalid json payload")
+		}
+		return StructuredToolReply{Content: trimmed}, nil
+	}
+
+	var reply StructuredToolReply
+	if err := json.Unmarshal([]byte(candidate), &reply); err != nil {
+		return StructuredToolReply{}, fmt.Errorf("parse structured tool reply: %w", err)
+	}
+	reply.Content = strings.TrimSpace(reply.Content)
+	for i := range reply.ToolCalls {
+		call := &reply.ToolCalls[i]
+		call.ID = strings.TrimSpace(call.ID)
+		call.Name = strings.TrimSpace(call.Name)
+		if call.Arguments == nil {
+			call.Arguments = map[string]any{}
+		}
+		if call.ID == "" {
+			call.ID = fmt.Sprintf("call-%d", i+1)
+		}
+	}
+	return reply, nil
+}
+
+func looksLikeStructuredReply(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	return strings.HasPrefix(raw, "{") ||
+		strings.HasPrefix(raw, "[") ||
+		strings.HasPrefix(raw, "```") ||
+		strings.Contains(raw, `"tool_calls"`)
+}

--- a/baseagent/structured_provider_test.go
+++ b/baseagent/structured_provider_test.go
@@ -1,0 +1,127 @@
+package baseagent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestParseStructuredToolReplyRejectsMalformedJSON(t *testing.T) {
+	_, err := parseStructuredToolReply(`{"tool_calls":[{"name":"write_file","arguments":{"path":"x.txt"}}`)
+	if err == nil {
+		t.Fatal("expected malformed structured reply to fail")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "parse structured tool reply") {
+		t.Fatalf("unexpected malformed structured reply error: %v", err)
+	}
+}
+
+func TestParseStructuredToolReplyHandlesFencedJSONAndDefaultCallID(t *testing.T) {
+	reply, err := parseStructuredToolReply("```json\n{\"tool_calls\":[{\"name\":\"write_file\",\"arguments\":{\"path\":\"x.txt\",\"content\":\"hello\"}}]}\n```")
+	if err != nil {
+		t.Fatalf("parse structured tool reply: %v", err)
+	}
+	if len(reply.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %+v", reply)
+	}
+	if reply.ToolCalls[0].ID != "call-1" {
+		t.Fatalf("expected default call id, got %+v", reply.ToolCalls[0])
+	}
+}
+
+func TestToolRegistryConcurrentAccess(t *testing.T) {
+	reg := NewToolRegistry()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := "tool-" + string(rune('a'+i%8))
+			_ = reg.RegisterTool(ToolSpec{
+				Name:        name,
+				Description: "concurrent test tool",
+				Match:       func(string) (ToolInvocation, bool) { return ToolInvocation{}, false },
+				Run: func(context.Context, ToolInvocation) (ChatResponse, error) {
+					return ChatResponse{Message: "ok"}, nil
+				},
+			})
+			_ = reg.ListToolNames()
+			_ = reg.ListToolDescriptors()
+			_ = reg.RenderToolSummary()
+			_, _ = reg.ExecuteTool(context.Background(), name, map[string]string{})
+		}(i)
+	}
+
+	wg.Wait()
+	if len(reg.ListToolNames()) == 0 {
+		t.Fatal("expected tools to remain registered after concurrent access")
+	}
+}
+
+func TestBuildStructuredToolPromptIncludesToolResultMetadata(t *testing.T) {
+	prompt := buildStructuredToolPrompt(StructuredToolRequest{
+		SystemPrompt: "system",
+		Messages: []StructuredToolMessage{
+			{
+				Role:             "tool",
+				Content:          "tool exec requires confirmation before automatic structured execution",
+				ToolCallID:       "call-1",
+				ToolName:         "exec",
+				ToolResultStatus: ExecutionToolResultStatusAsk,
+			},
+		},
+	})
+
+	if !strings.Contains(prompt, "tool(call-1)[ask][exec]: tool exec requires confirmation before automatic structured execution") {
+		t.Fatalf("expected prompt to include structured tool result metadata, got %q", prompt)
+	}
+}
+
+func TestBuildStructuredToolPromptIncludesStructuredHistoryMetadata(t *testing.T) {
+	sessions := NewSessionManager(8)
+	sessionKey := "cli:structured-prompt"
+
+	sessions.AddMessage(sessionKey, "user", "run the tests")
+	sessions.AddStructuredToolMessage(sessionKey, StructuredToolMessage{
+		Role:             "tool",
+		Content:          "tool exec requires confirmation before automatic structured execution",
+		ToolCallID:       "call-1",
+		ToolName:         "exec",
+		ToolResultStatus: ExecutionToolResultStatusAsk,
+	})
+
+	prompt := buildStructuredToolPrompt(StructuredToolRequest{
+		SystemPrompt: "system",
+		Messages:     sessions.StructuredHistory(sessionKey),
+	})
+
+	if !strings.Contains(prompt, "tool(call-1)[ask][exec]: tool exec requires confirmation before automatic structured execution") {
+		t.Fatalf("expected prompt to include structured history metadata, got %q", prompt)
+	}
+}
+
+func TestStructuredToolPromptIncludesPolicyReasonMetadata(t *testing.T) {
+	prompt := buildStructuredToolPrompt(StructuredToolRequest{
+		SystemPrompt: "system",
+		Messages: []StructuredToolMessage{
+			{
+				Role:             "tool",
+				Content:          "command denied by execution safety policy",
+				ToolCallID:       "call-1",
+				ToolName:         "exec",
+				ToolResultStatus: ExecutionToolResultStatusDeny,
+				ToolPolicyRuleID: "exec.blocked_command",
+				ToolPolicyReason: "Command matches blocked execution policy.",
+			},
+		},
+	})
+
+	if !strings.Contains(prompt, "[rule=exec.blocked_command]") {
+		t.Fatalf("expected prompt to include rule id metadata, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "[reason=Command matches blocked execution policy.]") {
+		t.Fatalf("expected prompt to include policy reason metadata, got %q", prompt)
+	}
+}

--- a/baseagent/structured_tool_surface.go
+++ b/baseagent/structured_tool_surface.go
@@ -1,0 +1,378 @@
+package baseagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type structuredToolTier string
+type structuredToolDecision string
+
+const (
+	structuredToolTierMetadataRead      structuredToolTier = "metadata_read"
+	structuredToolTierOperationalRead   structuredToolTier = "operational_read"
+	structuredToolTierWorkspaceRead     structuredToolTier = "workspace_read"
+	structuredToolTierWorkspaceMutation structuredToolTier = "workspace_mutation"
+	structuredToolTierHighRisk          structuredToolTier = "high_risk"
+
+	structuredToolDecisionAllow structuredToolDecision = "allow"
+	structuredToolDecisionAsk   structuredToolDecision = "ask"
+	structuredToolDecisionDeny  structuredToolDecision = "deny"
+)
+
+type structuredToolPolicy struct {
+	decisions map[structuredToolTier]structuredToolDecision
+}
+
+func defaultStructuredToolPolicySpec(hasWorkspace bool) StructuredToolPolicySpec {
+	spec := StructuredToolPolicySpec{
+		MetadataReadDecision:    string(structuredToolDecisionAllow),
+		OperationalReadDecision: string(structuredToolDecisionAllow),
+		HighRiskDecision:        string(structuredToolDecisionAsk),
+	}
+	if hasWorkspace {
+		spec.WorkspaceReadDecision = string(structuredToolDecisionAllow)
+		spec.WorkspaceMutationDecision = string(structuredToolDecisionAllow)
+	} else {
+		spec.WorkspaceReadDecision = string(structuredToolDecisionDeny)
+		spec.WorkspaceMutationDecision = string(structuredToolDecisionDeny)
+	}
+	return spec
+}
+
+func parseStructuredToolDecision(raw string) structuredToolDecision {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(structuredToolDecisionAllow):
+		return structuredToolDecisionAllow
+	case string(structuredToolDecisionAsk):
+		return structuredToolDecisionAsk
+	case string(structuredToolDecisionDeny):
+		return structuredToolDecisionDeny
+	default:
+		return ""
+	}
+}
+
+func structuredToolPolicyFromSpec(spec StructuredToolPolicySpec, hasWorkspace bool) structuredToolPolicy {
+	resolved := defaultStructuredToolPolicySpec(hasWorkspace)
+	if decision := parseStructuredToolDecision(spec.MetadataReadDecision); decision != "" {
+		resolved.MetadataReadDecision = string(decision)
+	}
+	if decision := parseStructuredToolDecision(spec.OperationalReadDecision); decision != "" {
+		resolved.OperationalReadDecision = string(decision)
+	}
+	if decision := parseStructuredToolDecision(spec.WorkspaceReadDecision); decision != "" {
+		resolved.WorkspaceReadDecision = string(decision)
+	}
+	if decision := parseStructuredToolDecision(spec.WorkspaceMutationDecision); decision != "" {
+		resolved.WorkspaceMutationDecision = string(decision)
+	}
+	if decision := parseStructuredToolDecision(spec.HighRiskDecision); decision != "" {
+		resolved.HighRiskDecision = string(decision)
+	}
+	return structuredToolPolicy{
+		decisions: map[structuredToolTier]structuredToolDecision{
+			structuredToolTierMetadataRead:      parseStructuredToolDecision(resolved.MetadataReadDecision),
+			structuredToolTierOperationalRead:   parseStructuredToolDecision(resolved.OperationalReadDecision),
+			structuredToolTierWorkspaceRead:     parseStructuredToolDecision(resolved.WorkspaceReadDecision),
+			structuredToolTierWorkspaceMutation: parseStructuredToolDecision(resolved.WorkspaceMutationDecision),
+			structuredToolTierHighRisk:          parseStructuredToolDecision(resolved.HighRiskDecision),
+		},
+	}
+}
+
+func (p structuredToolPolicy) decision(tier structuredToolTier) structuredToolDecision {
+	decision := p.decisions[tier]
+	if decision == "" {
+		return structuredToolDecisionDeny
+	}
+	return decision
+}
+
+type structuredToolDefinition struct {
+	descriptor StructuredToolDescriptor
+	tier       structuredToolTier
+	execute    func(context.Context, map[string]any) ExecutionToolResult
+}
+
+type structuredToolSurface struct {
+	policy structuredToolPolicy
+	order  []string
+	tools  map[string]structuredToolDefinition
+}
+
+var structuredBuiltinPassthroughTiers = map[string]structuredToolTier{
+	"help":            structuredToolTierMetadataRead,
+	"list_agents":     structuredToolTierOperationalRead,
+	"list_tools":      structuredToolTierMetadataRead,
+	"list_providers":  structuredToolTierMetadataRead,
+	"list_sessions":   structuredToolTierMetadataRead,
+	"show_boundaries": structuredToolTierMetadataRead,
+}
+
+func newStructuredToolSurface(builtin *ToolRegistry, workspace *ExecutionToolRegistry) *structuredToolSurface {
+	return newStructuredToolSurfaceWithPolicy(builtin, workspace, nil, StructuredToolPolicySpec{})
+}
+
+func newStructuredToolSurfaceWithPolicy(builtin *ToolRegistry, workspace *ExecutionToolRegistry, mcpManager MCPManager, policySpec StructuredToolPolicySpec) *structuredToolSurface {
+	// TODO(baseagent): add real confirmation handshakes for ask decisions and
+	// introduce argument-level controls.
+	surface := &structuredToolSurface{
+		policy: structuredToolPolicyFromSpec(policySpec, workspace != nil),
+		order:  []string{},
+		tools:  map[string]structuredToolDefinition{},
+	}
+
+	surface.registerBuiltinStructuredTools(builtin)
+	surface.registerWorkspaceStructuredTools(workspace)
+	surface.registerMCPStructuredTools(mcpManager)
+
+	if len(surface.order) == 0 {
+		return nil
+	}
+	return surface
+}
+
+func (s *structuredToolSurface) registerBuiltinStructuredTools(builtin *ToolRegistry) {
+	if s == nil || builtin == nil {
+		return
+	}
+
+	for _, descriptor := range builtin.ListStructuredToolDescriptors() {
+		tier, ok := structuredBuiltinPassthroughTiers[strings.TrimSpace(descriptor.Name)]
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(descriptor.Name)
+		s.register(structuredToolDefinition{
+			descriptor: descriptor,
+			tier:       tier,
+			execute: func(ctx context.Context, args map[string]any) ExecutionToolResult {
+				return executeStructuredBuiltinTool(ctx, builtin, name, name, args)
+			},
+		})
+	}
+
+	s.registerStructuredAgentAction(builtin, "agent_status", "status", structuredToolTierOperationalRead, "Read the current install/runtime/health state for an agent.")
+	s.registerStructuredAgentAction(builtin, "agent_logs", "logs", structuredToolTierOperationalRead, "Read the recent logs for an agent.")
+	s.registerStructuredAgentAction(builtin, "agent_start", "start", structuredToolTierHighRisk, "Start an agent runtime.")
+	s.registerStructuredAgentAction(builtin, "agent_stop", "stop", structuredToolTierHighRisk, "Stop an agent runtime.")
+	s.registerStructuredAgentAction(builtin, "agent_upgrade", "upgrade", structuredToolTierHighRisk, "Upgrade an agent runtime.")
+	s.registerStructuredAgentAction(builtin, "agent_uninstall", "uninstall", structuredToolTierHighRisk, "Uninstall an agent runtime.")
+	s.registerStructuredAgentAction(builtin, "agent_diagnose", "diagnose", structuredToolTierHighRisk, "Collect diagnose artifacts for an agent runtime.")
+}
+
+func (s *structuredToolSurface) registerStructuredAgentAction(builtin *ToolRegistry, name, action string, tier structuredToolTier, description string) {
+	if s == nil || builtin == nil {
+		return
+	}
+	s.register(structuredToolDefinition{
+		descriptor: StructuredToolDescriptor{
+			Name:        name,
+			Description: description,
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"agent_id": map[string]any{
+						"type": "string",
+					},
+				},
+				"required": []string{"agent_id"},
+			},
+		},
+		tier: tier,
+		execute: func(ctx context.Context, args map[string]any) ExecutionToolResult {
+			params := stringifyStructuredToolArgs(args)
+			if strings.TrimSpace(params["agent_id"]) == "" {
+				return executionError("agent_id is required")
+			}
+			params["action"] = action
+			return executeStructuredBuiltinTool(ctx, builtin, "agent_action", name, map[string]any{
+				"agent_id": params["agent_id"],
+				"action":   action,
+			})
+		},
+	})
+}
+
+func executeStructuredBuiltinTool(ctx context.Context, builtin *ToolRegistry, toolName, displayName string, args map[string]any) ExecutionToolResult {
+	if builtin == nil {
+		return executionError("tool registry is unavailable")
+	}
+	resp, err := builtin.ExecuteTool(ctx, toolName, stringifyStructuredToolArgs(args))
+	if err != nil {
+		return executionError(err.Error())
+	}
+	output := strings.TrimSpace(resp.Message)
+	if output == "" {
+		output = strings.TrimSpace(resp.Action)
+	}
+	if output == "" {
+		output = fmt.Sprintf("tool %s completed", displayName)
+	}
+	return ExecutionToolResult{Output: output}
+}
+
+func (s *structuredToolSurface) registerWorkspaceStructuredTools(workspace *ExecutionToolRegistry) {
+	if s == nil || workspace == nil {
+		return
+	}
+	for _, descriptor := range workspace.Descriptors() {
+		name := strings.TrimSpace(descriptor.Name)
+		if name == "" {
+			continue
+		}
+		tier := structuredWorkspaceToolTier(name)
+		s.register(structuredToolDefinition{
+			descriptor: descriptor,
+			tier:       tier,
+			execute: func(ctx context.Context, args map[string]any) ExecutionToolResult {
+				return workspace.Execute(ctx, name, args)
+			},
+		})
+	}
+}
+
+func (s *structuredToolSurface) registerMCPStructuredTools(mcpManager MCPManager) {
+	if s == nil || mcpManager == nil {
+		return
+	}
+	for _, descriptor := range mcpManager.ListStructuredTools() {
+		name := strings.TrimSpace(descriptor.Name)
+		if name == "" {
+			continue
+		}
+		s.register(structuredToolDefinition{
+			descriptor: descriptor,
+			tier:       structuredMCPToolTier(name),
+			execute: func(ctx context.Context, args map[string]any) ExecutionToolResult {
+				return mcpManager.ExecuteTool(ctx, name, args)
+			},
+		})
+	}
+}
+
+func structuredWorkspaceToolTier(name string) structuredToolTier {
+	switch strings.TrimSpace(name) {
+	case "read_file", "list_dir":
+		return structuredToolTierWorkspaceRead
+	case "write_file", "append_file", "edit_file":
+		return structuredToolTierWorkspaceMutation
+	case "exec":
+		return structuredToolTierHighRisk
+	default:
+		return structuredToolTierWorkspaceRead
+	}
+}
+
+func structuredMCPToolTier(name string) structuredToolTier {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.HasPrefix(lower, "get_"),
+		strings.HasPrefix(lower, "list_"),
+		strings.HasPrefix(lower, "read_"),
+		strings.Contains(lower, "search"):
+		return structuredToolTierMetadataRead
+	default:
+		return structuredToolTierHighRisk
+	}
+}
+
+func (s *structuredToolSurface) register(def structuredToolDefinition) {
+	if s == nil || def.execute == nil {
+		return
+	}
+	name := strings.TrimSpace(def.descriptor.Name)
+	if name == "" {
+		return
+	}
+	if _, exists := s.tools[name]; exists {
+		return
+	}
+	def.descriptor.Name = name
+	def.descriptor.Parameters = cloneToolSchema(def.descriptor.Parameters)
+	s.order = append(s.order, name)
+	s.tools[name] = def
+}
+
+func (s *structuredToolSurface) Descriptors() []StructuredToolDescriptor {
+	if s == nil {
+		return nil
+	}
+	out := make([]StructuredToolDescriptor, 0, len(s.order))
+	for _, name := range s.order {
+		def := s.tools[name]
+		if s.policy.decision(def.tier) != structuredToolDecisionAllow {
+			continue
+		}
+		out = append(out, StructuredToolDescriptor{
+			Name:        def.descriptor.Name,
+			Description: def.descriptor.Description,
+			Parameters:  cloneToolSchema(def.descriptor.Parameters),
+		})
+	}
+	return out
+}
+
+func (s *structuredToolSurface) Execute(ctx context.Context, name string, args map[string]any) ExecutionToolResult {
+	if s == nil {
+		return executionError("structured tool surface is unavailable")
+	}
+	def, ok := s.tools[strings.TrimSpace(name)]
+	if !ok {
+		return executionError(fmt.Sprintf("unknown tool %q", name))
+	}
+	decision := evaluateStructuredToolPolicy(name, args, s.policy.decision(def.tier))
+	switch decision.Decision {
+	case structuredToolDecisionAllow:
+		return applyStructuredPolicyMetadata(def.execute(ctx, args), decision)
+	case structuredToolDecisionAsk:
+		return executionAskWithPolicy(fmt.Sprintf("tool %s requires confirmation before automatic structured execution", strings.TrimSpace(name)), decision)
+	default:
+		return executionDenyWithPolicy(fmt.Sprintf("tool %s requires higher permissions and is not available for automatic structured execution", strings.TrimSpace(name)), decision)
+	}
+}
+
+func (s *structuredToolSurface) ExecuteApproved(ctx context.Context, name string, args map[string]any) ExecutionToolResult {
+	if s == nil {
+		return executionError("structured tool surface is unavailable")
+	}
+	def, ok := s.tools[strings.TrimSpace(name)]
+	if !ok {
+		return executionError(fmt.Sprintf("unknown tool %q", name))
+	}
+	decision := evaluateStructuredToolPolicy(name, args, s.policy.decision(def.tier))
+	if decision.Decision == structuredToolDecisionDeny {
+		return executionDenyWithPolicy(fmt.Sprintf("tool %s requires higher permissions and is not available for automatic structured execution", strings.TrimSpace(name)), decision)
+	}
+	return applyStructuredPolicyMetadata(def.execute(ctx, args), decision)
+}
+
+func stringifyStructuredToolArgs(args map[string]any) map[string]string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(args))
+	for key, value := range args {
+		out[key] = stringifyStructuredToolArg(value)
+	}
+	return out
+}
+
+func stringifyStructuredToolArg(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		if raw, err := json.Marshal(typed); err == nil {
+			return string(raw)
+		}
+		return fmt.Sprint(typed)
+	}
+}

--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -69,6 +69,12 @@ type agentChatRuntime interface {
 	Chat(ctx context.Context, req baseagent.ChatRequest) (baseagent.ChatResponse, error)
 }
 
+type baseAgentRuntime interface {
+	Chat(ctx context.Context, req baseagent.ChatRequest) (baseagent.ChatResponse, error)
+	RespondPendingApproval(ctx context.Context, sessionKey, approvalID string, decision baseagent.ApprovalDecision) (baseagent.ChatResponse, error)
+	ScheduleJob(ctx context.Context, job baseagent.CronJob) (baseagent.CronJob, error)
+}
+
 // Run starts the daemon HTTP API server. It blocks until a termination
 // signal is received or the server encounters a fatal error.
 func Run() {
@@ -123,7 +129,12 @@ func Run() {
 	if memStore != nil {
 		baseMemoryStore = newBaseAgentMemoryStoreAdapter(memStore)
 	}
-	baseRuntime := baseagent.NewRuntime(newLifecycleAgentServiceAdapter(svc), baseMemoryStore)
+	workspaceRoot, _ := os.Getwd()
+	baseRuntime := baseagent.NewRuntime(
+		newLifecycleAgentServiceAdapter(svc),
+		baseMemoryStore,
+		baseagent.WithWorkspaceRoot(workspaceRoot),
+	)
 	stopBaseAgentDistill := startBaseAgentDistillScheduler(memStore)
 	if stopBaseAgentDistill != nil {
 		defer stopBaseAgentDistill()
@@ -229,7 +240,7 @@ func buildHTTPMux(
 
 func buildHTTPMuxWithBaseAgent(
 	svc *lifecycle.Service,
-	baseRuntime *baseagent.Runtime,
+	baseRuntime baseAgentRuntime,
 	ready *atomic.Bool,
 	pairStore *api.PairingCodeStore,
 	pairLimiter *ratelimit.Limiter,
@@ -399,6 +410,118 @@ func buildHTTPMuxWithBaseAgent(
 			return
 		}
 		writeJSON(w, http.StatusOK, resp)
+	})
+
+	register("/api/base-agent/approvals/consume", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if baseRuntime == nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "base agent runtime is unavailable")
+			return
+		}
+		var body struct {
+			SessionKey string `json:"sessionKey"`
+			Provider   string `json:"provider,omitempty"`
+			ChatID     string `json:"chatId,omitempty"`
+			SessionID  string `json:"sessionId,omitempty"`
+			ApprovalID string `json:"approvalId"`
+			Decision   string `json:"decision"`
+		}
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		sessionKey := strings.TrimSpace(body.SessionKey)
+		if sessionKey == "" {
+			chatID := strings.TrimSpace(body.ChatID)
+			if chatID == "" {
+				chatID = strings.TrimSpace(body.SessionID)
+			}
+			if chatID != "" {
+				sessionKey = baseagent.ResolveSessionKey(body.Provider, chatID)
+			}
+		}
+		if sessionKey == "" {
+			writeJSONError(w, http.StatusBadRequest, "sessionKey or chat/session identity is required")
+			return
+		}
+		if strings.TrimSpace(body.ApprovalID) == "" {
+			writeJSONError(w, http.StatusBadRequest, "approvalId is required")
+			return
+		}
+		if strings.TrimSpace(body.Decision) == "" {
+			writeJSONError(w, http.StatusBadRequest, "decision is required")
+			return
+		}
+		resp, err := baseRuntime.RespondPendingApproval(
+			r.Context(),
+			sessionKey,
+			strings.TrimSpace(body.ApprovalID),
+			baseagent.ApprovalDecision(strings.TrimSpace(body.Decision)),
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, baseagent.ErrInvalidApprovalDecision):
+				writeJSONError(w, http.StatusBadRequest, err.Error())
+			case errors.Is(err, baseagent.ErrPendingApprovalNotFound):
+				writeJSONError(w, http.StatusNotFound, err.Error())
+			default:
+				writeJSONError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+
+	register("/api/base-agent/cron/schedule", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if baseRuntime == nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "base agent runtime is unavailable")
+			return
+		}
+		var body struct {
+			SessionKey string    `json:"sessionKey"`
+			Provider   string    `json:"provider,omitempty"`
+			ChatID     string    `json:"chatId,omitempty"`
+			SessionID  string    `json:"sessionId,omitempty"`
+			Prompt     string    `json:"prompt"`
+			NextRunAt  time.Time `json:"nextRunAt,omitempty"`
+		}
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		sessionKey := strings.TrimSpace(body.SessionKey)
+		if sessionKey == "" {
+			chatID := strings.TrimSpace(body.ChatID)
+			if chatID == "" {
+				chatID = strings.TrimSpace(body.SessionID)
+			}
+			if chatID != "" {
+				sessionKey = baseagent.ResolveSessionKey(body.Provider, chatID)
+			}
+		}
+		if sessionKey == "" {
+			writeJSONError(w, http.StatusBadRequest, "sessionKey or chat/session identity is required")
+			return
+		}
+		if strings.TrimSpace(body.Prompt) == "" {
+			writeJSONError(w, http.StatusBadRequest, "prompt is required")
+			return
+		}
+		job, err := baseRuntime.ScheduleJob(r.Context(), baseagent.CronJob{
+			SessionKey: sessionKey,
+			Prompt:     strings.TrimSpace(body.Prompt),
+			NextRunAt:  body.NextRunAt,
+		})
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, job)
 	})
 
 	register("/api/base-agent/decompose", func(w http.ResponseWriter, r *http.Request) {

--- a/daemon/server/server_test.go
+++ b/daemon/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,45 @@ import (
 	"carrier/daemon/internal/manifest"
 	"carrier/daemon/internal/ratelimit"
 )
+
+type fakeBaseAgentRuntime struct {
+	resp         baseagent.ChatResponse
+	approvalResp baseagent.ChatResponse
+	approvalErr  error
+	cronJob      baseagent.CronJob
+	cronErr      error
+	callCount    int
+	approvalCall int
+	cronCall     int
+	lastReq      baseagent.ChatRequest
+	lastSession  string
+	lastApproval string
+	lastDecision string
+	lastCronJob  baseagent.CronJob
+}
+
+func (f *fakeBaseAgentRuntime) Chat(_ context.Context, req baseagent.ChatRequest) (baseagent.ChatResponse, error) {
+	f.callCount++
+	f.lastReq = req
+	return f.resp, nil
+}
+
+func (f *fakeBaseAgentRuntime) RespondPendingApproval(_ context.Context, sessionKey, approvalID string, decision baseagent.ApprovalDecision) (baseagent.ChatResponse, error) {
+	f.approvalCall++
+	f.lastSession = sessionKey
+	f.lastApproval = approvalID
+	f.lastDecision = string(decision)
+	return f.approvalResp, f.approvalErr
+}
+
+func (f *fakeBaseAgentRuntime) ScheduleJob(_ context.Context, job baseagent.CronJob) (baseagent.CronJob, error) {
+	f.cronCall++
+	f.lastCronJob = job
+	if f.cronJob.ID == "" {
+		f.cronJob = job
+	}
+	return f.cronJob, f.cronErr
+}
 
 func newTestService() *lifecycle.Service {
 	return lifecycle.NewService(baseagent.NoopTriager{})
@@ -96,6 +136,180 @@ func TestReadyz_NotReady(t *testing.T) {
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDaemonServerApprovalEndpoint(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	rt := &fakeBaseAgentRuntime{
+		resp:         baseagent.ChatResponse{Message: "unused", Action: "chat"},
+		approvalResp: baseagent.ChatResponse{Message: "confirmed", Action: "approval_confirm"},
+	}
+	mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"sessionKey":"cli:approval-api","approvalId":"approval-1","decision":"confirm"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if rt.approvalCall != 1 || rt.lastSession != "cli:approval-api" || rt.lastApproval != "approval-1" || rt.lastDecision != "confirm" {
+		t.Fatalf("unexpected approval runtime call state: %+v", rt)
+	}
+	if !strings.Contains(w.Body.String(), `"action":"approval_confirm"`) {
+		t.Fatalf("unexpected approval response body=%s", w.Body.String())
+	}
+}
+
+func TestDaemonServerApprovalEndpointReject(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	rt := &fakeBaseAgentRuntime{
+		approvalResp: baseagent.ChatResponse{Message: "rejected", Action: "approval_cancel"},
+	}
+	mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"provider":"cli","chatId":"approval-api","approvalId":"approval-2","decision":"reject"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if rt.lastSession != baseagent.ResolveSessionKey("cli", "approval-api") || rt.lastDecision != "reject" {
+		t.Fatalf("unexpected derived approval request state: %+v", rt)
+	}
+	if !strings.Contains(w.Body.String(), `"action":"approval_cancel"`) {
+		t.Fatalf("unexpected reject response body=%s", w.Body.String())
+	}
+}
+
+func TestDaemonServerApprovalEndpointMethodAndValidationBranches(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	mux := buildHTTPMuxWithBaseAgent(svc, &fakeBaseAgentRuntime{}, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/base-agent/approvals/consume", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("expected 405, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing session identity", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"approvalId":"approval-1","decision":"confirm"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing approval id", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"sessionKey":"cli:approval-api","decision":"confirm"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing decision", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"sessionKey":"cli:approval-api","approvalId":"approval-1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d; body=%s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestDaemonServerApprovalEndpointMapsRuntimeErrors(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+
+	t.Run("invalid decision", func(t *testing.T) {
+		rt := &fakeBaseAgentRuntime{approvalErr: baseagent.ErrInvalidApprovalDecision}
+		mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+		req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"sessionKey":"cli:approval-api","approvalId":"approval-1","decision":"later"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		rt := &fakeBaseAgentRuntime{approvalErr: baseagent.ErrPendingApprovalNotFound}
+		mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+		req := httptest.NewRequest(http.MethodPost, "/api/base-agent/approvals/consume", strings.NewReader(`{"sessionKey":"cli:approval-api","approvalId":"approval-1","decision":"confirm"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d; body=%s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestDaemonServerCronScheduleEndpoint(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	rt := &fakeBaseAgentRuntime{
+		cronJob: baseagent.CronJob{ID: "cron-1", SessionKey: "cli:cron-api", Prompt: "perform maintenance planning"},
+	}
+	mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/base-agent/cron/schedule", strings.NewReader(`{"sessionKey":"cli:cron-api","prompt":"perform maintenance planning"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if rt.cronCall != 1 || rt.lastCronJob.SessionKey != "cli:cron-api" || rt.lastCronJob.Prompt != "perform maintenance planning" {
+		t.Fatalf("unexpected cron runtime call state: %+v", rt)
+	}
+	if !strings.Contains(w.Body.String(), `"id":"cron-1"`) {
+		t.Fatalf("unexpected cron response body=%s", w.Body.String())
+	}
+}
+
+func TestDaemonServerCronScheduleEndpointDerivesSessionKey(t *testing.T) {
+	svc := newTestServiceWithAgent(t)
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	rt := &fakeBaseAgentRuntime{
+		cronJob: baseagent.CronJob{ID: "cron-2", SessionKey: "cli:cron-derived", Prompt: "perform maintenance planning"},
+	}
+	mux := buildHTTPMuxWithBaseAgent(svc, rt, ready, api.NewPairingCodeStore(nil), ratelimit.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/base-agent/cron/schedule", strings.NewReader(`{"provider":"cli","chatId":"cron-derived","prompt":"perform maintenance planning"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body=%s", w.Code, w.Body.String())
+	}
+	if rt.lastCronJob.SessionKey != baseagent.ResolveSessionKey("cli", "cron-derived") {
+		t.Fatalf("unexpected derived cron job state: %+v", rt.lastCronJob)
 	}
 }
 

--- a/docs/plans/2026-03-11-baseagent-parity-remaining-implementation.md
+++ b/docs/plans/2026-03-11-baseagent-parity-remaining-implementation.md
@@ -1,0 +1,537 @@
+# Baseagent Parity Remaining Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Complete the remaining baseagent parity work for approval flow, policy externalization, argument-level controls, approval lifecycle/audit state, MCP, cron, and skills integration.
+
+**Architecture:** Finish the control-plane hardening first so high-risk structured tools have a durable approval lifecycle and machine-readable policy outcomes. Then externalize policy and add argument-level enforcement before expanding the surface area to MCP, cron, and skills, so new tool sources enter a single policy model instead of creating parallel exceptions.
+
+**Tech Stack:** Go, JSON boundary spec, baseagent runtime/session/provider loop, daemon HTTP server, gateway forwarding, persisted session JSON under `.baseagent/sessions`.
+
+---
+
+### Task 1: Approval API And Token Consume Path
+
+**Files:**
+- Create: `baseagent/approval_flow.go`
+- Create: `baseagent/approval_flow_test.go`
+- Modify: `baseagent/agent_loop.go`
+- Modify: `baseagent/controlplane_sessions.go`
+- Modify: `baseagent/runtime.go`
+- Modify: `daemon/server/server.go`
+- Test: `baseagent/runtime_structured_loop_test.go`
+- Test: `daemon/server/server_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestRuntimeRespondPendingApprovalConfirmsSpecificApproval(t *testing.T) {
+    rt := newApprovalRuntimeForTest(t)
+    _, _ = rt.Chat(context.Background(), ChatRequest{
+        Provider: "cli",
+        ChatID:   "approval-api",
+        Message:  "perform maintenance planning",
+    })
+
+    pending := rt.sessions.PendingApprovals("cli:approval-api")
+    resp, err := rt.RespondPendingApproval(context.Background(), "cli:approval-api", pending[0].ID, ApprovalDecisionConfirm)
+
+    if err != nil || resp.Action != "approval_confirm" {
+        t.Fatalf("expected approval confirm path, got resp=%+v err=%v", resp, err)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestRuntimeRespondPendingApprovalConfirmsSpecificApproval|TestDaemonServerApprovalEndpoint'`
+Expected: FAIL with missing runtime approval API / missing daemon route.
+
+**Step 3: Write minimal implementation**
+
+```go
+type ApprovalDecision string
+
+const (
+    ApprovalDecisionConfirm ApprovalDecision = "confirm"
+    ApprovalDecisionReject  ApprovalDecision = "reject"
+)
+
+func (r *Runtime) RespondPendingApproval(ctx context.Context, sessionKey, approvalID string, decision ApprovalDecision) (ChatResponse, error) {
+    return r.loop.RespondPendingApproval(ctx, sessionKey, approvalID, decision)
+}
+```
+
+Add one daemon endpoint around the runtime method. Keep the first version narrow:
+- confirm or reject one approval by ID
+- return the resumed `ChatResponse`
+- keep natural-language `confirm/cancel` as backward-compatible fallback
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestRuntimeRespondPendingApprovalConfirmsSpecificApproval|TestDaemonServerApprovalEndpoint'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/approval_flow.go baseagent/approval_flow_test.go baseagent/agent_loop.go baseagent/controlplane_sessions.go baseagent/runtime.go daemon/server/server.go baseagent/runtime_structured_loop_test.go daemon/server/server_test.go
+git commit -m "feat: add explicit approval consume path"
+```
+
+### Task 2: Persist Full Tool Metadata In Session History
+
+**Files:**
+- Modify: `baseagent/controlplane_sessions.go`
+- Modify: `baseagent/structured_provider.go`
+- Modify: `baseagent/structured_loop.go`
+- Create: `baseagent/session_metadata_test.go`
+- Test: `baseagent/structured_provider_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestSessionManagerPersistsStructuredToolMetadata(t *testing.T) {
+    sm := NewSessionManagerWithStorage(8, t.TempDir())
+    sm.AddStructuredToolMessage("cli:meta", StructuredToolMessage{
+        Role:             "tool",
+        Content:          "needs confirmation",
+        ToolCallID:       "call-1",
+        ToolName:         "exec",
+        ToolResultStatus: ExecutionToolResultStatusAsk,
+    })
+
+    got := NewSessionManagerWithStorage(8, sm.storageDir).StructuredHistory("cli:meta")
+    if len(got) != 1 || got[0].ToolName != "exec" || got[0].ToolResultStatus != ExecutionToolResultStatusAsk {
+        t.Fatalf("unexpected structured history: %+v", got)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestSessionManagerPersistsStructuredToolMetadata|TestBuildStructuredToolPromptIncludesStructuredHistoryMetadata'`
+Expected: FAIL because session storage still only persists flat `ConversationMessage`.
+
+**Step 3: Write minimal implementation**
+
+```go
+type ConversationEvent struct {
+    Role             string                    `json:"role"`
+    Content          string                    `json:"content"`
+    ToolCallID       string                    `json:"tool_call_id,omitempty"`
+    ToolName         string                    `json:"tool_name,omitempty"`
+    ToolResultStatus ExecutionToolResultStatus `json:"tool_result_status,omitempty"`
+}
+```
+
+Use `ConversationEvent` as the persisted session record while keeping the old `History()` helper for compatibility. `StructuredHistory()` should become the source of truth for `processStructuredChat()`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestSessionManagerPersistsStructuredToolMetadata|TestBuildStructuredToolPromptIncludesStructuredHistoryMetadata'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/controlplane_sessions.go baseagent/structured_provider.go baseagent/structured_loop.go baseagent/session_metadata_test.go baseagent/structured_provider_test.go
+git commit -m "feat: persist structured tool metadata in sessions"
+```
+
+### Task 3: Externalize Structured Tool Policy Into Boundary Spec And Runtime Config
+
+**Files:**
+- Modify: `baseagent/spec/baseagent-boundary.v1.json`
+- Modify: `baseagent/boundary_spec.go`
+- Modify: `baseagent/boundary_spec_test.go`
+- Modify: `baseagent/runtime_options.go`
+- Modify: `baseagent/runtime.go`
+- Modify: `baseagent/structured_tool_surface.go`
+- Test: `baseagent/runtime_structured_loop_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestStructuredToolSurfaceReadsPolicyFromBoundarySpec(t *testing.T) {
+    spec := ActiveBoundarySpec()
+    spec.StructuredToolPolicy.HighRiskDecision = "deny"
+    surface := newStructuredToolSurfaceWithPolicy(NewToolRegistry(), NewExecutionToolRegistry(t.TempDir()), spec.StructuredToolPolicy)
+
+    result := surface.Execute(context.Background(), "exec", map[string]any{"command": "go test ./..."})
+    if result.Status != ExecutionToolResultStatusDeny {
+        t.Fatalf("expected boundary policy to drive deny, got %+v", result)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestStructuredToolSurfaceReadsPolicyFromBoundarySpec|TestBoundarySpecRendersStructuredToolPolicy'`
+Expected: FAIL because policy is still hardcoded in `defaultStructuredToolPolicy`.
+
+**Step 3: Write minimal implementation**
+
+```go
+type StructuredToolPolicySpec struct {
+    MetadataReadDecision      string `json:"metadata_read_decision"`
+    OperationalReadDecision   string `json:"operational_read_decision"`
+    WorkspaceReadDecision     string `json:"workspace_read_decision"`
+    WorkspaceMutationDecision string `json:"workspace_mutation_decision"`
+    HighRiskDecision          string `json:"high_risk_decision"`
+}
+```
+
+Wire the active boundary spec into runtime construction. Keep runtime options able to override the spec for tests.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestStructuredToolSurfaceReadsPolicyFromBoundarySpec|TestBoundarySpecRendersStructuredToolPolicy'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/spec/baseagent-boundary.v1.json baseagent/boundary_spec.go baseagent/boundary_spec_test.go baseagent/runtime_options.go baseagent/runtime.go baseagent/structured_tool_surface.go baseagent/runtime_structured_loop_test.go
+git commit -m "feat: externalize structured tool policy"
+```
+
+### Task 4: Add Argument-Level Policy And Audit Reasons
+
+**Files:**
+- Create: `baseagent/structured_policy.go`
+- Create: `baseagent/structured_policy_test.go`
+- Modify: `baseagent/structured_tool_surface.go`
+- Modify: `baseagent/execution_tools.go`
+- Modify: `baseagent/policy.go`
+- Modify: `baseagent/structured_provider.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestStructuredPolicyClassifiesExecCommandsDifferently(t *testing.T) {
+    allow := evaluateStructuredToolPolicy("exec", map[string]any{"command": "go test ./..."})
+    deny := evaluateStructuredToolPolicy("exec", map[string]any{"command": "rm -rf /"})
+
+    if allow.Decision != structuredToolDecisionAsk {
+        t.Fatalf("expected bounded test command to require confirmation, got %+v", allow)
+    }
+    if deny.Decision != structuredToolDecisionDeny || deny.RuleID == "" {
+        t.Fatalf("expected dangerous command deny with rule id, got %+v", deny)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestStructuredPolicyClassifiesExecCommandsDifferently|TestStructuredToolPromptIncludesPolicyReasonMetadata'`
+Expected: FAIL because policy still only keys on tool name/tier.
+
+**Step 3: Write minimal implementation**
+
+```go
+type StructuredPolicyDecision struct {
+    Decision structuredToolDecision
+    Reason   string
+    RuleID   string
+}
+```
+
+Add argument-sensitive policy hooks for:
+- `exec.command`
+- `agent_start/stop/upgrade/uninstall/diagnose`
+- future MCP/cron routed tools
+
+Expose `reason` and `rule_id` in structured tool result metadata so providers and logs can explain why a call was allowed, asked, or denied.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestStructuredPolicyClassifiesExecCommandsDifferently|TestStructuredToolPromptIncludesPolicyReasonMetadata'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/structured_policy.go baseagent/structured_policy_test.go baseagent/structured_tool_surface.go baseagent/execution_tools.go baseagent/policy.go baseagent/structured_provider.go
+git commit -m "feat: add argument-level structured tool policy"
+```
+
+### Task 5: Expand Approval Lifecycle To Multiple Pending Items, Expiry, And Audit State
+
+**Files:**
+- Modify: `baseagent/controlplane_sessions.go`
+- Modify: `baseagent/approval_flow.go`
+- Modify: `baseagent/agent_loop.go`
+- Create: `baseagent/approval_store_test.go`
+- Test: `baseagent/execution_tools_test.go`
+- Test: `baseagent/runtime_structured_loop_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestSessionManagerStoresMultiplePendingApprovalsWithExpiry(t *testing.T) {
+    sm := NewSessionManager(8)
+    sm.SetPendingApprovals("cli:multi", []*PendingToolApproval{
+        {ID: "a1", ToolName: "exec"},
+        {ID: "a2", ToolName: "agent_start"},
+    })
+
+    got := sm.PendingApprovals("cli:multi")
+    if len(got) != 2 {
+        t.Fatalf("expected 2 pending approvals, got %+v", got)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestSessionManagerStoresMultiplePendingApprovalsWithExpiry|TestRuntimeRejectsExpiredApproval'`
+Expected: FAIL because sessions still store only one pending approval and no expiry.
+
+**Step 3: Write minimal implementation**
+
+```go
+type PendingToolApproval struct {
+    ID          string
+    ToolName    string
+    Arguments   map[string]any
+    RequestedAt time.Time
+    ExpiresAt   time.Time
+    Decision    string
+    Reason      string
+    RuleID      string
+}
+```
+
+Keep lookup by `approval_id`. Add cleanup of expired items during read/write. Preserve resolved audit state long enough for session replay.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestSessionManagerStoresMultiplePendingApprovalsWithExpiry|TestRuntimeRejectsExpiredApproval'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/controlplane_sessions.go baseagent/approval_flow.go baseagent/agent_loop.go baseagent/approval_store_test.go baseagent/execution_tools_test.go baseagent/runtime_structured_loop_test.go
+git commit -m "feat: expand approval lifecycle state"
+```
+
+### Task 6: Add MCP Manager Integration Under The Structured Policy Model
+
+**Files:**
+- Create: `baseagent/mcp_manager.go`
+- Create: `baseagent/mcp_manager_test.go`
+- Modify: `baseagent/runtime.go`
+- Modify: `baseagent/structured_tool_surface.go`
+- Modify: `baseagent/structured_provider.go`
+- Modify: `daemon/server/server.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestMCPToolsAppearInStructuredSurfaceUnderPolicy(t *testing.T) {
+    mgr := newFakeMCPManager()
+    mgr.RegisterTool("repo_search", fakeMCPToolSpec())
+
+    rt := NewRuntime(&runtimeServiceFake{}, nil, WithMCPManager(mgr))
+    got := rt.loop.structuredTools.Descriptors()
+
+    if !containsStructuredTool(got, "repo_search") {
+        t.Fatalf("expected MCP tool descriptor, got %+v", got)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestMCPToolsAppearInStructuredSurfaceUnderPolicy|TestMCPToolExecutionRespectsPolicyDecision'`
+Expected: FAIL because no MCP manager exists in baseagent runtime.
+
+**Step 3: Write minimal implementation**
+
+```go
+type MCPManager interface {
+    ListStructuredTools() []StructuredToolDescriptor
+    ExecuteTool(ctx context.Context, name string, args map[string]any) ExecutionToolResult
+}
+```
+
+Register MCP tools as another policy-governed source in `structuredToolSurface`. Do not bypass policy for MCP.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestMCPToolsAppearInStructuredSurfaceUnderPolicy|TestMCPToolExecutionRespectsPolicyDecision'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/mcp_manager.go baseagent/mcp_manager_test.go baseagent/runtime.go baseagent/structured_tool_surface.go baseagent/structured_provider.go daemon/server/server.go
+git commit -m "feat: add mcp tool integration"
+```
+
+### Task 7: Add Cron/Scheduled Re-entry Into The Structured Loop
+
+**Files:**
+- Create: `baseagent/cron_service.go`
+- Create: `baseagent/cron_service_test.go`
+- Modify: `baseagent/runtime.go`
+- Modify: `baseagent/agent_loop.go`
+- Modify: `baseagent/controlplane_sessions.go`
+- Modify: `daemon/server/server.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestCronJobReentersStructuredLoopWithSessionContext(t *testing.T) {
+    rt := newCronRuntimeForTest(t)
+    _, err := rt.ScheduleJob(CronJob{
+        SessionKey: "cron:check",
+        Prompt:     "perform maintenance planning",
+    })
+    if err != nil {
+        t.Fatalf("schedule job: %v", err)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestCronJobReentersStructuredLoopWithSessionContext|TestCronJobRespectsPendingApprovalPolicy'`
+Expected: FAIL because no cron service exists.
+
+**Step 3: Write minimal implementation**
+
+```go
+type CronJob struct {
+    ID         string
+    SessionKey string
+    Prompt     string
+    NextRunAt  time.Time
+}
+```
+
+Use a simple in-process scheduler first. The key rule: cron jobs must re-enter `ProcessChat()` or the same structured loop path so approvals and policy are enforced identically to interactive requests.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestCronJobReentersStructuredLoopWithSessionContext|TestCronJobRespectsPendingApprovalPolicy'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/cron_service.go baseagent/cron_service_test.go baseagent/runtime.go baseagent/agent_loop.go baseagent/controlplane_sessions.go daemon/server/server.go
+git commit -m "feat: add cron re-entry for baseagent"
+```
+
+### Task 8: Add Skills Loading And Provider Context Integration
+
+**Files:**
+- Create: `baseagent/skills_loader.go`
+- Create: `baseagent/skills_loader_test.go`
+- Modify: `baseagent/runtime.go`
+- Modify: `baseagent/structured_provider.go`
+- Modify: `baseagent/agent_loop.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestProviderRequestIncludesRelevantSkillsSummary(t *testing.T) {
+    loader := newFakeSkillsLoader("go-testing", "Use go test before claiming success.")
+    rt := NewRuntime(&runtimeServiceFake{}, nil, WithSkillsLoader(loader))
+
+    _ = rt.Chat(context.Background(), ChatRequest{
+        Provider: "cli",
+        ChatID:   "skills",
+        Message:  "run repository diagnostics",
+    })
+
+    if !loader.WasConsulted() {
+        t.Fatal("expected skills loader to contribute provider context")
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestProviderRequestIncludesRelevantSkillsSummary|TestStructuredLoopCarriesSkillSummaryAcrossTurns'`
+Expected: FAIL because runtime does not yet know about skills.
+
+**Step 3: Write minimal implementation**
+
+```go
+type SkillsLoader interface {
+    RelevantSkills(query string) []SkillSummary
+}
+```
+
+Inject compact skill summaries into:
+- provider prompt construction
+- structured loop system/context
+- optionally `/tools` or `/boundaries` diagnostics
+
+Keep the first version summary-only. Do not build auto-install/mutation behavior here.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./... -run 'TestProviderRequestIncludesRelevantSkillsSummary|TestStructuredLoopCarriesSkillSummaryAcrossTurns'`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent/skills_loader.go baseagent/skills_loader_test.go baseagent/runtime.go baseagent/structured_provider.go baseagent/agent_loop.go
+git commit -m "feat: add skills context integration"
+```
+
+### Task 9: Final Hardening, End-To-End Verification, And Docs
+
+**Files:**
+- Modify: `baseagent/spec/baseagent-boundary.v1.json`
+- Modify: `baseagent/boundary_spec.go`
+- Modify: `baseagent/runtime_structured_loop_test.go`
+- Modify: `baseagent/controlplane_test.go`
+- Modify: `daemon/server/server_test.go`
+- Modify: `docs/plans/2026-03-11-baseagent-parity-remaining-implementation.md`
+
+**Step 1: Write the failing test**
+
+```go
+func TestEndToEndApprovalMCPAndCronShareOnePolicyModel(t *testing.T) {
+    t.Fatal("write this integration test before the final pass")
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./... -run 'TestEndToEndApprovalMCPAndCronShareOnePolicyModel'`
+Expected: FAIL by design until the whole stack is integrated.
+
+**Step 3: Write minimal implementation**
+
+The final implementation pass should only do cleanup:
+- remove duplicated policy helpers
+- ensure `/boundaries` explains approval/API behavior
+- ensure daemon routes and runtime methods align
+- ensure structured provider metadata remains stable
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+go test ./...                               # in baseagent
+go test ./...                               # in gateway
+go test ./server                            # in daemon
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add baseagent daemon/server docs/plans/2026-03-11-baseagent-parity-remaining-implementation.md
+git commit -m "feat: finish remaining baseagent parity work"
+```


### PR DESCRIPTION
## Summary
- complete the baseagent parity control plane for structured tool-call execution, approval lifecycle, and policy-governed audit metadata
- integrate MCP, cron, and skills into the same structured tool surface and extend daemon endpoints for approval consume and cron scheduling
- add broad regression coverage across execution tools, approval flow, provider failover, structured loop behavior, policy, MCP, cron, and skills

## Test Plan
- go test ./... (baseagent)
- go test ./server (daemon)
- go test ./... (gateway)
