### PR TITLE
ci: add PR metrics harness with PR comment reporting

### DIFF
--- a/.github/workflows/metrics-harness.yml
+++ b/.github/workflows/metrics-harness.yml
@@ -147,55 +147,68 @@ jobs:
           echo "initial_limit_kb=${initial_limit_kb}" >> "$GITHUB_OUTPUT"
           echo "hard_fail=${hard_fail}" >> "$GITHUB_OUTPUT"
 
-      - name: Code readability metrics (informational)
+      - name: "Code readability (hard gate: changed source files <= 500 lines)"
         id: readability
         shell: bash
         run: |
           set -euo pipefail
 
+          max_lines=500
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+
+          checked=0
+          violations=0
           details=""
-          over_target=0
-          files_over_500=0
 
-          while read -r lines file; do
-            [[ -z "${lines}" || -z "${file}" ]] && continue
-            if [[ "${lines}" -le 300 ]]; then
-              continue
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+
+            case "${file}" in
+              baseagent/*|cmd/*|codeagent/*|daemon/*|gateway/*|shared/*|webui/src/*|scripts/*)
+                ;;
+              *)
+                continue
+                ;;
+            esac
+
+            case "${file}" in
+              *.go|*.ts|*.tsx|*.js|*.cjs|*.mjs|*.sh)
+                ;;
+              *)
+                continue
+                ;;
+            esac
+
+            [[ -f "${file}" ]] || continue
+
+            lines="$(wc -l < "${file}" | tr -d ' ')"
+            checked=$((checked + 1))
+
+            if [[ "${lines}" -gt "${max_lines}" ]]; then
+              status='❌'
+              violations=$((violations + 1))
+            else
+              status='✅'
             fi
 
-            target=$(( ((lines * 60 / 100) + 50) / 100 * 100 ))
-            if [[ "${target}" -lt 500 ]]; then
-              target=500
-            fi
+            details+="| \`${file}\` | ${lines} | ≤ ${max_lines} | ${status} |\n"
+          done < <(git diff --name-only "${base_sha}" "${head_sha}")
 
-            status='✅'
-            if [[ "${lines}" -gt "${target}" ]]; then
-              status='⚠️'
-              over_target=$((over_target + 1))
-            fi
+          if [[ "${checked}" -eq 0 ]]; then
+            details='| _(no changed source files)_ | 0 | ≤ 500 | ✅ |\n'
+          fi
 
-            if [[ "${lines}" -gt 500 ]]; then
-              files_over_500=$((files_over_500 + 1))
-            fi
-
-            details+="| \`${file}\` | ${lines} | ≤ ${target} | ${status} |\n"
-          done < <(
-            find baseagent cmd codeagent daemon gateway shared webui/src scripts \
-              -type f \( -name '*.go' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.cjs' -o -name '*.mjs' -o -name '*.sh' \) \
-              -exec wc -l {} + 2>/dev/null \
-              | grep -v ' total$' \
-              | sort -rn \
-              | awk '{print $1 " " $2}' \
-              | head -n 120
-          )
-
-          if [[ -z "${details}" ]]; then
-            details='| _(no files above 300 lines)_ | 0 | ≤ 500 | ✅ |\n'
+          fail=0
+          if [[ "${violations}" -gt 0 ]]; then
+            fail=1
           fi
 
           printf "%b" "${details}" > /tmp/metrics_readability_details.md
-          echo "over_target=${over_target}" >> "$GITHUB_OUTPUT"
-          echo "files_over_500=${files_over_500}" >> "$GITHUB_OUTPUT"
+          echo "max_lines=${max_lines}" >> "$GITHUB_OUTPUT"
+          echo "checked=${checked}" >> "$GITHUB_OUTPUT"
+          echo "violations=${violations}" >> "$GITHUB_OUTPUT"
+          echo "fail=${fail}" >> "$GITHUB_OUTPUT"
 
       - name: Build metrics report
         id: report
@@ -210,10 +223,19 @@ jobs:
             hard_fail=1
             overall='❌ Hard gates failed'
           fi
+          if [[ "${{ steps.readability.outputs.fail }}" == '1' ]]; then
+            hard_fail=1
+            overall='❌ Hard gates failed'
+          fi
 
           bundle_icon='✅'
           if [[ "${{ steps.bundle.outputs.hard_fail }}" == '1' ]]; then
             bundle_icon='❌'
+          fi
+
+          readability_icon='✅'
+          if [[ "${{ steps.readability.outputs.fail }}" == '1' ]]; then
+            readability_icon='❌'
           fi
 
           commit_icon='✅'
@@ -254,13 +276,13 @@ jobs:
           | JS bundle (gzip) | ${{ steps.bundle.outputs.gzip_kb }} KB | ≤ ${{ steps.bundle.outputs.gzip_limit_kb }} KB | $( [[ "${{ steps.bundle.outputs.gzip_kb }}" -le "${{ steps.bundle.outputs.gzip_limit_kb }}" ]] && echo "✅" || echo "❌" ) |
           | JS initial load (gzip) | ${{ steps.bundle.outputs.initial_gzip_kb }} KB | ≤ ${{ steps.bundle.outputs.initial_limit_kb }} KB | $( [[ "${{ steps.bundle.outputs.initial_gzip_kb }}" -le "${{ steps.bundle.outputs.initial_limit_kb }}" ]] && echo "✅" || echo "❌" ) |
 
-          ### Code Readability (informational)
+          ### Code Readability (hard gate: changed source files) ${readability_icon}
 
-          | File | Lines | Target | Status |
-          |------|-------|--------|--------|
+          | File | Lines | Limit | Status |
+          |------|-------|-------|--------|
           ${readability_details}
-          | **Files > 500 lines** | **${{ steps.readability.outputs.files_over_500 }}** | trend ↓ | $( [[ "${{ steps.readability.outputs.files_over_500 }}" -le 40 ]] && echo "✅" || echo "⚠️" ) |
-          | Files over target | ${{ steps.readability.outputs.over_target }} | 0 | $( [[ "${{ steps.readability.outputs.over_target }}" -eq 0 ]] && echo "✅" || echo "⚠️" ) |
+          | Source files checked | ${{ steps.readability.outputs.checked }} | — | — |
+          | Violations | ${{ steps.readability.outputs.violations }} | must be 0 | $( [[ "${{ steps.readability.outputs.violations }}" -eq 0 ]] && echo "✅" || echo "❌" ) |
 
           ---
           > 📊 Metrics spec: [\`docs/architecture/metrics.md\`](../blob/${{ github.head_ref }}/docs/architecture/metrics.md)

--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -10,7 +10,7 @@ Current harness sections:
 
 1. **Commit Size** (soft gate)
 2. **WebUI Bundle Size** (hard gate)
-3. **Code Readability Scan** (informational)
+3. **Code Readability** (hard gate on changed source files)
 
 The workflow is implemented in:
 
@@ -33,9 +33,9 @@ Measured after `bash scripts/build-webui.sh` using files under `webui/static/ass
 
 If either threshold is exceeded, the metrics workflow fails.
 
-## 3) Code Readability Scan (informational)
+## 3) Code Readability (hard gate)
 
-Scans source files across:
+Checks **changed source files in the PR diff** across:
 
 - `baseagent`, `cmd`, `codeagent`, `daemon`, `gateway`, `shared`, `webui/src`, `scripts`
 
@@ -45,14 +45,11 @@ File types:
 
 Rules:
 
-- Track files with more than 300 lines
-- Auto target = max(500, round(60% of current lines to nearest 100))
-- Report:
-  - file line count
-  - computed target
-  - status (`✅` / `⚠️`)
+- Every checked source file must be `≤ 500` lines
+- Violations are reported per file in the PR metrics comment
+- Any violation fails the metrics workflow
 
-This section is informational and trend-focused.
+This is intentionally strict for changed code so new/modified files stay readable without forcing an immediate full-repo refactor.
 
 ## PR Comment Contract
 


### PR DESCRIPTION
## What

Add a dedicated **PR metrics harness** for `carrier`, inspired by the Clawpal metrics-gate report style (reference: lay2dev/clawpal#140 comment).

## Included

1. **New workflow**: `.github/workflows/metrics-harness.yml`
   - Runs on PRs to `main`
   - Produces/updates a single PR comment (`<!-- carrier-pr-metrics-harness -->`)
   - Sections:
     - Commit size (soft gate)
     - WebUI bundle size (hard gate)
     - Code readability scan (informational)
   - Hard gate failure currently only on bundle thresholds

2. **Metrics spec doc**: `docs/architecture/metrics.md`
   - Documents scope, thresholds, and comment contract
   - Notes future extension directions

## Gate defaults

- Commit size: `<= 500` lines/commit (soft)
- WebUI JS bundle gzip: `<= 350 KB` (hard)
- WebUI initial JS gzip (from `webui/static/index.html` script tags): `<= 180 KB` (hard)

## Notes

- Action refs are pinned to immutable SHAs and pass `scripts/ci/check-action-pinning.sh`.
- Existing CI parser tests pass (`node --test scripts/ci/*.test.cjs`).
