### PR TITLE
ci: make PR artifact download comment prettier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,13 +396,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p pr-meta
+          package_size_bytes="$(wc -c < "dist/${{ steps.build.outputs.package_file }}" | tr -d ' ')"
           jq -n \
             --arg label "${{ matrix.label }}" \
             --arg archive_name "${{ steps.build.outputs.archive_name }}" \
             --arg variant "${{ matrix.variant }}" \
             --arg package_file "${{ steps.build.outputs.package_file }}" \
             --arg artifact_id "${{ steps.upload.outputs.artifact-id }}" \
-            '{label: $label, variant: $variant, archive_name: $archive_name, package_file: $package_file, artifact_id: $artifact_id}' \
+            --arg package_size_bytes "${package_size_bytes}" \
+            '{label: $label, variant: $variant, archive_name: $archive_name, package_file: $package_file, artifact_id: $artifact_id, package_size_bytes: ($package_size_bytes | tonumber)}' \
             > "pr-meta/${{ matrix.variant }}-${{ matrix.label }}.json"
 
       - name: Upload PR metadata

--- a/scripts/ci/pr-package-comment.cjs
+++ b/scripts/ci/pr-package-comment.cjs
@@ -28,12 +28,26 @@ function listMetadataFiles(metadataDir) {
   return files.sort();
 }
 
+function parseOptionalSize(raw, filePath) {
+  if (raw.package_size_bytes === undefined || raw.package_size_bytes === null || raw.package_size_bytes === "") {
+    return null;
+  }
+
+  const parsed = Number(raw.package_size_bytes);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid "package_size_bytes" in ${filePath}: "${raw.package_size_bytes}"`);
+  }
+
+  return Math.round(parsed);
+}
+
 function parseMetadataFile(filePath) {
   const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
   const label = String(raw.label || "").trim();
   const variant = String(raw.variant || "").trim();
   const packageFile = String(raw.package_file || "").trim();
   const artifactId = String(raw.artifact_id || "").trim();
+  const packageSizeBytes = parseOptionalSize(raw, filePath);
 
   if (!label) {
     throw new Error(`Missing "label" in ${filePath}`);
@@ -54,12 +68,25 @@ function parseMetadataFile(filePath) {
     variant,
     packageFile,
     artifactId,
+    packageSizeBytes,
   };
 }
 
 function loadPackageMetadata(metadataDir) {
   const files = listMetadataFiles(metadataDir);
   return files.map((filePath) => parseMetadataFile(filePath));
+}
+
+function formatSize(sizeBytes) {
+  if (!Number.isFinite(sizeBytes) || sizeBytes <= 0) {
+    return "—";
+  }
+  const mb = sizeBytes / (1024 * 1024);
+  if (mb >= 1) {
+    return `${mb.toFixed(1)} MB`;
+  }
+  const kb = sizeBytes / 1024;
+  return `${kb.toFixed(1)} KB`;
 }
 
 function buildPrPackagesComment({ repository, runId, commitSha, packages }) {
@@ -78,20 +105,33 @@ function buildPrPackagesComment({ repository, runId, commitSha, packages }) {
   }
 
   const runUrl = `https://github.com/${repo}/actions/runs/${run}`;
+  const shortSha = sha.slice(0, 7);
+  const rows = Array.isArray(packages) ? packages : [];
+
   const lines = [
     COMMENT_MARKER,
-    "## Test Packages",
+    "## 📦 PR Test Package Artifacts",
     "",
-    `- Commit: \`${sha}\``,
-    `- Workflow run: [${run}](${runUrl})`,
-    "",
-    "Download:",
   ];
 
-  for (const item of packages) {
-    const label = item.variant ? `${item.variant}/${item.label}` : item.label;
-    lines.push(`- ${label}: [\`${item.packageFile}\`](${runUrl}/artifacts/${item.artifactId})`);
+  if (rows.length === 0) {
+    lines.push(`⚠️ No package artifacts were produced. Check the [workflow run](${runUrl}) for details.`);
+  } else {
+    lines.push("| Platform | Download | Size |");
+    lines.push("|----------|----------|------|");
+
+    for (const item of rows) {
+      const platform = item.variant ? `${item.variant}/${item.label}` : item.label;
+      const download = `[📥 ${item.packageFile}](${runUrl}/artifacts/${item.artifactId})`;
+      const sizeText = formatSize(item.packageSizeBytes);
+      lines.push(`| ${platform} | ${download} | ${sizeText} |`);
+    }
   }
+
+  lines.push("");
+  lines.push("---");
+  lines.push(`> 🔨 Built from \`${shortSha}\` · [View workflow run](${runUrl})`);
+  lines.push("> ⚠️ **Unsigned development test packages** — for verification only");
 
   return `${lines.join("\n")}\n`;
 }
@@ -140,4 +180,5 @@ module.exports = {
   listMetadataFiles,
   loadPackageMetadata,
   parseMetadataFile,
+  formatSize,
 };

--- a/scripts/ci/pr-package-comment.test.cjs
+++ b/scripts/ci/pr-package-comment.test.cjs
@@ -10,6 +10,7 @@ const {
   COMMENT_MARKER,
   buildPrPackagesComment,
   loadPackageMetadata,
+  formatSize,
 } = require("./pr-package-comment.cjs");
 
 function withTempDir(fn) {
@@ -29,6 +30,7 @@ test("loadPackageMetadata reads sorted metadata and enforces zip package names",
         label: "darwin-arm64",
         package_file: "carrier-darwin-arm64.zip",
         artifact_id: "22",
+        package_size_bytes: 22 * 1024 * 1024,
       }),
     );
     fs.writeFileSync(
@@ -44,6 +46,8 @@ test("loadPackageMetadata reads sorted metadata and enforces zip package names",
     assert.equal(metadata.length, 2);
     assert.equal(metadata[0].artifactId, "11");
     assert.equal(metadata[1].artifactId, "22");
+    assert.equal(metadata[0].packageSizeBytes, null);
+    assert.equal(metadata[1].packageSizeBytes, 22 * 1024 * 1024);
   });
 });
 
@@ -92,7 +96,13 @@ test("loadPackageMetadata fails when package_file does not end with .zip", () =>
   });
 });
 
-test("buildPrPackagesComment renders markdown body with artifact links", () => {
+test("formatSize supports MB and fallback dash", () => {
+  assert.equal(formatSize(15.7 * 1024 * 1024), "15.7 MB");
+  assert.equal(formatSize(5120), "5.0 KB");
+  assert.equal(formatSize(null), "—");
+});
+
+test("buildPrPackagesComment renders markdown body with table and artifact links", () => {
   const body = buildPrPackagesComment({
     repository: "Keith-CY/carrier",
     runId: "22252074017",
@@ -103,23 +113,23 @@ test("buildPrPackagesComment renders markdown body with artifact links", () => {
         variant: "app",
         packageFile: "carrier-app-darwin-arm64.zip",
         artifactId: "5600022400",
+        packageSizeBytes: 15.7 * 1024 * 1024,
       },
       {
         label: "linux-x64",
         variant: "cli",
         packageFile: "carrier-linux-x64.zip",
         artifactId: "5600022428",
+        packageSizeBytes: 102.9 * 1024 * 1024,
       },
     ],
   });
 
   assert.match(body, new RegExp(COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-  assert.match(body, /- Commit: `38695c9610c2592d729cc566fa2b3619e0841905`/);
-  assert.match(body, /- Workflow run: \[22252074017\]\(https:\/\/github\.com\/Keith-CY\/carrier\/actions\/runs\/22252074017\)/);
-  assert.match(body, /app\/darwin-arm64/);
-  assert.match(body, /carrier-app-darwin-arm64\.zip/);
-  assert.match(body, /actions\/runs\/22252074017\/artifacts\/5600022400/);
-  assert.match(body, /cli\/linux-x64/);
-  assert.match(body, /carrier-linux-x64\.zip/);
-  assert.match(body, /actions\/runs\/22252074017\/artifacts\/5600022428/);
+  assert.match(body, /## 📦 PR Test Package Artifacts/);
+  assert.match(body, /\| Platform \| Download \| Size \|/);
+  assert.match(body, /\| app\/darwin-arm64 \| \[📥 carrier-app-darwin-arm64\.zip\]\(https:\/\/github\.com\/Keith-CY\/carrier\/actions\/runs\/22252074017\/artifacts\/5600022400\) \| 15\.7 MB \|/);
+  assert.match(body, /\| cli\/linux-x64 \| \[📥 carrier-linux-x64\.zip\]\(https:\/\/github\.com\/Keith-CY\/carrier\/actions\/runs\/22252074017\/artifacts\/5600022428\) \| 102\.9 MB \|/);
+  assert.match(body, /> 🔨 Built from `38695c9`/);
+  assert.match(body, /Unsigned development test packages/);
 });


### PR DESCRIPTION
## What

Improve Carrier PR artifact comments so download links are easier to scan and visually closer to the Clawpal style reference:
- <https://github.com/lay2dev/clawpal/pull/140#issuecomment-4083947180>

## Changes

1. **Prettier PR package comment output** (`scripts/ci/pr-package-comment.cjs`)
   - Switch from bullet list to markdown table:
     - Platform
     - Download link
     - Size
   - Add footer metadata:
     - short commit SHA
     - workflow run link
     - unsigned test package warning

2. **Include package size in PR metadata** (`.github/workflows/release.yml`)
   - Save `package_size_bytes` in each `pr-meta/*.json` artifact.
   - Comment generator uses this to render human-readable MB/KB sizes.

3. **Tests updated** (`scripts/ci/pr-package-comment.test.cjs`)
   - Validate new table-style body and footer.
   - Validate size formatting behavior.

## Validation

- `node --test scripts/ci/pr-package-comment.test.cjs`
- `node --test scripts/ci/*.test.cjs`
- `bash scripts/ci/check-action-pinning.sh`
