### PR TITLE
compat: refresh upstream schema locks

### DIFF
--- a/compat/upstreams.lock.json
+++ b/compat/upstreams.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-02-27T00:00:00Z",
+  "updated_at": "2026-03-19T00:00:00Z",
   "agents": {
     "openclaw": {
       "repository": "openclaw/openclaw",
@@ -16,22 +16,22 @@
       "tracked_files": [
         {
           "path": "docs/gateway/configuration-reference.md",
-          "sha": "9bbf0328fc9c4470a2f2fb5d6ee02c94711dca86"
+          "sha": "49c743db6232ca0c61686b0e21a21eaa808ed436"
         },
         {
           "path": "src/channels/plugins/config-schema.ts",
-          "sha": "75074ae569d9a895a7a2bf93d2c29058a7417caf"
+          "sha": "5ae166aa5a78066cdd3d1d21c8632ca6fcf88444"
         },
         {
           "path": "src/config/config.ts",
-          "sha": "df667d498b12e045fc706893af1f7356f7de493d"
+          "sha": "3bd36d0d709594c7d896132c8472e445d1994940"
         },
         {
           "path": "src/gateway/protocol/schema/config.ts",
-          "sha": "150cd6b4ad189d7cf74671e0ed2a420af976b0f6"
+          "sha": "9d0ec87666821aafd56049987c6bc7d54a5a3f72"
         }
       ],
-      "expected_fingerprint": "sha256:c6abd8d448495b1d5976a08bf3677a3f91c82f260d1f792c19e69b8865c23601"
+      "expected_fingerprint": "sha256:ab8b02dc9dad1c97bf97e8708900cdfabed8f463daea87dbc3d9197d9ef13c22"
     },
     "picoclaw": {
       "repository": "sipeed/picoclaw",
@@ -47,14 +47,14 @@
       "tracked_files": [
         {
           "path": "config/config.example.json",
-          "sha": "9575039f8787754be78d39051ffafb85d904d295"
+          "sha": "221e89491a4e66013e42247ce8f1d559ce985bd0"
         },
         {
           "path": "pkg/config/config.go",
-          "sha": "ca5803c35b4cc5cd38cc51158ab04cf1c138d2f4"
+          "sha": "4f8026d274d8b1f0b38a013c830e8d0e510496a6"
         }
       ],
-      "expected_fingerprint": "sha256:93c8d9ef27c45a44fbffeaedb26aa6032f0b2b4bc18c5a95f4020d624b4653da"
+      "expected_fingerprint": "sha256:00d9e819b162da93c6cc4f6f622cb12f525dc4d72c9b1b91d7cbe171be667203"
     },
     "zeroclaw": {
       "repository": "zeroclaw-labs/zeroclaw",
@@ -70,18 +70,18 @@
       "tracked_files": [
         {
           "path": "dev/config.template.toml",
-          "sha": "eae418c1a379fe83456b49963327d695e4774dfa"
+          "sha": "cf4511b85d9c0f6ba8c1d5404fbfb168d30f7229"
         },
         {
-          "path": "docs/config-reference.md",
-          "sha": "4fa30452c6ab6fe0ed8dc7be62bc38e4161b32dc"
+          "path": "docs/reference/api/config-reference.md",
+          "sha": "5775c40d7266954a94b094b4cf2e5532bd415e8c"
         },
         {
           "path": "src/config/schema.rs",
-          "sha": "669396b6452dcb26f8dd52b3a0c96e786582cc22"
+          "sha": "ad767b43ddf561e24f4b5c8b30db6fce06c904be"
         }
       ],
-      "expected_fingerprint": "sha256:27f0c017721f28eeacceaaa8604b4d227e87e2d2c3755b1ae24c5e3105094a1f"
+      "expected_fingerprint": "sha256:96aefe249019aa9c6f97efd0d762d15cb393252d505f27ed5e6c30b6915527ff"
     }
   }
 }

--- a/scripts/ci/upstreams-lock.test.cjs
+++ b/scripts/ci/upstreams-lock.test.cjs
@@ -1,0 +1,53 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+function readLock() {
+  const lockPath = path.resolve(__dirname, "../../compat/upstreams.lock.json");
+  return JSON.parse(fs.readFileSync(lockPath, "utf8"));
+}
+
+function trackedFilesByPath(agent) {
+  return Object.fromEntries((agent.tracked_files || []).map((entry) => [entry.path, entry.sha]));
+}
+
+test("upstreams lock records the refreshed openclaw snapshot", () => {
+  const lock = readLock();
+  const openclaw = lock.agents.openclaw;
+
+  assert.equal(lock.updated_at, "2026-03-19T00:00:00Z");
+  assert.equal(openclaw.expected_fingerprint, "sha256:ab8b02dc9dad1c97bf97e8708900cdfabed8f463daea87dbc3d9197d9ef13c22");
+  assert.deepEqual(trackedFilesByPath(openclaw), {
+    "docs/gateway/configuration-reference.md": "49c743db6232ca0c61686b0e21a21eaa808ed436",
+    "src/channels/plugins/config-schema.ts": "5ae166aa5a78066cdd3d1d21c8632ca6fcf88444",
+    "src/config/config.ts": "3bd36d0d709594c7d896132c8472e445d1994940",
+    "src/gateway/protocol/schema/config.ts": "9d0ec87666821aafd56049987c6bc7d54a5a3f72",
+  });
+});
+
+test("upstreams lock records the refreshed picoclaw snapshot", () => {
+  const lock = readLock();
+  const picoclaw = lock.agents.picoclaw;
+
+  assert.equal(picoclaw.expected_fingerprint, "sha256:00d9e819b162da93c6cc4f6f622cb12f525dc4d72c9b1b91d7cbe171be667203");
+  assert.deepEqual(trackedFilesByPath(picoclaw), {
+    "config/config.example.json": "221e89491a4e66013e42247ce8f1d559ce985bd0",
+    "pkg/config/config.go": "4f8026d274d8b1f0b38a013c830e8d0e510496a6",
+  });
+});
+
+test("upstreams lock records the refreshed zeroclaw snapshot and migrated doc path", () => {
+  const lock = readLock();
+  const zeroclaw = lock.agents.zeroclaw;
+
+  assert.equal(zeroclaw.expected_fingerprint, "sha256:96aefe249019aa9c6f97efd0d762d15cb393252d505f27ed5e6c30b6915527ff");
+  assert.deepEqual(trackedFilesByPath(zeroclaw), {
+    "dev/config.template.toml": "cf4511b85d9c0f6ba8c1d5404fbfb168d30f7229",
+    "docs/reference/api/config-reference.md": "5775c40d7266954a94b094b4cf2e5532bd415e8c",
+    "src/config/schema.rs": "ad767b43ddf561e24f4b5c8b30db6fce06c904be",
+  });
+  assert.ok(!("docs/config-reference.md" in trackedFilesByPath(zeroclaw)));
+});


### PR DESCRIPTION
## Summary
- refresh `compat/upstreams.lock.json` for openclaw, picoclaw, and zeroclaw to the current upstream snapshots
- migrate the stale zeroclaw tracked doc path to `docs/reference/api/config-reference.md`
- add a regression test for the refreshed lock fingerprints and tracked blob SHAs

## Test Plan
- [x] `node --test scripts/ci/upstreams-lock.test.cjs`
- [x] `node scripts/ci/upstream-schema-watch.cjs --mode check-only --lock compat/upstreams.lock.json`

Closes #1477
Closes #1478
Closes #1479