### PR TITLE
feat(webui): add mothership-inspired header logo for Carrier

### DIFF
--- a/webui/public/icons/carrier-header-logo.svg
+++ b/webui/public/icons/carrier-header-logo.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 6L45 13L52 26L45 39L32 58L19 39L12 26L19 13Z" fill="#5E7AEF" fill-opacity="0.12" stroke="#5E7AEF" stroke-width="2.5"/>
+    <path d="M32 12L40 17L45 26L40 35L32 48L24 35L19 26L24 17Z" fill="#5E7AEF" fill-opacity="0.22" stroke="#5E7AEF" stroke-width="2"/>
+    <circle cx="32" cy="26" r="4.5" fill="#5E7AEF" fill-opacity="0.95" stroke="#5E7AEF" stroke-width="1.4"/>
+
+    <path d="M32 31V39" stroke="#5E7AEF" stroke-opacity="0.72" stroke-width="1.8"/>
+    <path d="M32 39L22 49" stroke="#5E7AEF" stroke-opacity="0.56" stroke-width="1.8"/>
+    <path d="M32 39L42 49" stroke="#5E7AEF" stroke-opacity="0.56" stroke-width="1.8"/>
+
+    <path d="M32 48L29.4 52.4L34.6 52.4Z" fill="#5E7AEF" fill-opacity="0.95" stroke="#5E7AEF" stroke-width="1"/>
+    <path d="M22 49L19.8 52.6L24.2 52.6Z" fill="#5E7AEF" fill-opacity="0.9" stroke="#5E7AEF" stroke-width="1"/>
+    <path d="M42 49L39.8 52.6L44.2 52.6Z" fill="#5E7AEF" fill-opacity="0.9" stroke="#5E7AEF" stroke-width="1"/>
+  </g>
+</svg>

--- a/webui/src/app/AppLayout.tsx
+++ b/webui/src/app/AppLayout.tsx
@@ -15,6 +15,7 @@ import {
   RiSparklingLine,
   RiTerminalBoxLine,
 } from 'react-icons/ri';
+import { CarrierHeaderLogo } from '@/components/carrier-header-logo';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -140,7 +141,7 @@ export function AppLayout() {
               <CardContent className="space-y-5 p-7">
                 <div className="flex items-center gap-2">
                   <span className="flex size-9 items-center justify-center rounded-[0.85rem] border border-[color:rgba(20,24,31,0.08)] bg-[var(--color-panel)] text-[var(--color-primary)]">
-                    <RiSparklingLine className="size-4.5" />
+                    <CarrierHeaderLogo className="size-5" />
                   </span>
                   <div className="text-base font-medium text-[var(--color-ink)]">Carrier</div>
                 </div>
@@ -198,7 +199,7 @@ export function AppLayout() {
               <div className="sticky top-5 flex min-h-[calc(100vh-2.5rem)] flex-col items-center justify-between rounded-[1rem] border border-[var(--color-line)] bg-[rgba(251,250,246,0.9)] p-2 shadow-[0_10px_30px_rgba(45,41,36,0.04)]">
                 <div className="grid gap-3">
                   <div className="flex size-10 items-center justify-center rounded-xl bg-[var(--color-panel-2)] text-[var(--color-primary)]">
-                    <RiSparklingLine className="size-4.5" />
+                    <CarrierHeaderLogo className="size-5" />
                   </div>
                   <ShellNavigation compact />
                 </div>
@@ -230,13 +231,21 @@ export function AppLayout() {
                       </Button>
                     </SheetTrigger>
                     <SheetContent side="left" className="w-[18rem] bg-[var(--color-panel)] p-4">
-                      <div className="mb-4 text-sm font-medium text-[var(--color-ink)]">
+                      <div className="mb-4 flex items-center gap-2 text-sm font-medium text-[var(--color-ink)]">
+                        <span className="flex size-7 items-center justify-center rounded-lg bg-[var(--color-panel-2)] text-[var(--color-primary)]">
+                          <CarrierHeaderLogo className="size-4" />
+                        </span>
                         Carrier
                       </div>
                       <ShellNavigation onNavigate={() => {}} compact={false} />
                     </SheetContent>
                   </Sheet>
 
+                  <div className="hidden items-center gap-2 rounded-lg border border-[var(--color-line)] bg-[var(--color-panel)] px-2 py-1 text-[var(--color-primary)] sm:flex">
+                    <CarrierHeaderLogo className="size-4" />
+                    <span className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--color-ink)]">Carrier</span>
+                  </div>
+                  <span className="hidden h-5 w-px bg-[var(--color-line)] sm:block" />
                   <span className="flex size-8 items-center justify-center rounded-lg bg-[var(--color-panel-2)] text-[var(--color-primary)]">
                     <currentNavItem.icon className="size-4" />
                   </span>

--- a/webui/src/components/carrier-header-logo.tsx
+++ b/webui/src/components/carrier-header-logo.tsx
@@ -1,0 +1,48 @@
+import type { SVGProps } from 'react';
+import { cn } from '@/lib/utils';
+
+type CarrierHeaderLogoProps = SVGProps<SVGSVGElement> & {
+  title?: string;
+};
+
+/**
+ * Carrier header logo.
+ *
+ * Inspiration: a command ship releasing small task drones.
+ * Original geometry (not a direct game asset copy).
+ */
+export function CarrierHeaderLogo({ className, title = 'Carrier', ...props }: CarrierHeaderLogoProps) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      role="img"
+      aria-label={title}
+      className={cn('h-5 w-5', className)}
+      {...props}
+    >
+      <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" fill="none">
+        <path
+          d="M32 6L45 13L52 26L45 39L32 58L19 39L12 26L19 13Z"
+          fill="currentColor"
+          fillOpacity="0.08"
+          strokeWidth="2.5"
+        />
+        <path
+          d="M32 12L40 17L45 26L40 35L32 48L24 35L19 26L24 17Z"
+          fill="currentColor"
+          fillOpacity="0.16"
+          strokeWidth="2"
+        />
+        <circle cx="32" cy="26" r="4.5" fill="currentColor" fillOpacity="0.9" strokeWidth="1.4" />
+
+        <path d="M32 31V39" strokeWidth="1.8" strokeOpacity="0.7" />
+        <path d="M32 39L22 49" strokeWidth="1.8" strokeOpacity="0.55" />
+        <path d="M32 39L42 49" strokeWidth="1.8" strokeOpacity="0.55" />
+
+        <path d="M32 48L29.4 52.4L34.6 52.4Z" fill="currentColor" fillOpacity="0.9" strokeWidth="1" />
+        <path d="M22 49L19.8 52.6L24.2 52.6Z" fill="currentColor" fillOpacity="0.85" strokeWidth="1" />
+        <path d="M42 49L39.8 52.6L44.2 52.6Z" fill="currentColor" fillOpacity="0.85" strokeWidth="1" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Design and add a dedicated Carrier logo for header embedding, inspired by a **command ship releasing task drones** (Protoss-style concept, original geometry).

## What changed

1. New reusable logo component
- `webui/src/components/carrier-header-logo.tsx`
- Inline SVG mark optimized for small header/icon usage
- Uses `currentColor` so it adapts cleanly to theme/context

2. New standalone SVG asset
- `webui/public/icons/carrier-header-logo.svg`
- Can be embedded directly via `<img src="/icons/carrier-header-logo.svg" ... />`

3. App shell integration
- Replaced sparkle mark with the new logo in:
  - login card brand chip
  - desktop sidebar brand chip
  - mobile sheet brand heading
- Added a compact brand chip in the top header next to current section context

## Validation

- `bun --cwd webui test`
- `bun --cwd webui build`
