### PR TITLE
fix(e2e): reload control plane after onboarding config patch

### DIFF
--- a/scripts/e2e-control-plane-live-provider.sh
+++ b/scripts/e2e-control-plane-live-provider.sh
@@ -531,7 +531,7 @@ jq -e \
 # Restart once so daemon+gateway reload the finalized config and the live
 # launcher/run validation reads consistent provider/model settings.
 echo "[2.5/10] reset control plane after onboarding/config normalization"
-run_with_timeout 10 "$BIN_PATH" stop >/dev/null 2>&1 || true
+run_with_timeout 10 "$BIN_PATH" stop >/dev/null 2>&1 || echo "warning: 'carrier stop' command failed but was ignored"
 stop_control_plane_processes
 
 if [[ ! -f "$TRANSCRIPTION_AUDIO_FIXTURE" ]]; then


### PR DESCRIPTION
## Summary
Fix flaky/incorrect live-provider control-plane E2E behavior where onboarding-launched control plane can continue running with pre-normalization config.

## Problem
In `scripts/e2e-control-plane-live-provider.sh`, onboarding happens before optional model/base_url normalization. If onboarding starts daemon+gateway, step `[3/10]` may reuse that already-healthy control plane. That means later `agent run` checks can execute against stale provider/model settings and fail with:

- `E_COMMAND_FAILED`
- `daemon command failed` (gateway 502)

This is the failure pattern seen in run/job:
- https://github.com/Keith-CY/carrier/actions/runs/23352634683/job/67935187269

## Change
After config normalization verification and before step `[3/10]`, explicitly reset control plane once:

- `carrier stop` (best-effort)
- `stop_control_plane_processes`

Then step `[3/10]` starts a fresh daemon+gateway that loads the finalized config.

## Why this is safe
- Existing cleanup already runs `carrier stop`; this just shifts a controlled restart earlier in the script.
- Port selection remains pinned via requested daemon/gateway ports, so single-pair intent is preserved.
- Improves reproducibility and debugability for launcher/run/heartbeat/cron validations.
