### PR TITLE
compat: refresh upstream schema lock snapshots

### DIFF
--- a/compat/upstreams.lock.json
+++ b/compat/upstreams.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-03-19T00:00:00Z",
+  "updated_at": "2026-03-21T00:00:00Z",
   "agents": {
     "openclaw": {
       "repository": "openclaw/openclaw",
@@ -16,7 +16,7 @@
       "tracked_files": [
         {
           "path": "docs/gateway/configuration-reference.md",
-          "sha": "49c743db6232ca0c61686b0e21a21eaa808ed436"
+          "sha": "11ea717513ad9d83fa82a3d7d5ced7bcf09e72a1"
         },
         {
           "path": "src/channels/plugins/config-schema.ts",
@@ -31,7 +31,7 @@
           "sha": "9d0ec87666821aafd56049987c6bc7d54a5a3f72"
         }
       ],
-      "expected_fingerprint": "sha256:ab8b02dc9dad1c97bf97e8708900cdfabed8f463daea87dbc3d9197d9ef13c22"
+      "expected_fingerprint": "sha256:3ccbee7795afffb0c61ad943b87196371fa7f7ea7b967081ac305348469ba7c0"
     },
     "picoclaw": {
       "repository": "sipeed/picoclaw",
@@ -47,14 +47,14 @@
       "tracked_files": [
         {
           "path": "config/config.example.json",
-          "sha": "221e89491a4e66013e42247ce8f1d559ce985bd0"
+          "sha": "81c9014ec9e84d06c1ab307feb56d63a5e8216d3"
         },
         {
           "path": "pkg/config/config.go",
-          "sha": "4f8026d274d8b1f0b38a013c830e8d0e510496a6"
+          "sha": "235cb0641006d9c82a7f1fbf4e18d3106525836d"
         }
       ],
-      "expected_fingerprint": "sha256:00d9e819b162da93c6cc4f6f622cb12f525dc4d72c9b1b91d7cbe171be667203"
+      "expected_fingerprint": "sha256:936b45c034be7dc575f3a95f5e2c02eb86f7b82f6e4a97c9290117cbf8db1b37"
     },
     "zeroclaw": {
       "repository": "zeroclaw-labs/zeroclaw",
@@ -74,14 +74,14 @@
         },
         {
           "path": "docs/reference/api/config-reference.md",
-          "sha": "5775c40d7266954a94b094b4cf2e5532bd415e8c"
+          "sha": "5436ff3db40d33b45cf3450e3737520dc4b0aefc"
         },
         {
           "path": "src/config/schema.rs",
-          "sha": "ad767b43ddf561e24f4b5c8b30db6fce06c904be"
+          "sha": "d8cb374b9e1245612303c83c8c3c1509d0a37a24"
         }
       ],
-      "expected_fingerprint": "sha256:96aefe249019aa9c6f97efd0d762d15cb393252d505f27ed5e6c30b6915527ff"
+      "expected_fingerprint": "sha256:52aed7b8ba46c3dba474a6716fb0148044d395313b4369f32184deb1b70256bc"
     }
   }
 }

--- a/scripts/ci/upstreams-lock.test.cjs
+++ b/scripts/ci/upstreams-lock.test.cjs
@@ -18,10 +18,10 @@ test("upstreams lock records the refreshed openclaw snapshot", () => {
   const lock = readLock();
   const openclaw = lock.agents.openclaw;
 
-  assert.equal(lock.updated_at, "2026-03-19T00:00:00Z");
-  assert.equal(openclaw.expected_fingerprint, "sha256:ab8b02dc9dad1c97bf97e8708900cdfabed8f463daea87dbc3d9197d9ef13c22");
+  assert.equal(lock.updated_at, "2026-03-21T00:00:00Z");
+  assert.equal(openclaw.expected_fingerprint, "sha256:3ccbee7795afffb0c61ad943b87196371fa7f7ea7b967081ac305348469ba7c0");
   assert.deepEqual(trackedFilesByPath(openclaw), {
-    "docs/gateway/configuration-reference.md": "49c743db6232ca0c61686b0e21a21eaa808ed436",
+    "docs/gateway/configuration-reference.md": "11ea717513ad9d83fa82a3d7d5ced7bcf09e72a1",
     "src/channels/plugins/config-schema.ts": "5ae166aa5a78066cdd3d1d21c8632ca6fcf88444",
     "src/config/config.ts": "3bd36d0d709594c7d896132c8472e445d1994940",
     "src/gateway/protocol/schema/config.ts": "9d0ec87666821aafd56049987c6bc7d54a5a3f72",
@@ -32,10 +32,10 @@ test("upstreams lock records the refreshed picoclaw snapshot", () => {
   const lock = readLock();
   const picoclaw = lock.agents.picoclaw;
 
-  assert.equal(picoclaw.expected_fingerprint, "sha256:00d9e819b162da93c6cc4f6f622cb12f525dc4d72c9b1b91d7cbe171be667203");
+  assert.equal(picoclaw.expected_fingerprint, "sha256:936b45c034be7dc575f3a95f5e2c02eb86f7b82f6e4a97c9290117cbf8db1b37");
   assert.deepEqual(trackedFilesByPath(picoclaw), {
-    "config/config.example.json": "221e89491a4e66013e42247ce8f1d559ce985bd0",
-    "pkg/config/config.go": "4f8026d274d8b1f0b38a013c830e8d0e510496a6",
+    "config/config.example.json": "81c9014ec9e84d06c1ab307feb56d63a5e8216d3",
+    "pkg/config/config.go": "235cb0641006d9c82a7f1fbf4e18d3106525836d",
   });
 });
 
@@ -43,11 +43,11 @@ test("upstreams lock records the refreshed zeroclaw snapshot and migrated doc pa
   const lock = readLock();
   const zeroclaw = lock.agents.zeroclaw;
 
-  assert.equal(zeroclaw.expected_fingerprint, "sha256:96aefe249019aa9c6f97efd0d762d15cb393252d505f27ed5e6c30b6915527ff");
+  assert.equal(zeroclaw.expected_fingerprint, "sha256:52aed7b8ba46c3dba474a6716fb0148044d395313b4369f32184deb1b70256bc");
   assert.deepEqual(trackedFilesByPath(zeroclaw), {
     "dev/config.template.toml": "cf4511b85d9c0f6ba8c1d5404fbfb168d30f7229",
-    "docs/reference/api/config-reference.md": "5775c40d7266954a94b094b4cf2e5532bd415e8c",
-    "src/config/schema.rs": "ad767b43ddf561e24f4b5c8b30db6fce06c904be",
+    "docs/reference/api/config-reference.md": "5436ff3db40d33b45cf3450e3737520dc4b0aefc",
+    "src/config/schema.rs": "d8cb374b9e1245612303c83c8c3c1509d0a37a24",
   });
   assert.ok(!("docs/config-reference.md" in trackedFilesByPath(zeroclaw)));
 });


### PR DESCRIPTION
## Summary
- refresh upstream tracked file SHAs for `openclaw`, `picoclaw`, and `zeroclaw` in `compat/upstreams.lock.json`
- update expected fingerprints to current upstream snapshots
- refresh `scripts/ci/upstreams-lock.test.cjs` fixture assertions to match the lock update

## Validation
- `node --test scripts/ci/upstreams-lock.test.cjs`
- `node scripts/ci/upstream-schema-watch.cjs --mode check-only --lock compat/upstreams.lock.json`

Fixes #1585
Fixes #1586
Fixes #1587
